### PR TITLE
fix: asymmetric display of setting interface

### DIFF
--- a/src/grand-search/gui/searchconfig/configwidget.cpp
+++ b/src/grand-search/gui/searchconfig/configwidget.cpp
@@ -49,6 +49,18 @@ ConfigWidget::~ConfigWidget()
 {
 }
 
+void ConfigWidget::themeTypeChanged(DGuiApplicationHelper::ColorType themeColor)
+{
+    if (themeColor == DGuiApplicationHelper::LightType) {
+        QPalette p(this->palette());
+        p.setColor(QPalette::Background, QColor(255, 255, 255, static_cast<int>(255 * 0.99)));
+        this->setPalette(p);
+    } else {
+        this->setPalette(QPalette());
+    }
+    update();
+}
+
 void ConfigWidget::initUI()
 {
     setFixedSize(MAINWINDOW_WIDTH, MAINWINDOW_HEIGHT);
@@ -63,6 +75,12 @@ void ConfigWidget::initUI()
     QIcon tmpIcon = QIcon(QString(":/icons/%1.svg").arg("dde-grand-search-setting"));
     this->titlebar()->setIcon(tmpIcon);
     setWindowIcon(tmpIcon);
+
+    if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType) {
+        QPalette p(this->palette());
+        p.setColor(QPalette::Background, QColor(255, 255, 255, static_cast<int>(255 * 0.99)));
+        this->setPalette(p);
+    }
 
     QWidget *mainWidget = new QWidget(this);
     setCentralWidget(mainWidget);
@@ -91,6 +109,8 @@ void ConfigWidget::initUI()
     m_scrollLayout->addStretch();
 
     m_scrollArea->setWidget(m_scrollAreaContent);
+
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, &ConfigWidget::themeTypeChanged);
 }
 
 void ConfigWidget::initData()

--- a/src/grand-search/gui/searchconfig/configwidget.h
+++ b/src/grand-search/gui/searchconfig/configwidget.h
@@ -23,6 +23,7 @@
 
 #include <DMainWindow>
 #include <DWidget>
+#include <DGuiApplicationHelper>
 
 #include <QVBoxLayout>
 
@@ -37,6 +38,9 @@ class ConfigWidget : public Dtk::Widget::DMainWindow
 public:
     explicit ConfigWidget(QWidget *parent = nullptr);
     ~ConfigWidget();
+
+private slots:
+    void themeTypeChanged(DGuiApplicationHelper::ColorType themeColor);
 
 private:
     void initUI();


### PR DESCRIPTION
fix the bug about asymmetric display of setting interface

Log: 修复设置界面显示不对称，以及浅色模式下没有大面积白色底色问题

Bug: https://pms.uniontech.com/bug-view-134971.html
Influence: 设置界面显示对称，浅色模式下呈现大面积白底