### PR TITLE
fix: fix the bug about hovert color

### DIFF
--- a/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistdelegate.cpp
+++ b/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistdelegate.cpp
@@ -134,7 +134,15 @@ void GrandSearchListDelegate::drawSelectState(QPainter *painter, const QStyleOpt
     if (option.state & QStyle::State_MouseOver) {
         painter->save();
         painter->setPen(Qt::NoPen);
-        QColor hovertColor(0, 0, 0, int(255*0.05));
+
+        QColor hovertColor;
+        const GrandSearchListView *listview = qobject_cast<const GrandSearchListView *>(option.widget);
+        if ((listview->getThemeType() == DGuiApplicationHelper::DarkType)
+                || (index.isValid() && index == listview->currentIndex())) {
+            hovertColor = QColor(255, 255, 255, static_cast<int>(255 * 0.05));
+        } else {
+            hovertColor = QColor(0, 0, 0, static_cast<int>(255*0.05));
+        }
         painter->setBrush(hovertColor);
         QRect selecteColorRect = option.rect.adjusted(0, 0, 0, 0);
         painter->drawRoundedRect(selecteColorRect, 8, 8);
@@ -157,6 +165,7 @@ void GrandSearchListDelegate::drawSearchResultText(QPainter *painter, const QSty
 
     // 设置字体
     QFont nameFont = DFontSizeManager::instance()->get(DFontSizeManager::T6);
+    nameFont.setWeight(QFont::Medium);
 
     const QString &name = index.data(DATA_ROLE).value<MatchedItem>().name;
     const QString &searcher = index.data(DATA_ROLE).value<MatchedItem>().searcher;

--- a/tests/grand-search/gui/exhibition/matchresult/listview/ut_grandsearchlistdelegate.cpp
+++ b/tests/grand-search/gui/exhibition/matchresult/listview/ut_grandsearchlistdelegate.cpp
@@ -202,6 +202,7 @@ TEST(GrandSearchListDelegateTest, drawSelectState)
 
     QStyleOptionViewItem option;
     QModelIndex index = view.model()->index(0, 0);
+    option.widget = &view;
 
     delegate->initStyleOption(&option, index);
     option.state = option.state | QStyle::State_Selected;

--- a/tests/grand-search/gui/ut_mainwindow.cpp
+++ b/tests/grand-search/gui/ut_mainwindow.cpp
@@ -82,7 +82,6 @@ TEST(MainWindowTest, onGeometryChanged)
     w.onGeometryChanged(rect);
 
     QPoint point = w.geometry().topLeft();
-    auto aaa = rect.topLeft();
 
     EXPECT_EQ(point, rect.topLeft());
 }


### PR DESCRIPTION
fix the bug about hovert color

Log: 深色模式下鼠标悬浮在类目上背景色为一定透明度的白色

Bug: https://pms.uniontech.com/bug-view-134981.html
Influence: 深色模式下鼠标悬浮在类目上背景色为一定透明度的白色
Change-Id: I079b8e93d88a008670e21bc849838cb0e2bf8f69