### PR TITLE
fix: 模板有 C 链接 (linuxdeepin/developer-center#3118)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ CMakeLists.txt.user
 build-ut/
 
 *.qm
+Build

--- a/src/grand-search/utils/utils.cpp
+++ b/src/grand-search/utils/utils.cpp
@@ -19,10 +19,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 extern "C" {
-#include <gio/gio.h>
 #include <gio/gdesktopappinfo.h>
 #include <ctype.h>
 }
+#include <gio/gio.h>
 
 #include "utils.h"
 


### PR DESCRIPTION
尝试修正构建时出现`error: template with C linkage`的问题

详细：linuxdeepin/developer-center#3118