### PR TITLE
feat: add path blacklist configuration

### DIFF
--- a/src/grand-search-daemon/configuration/configer_p.h
+++ b/src/grand-search-daemon/configuration/configer_p.h
@@ -41,6 +41,7 @@ public:
     static UserPreferencePointer blacklist();
     static UserPreferencePointer webSearchEngine();
     bool updateConfig1(QSettings *);
+    void resetPath(QString &path) const;
 private:
     Configer *q;
     mutable QReadWriteLock m_rwLock;

--- a/src/grand-search/CMakeLists.txt
+++ b/src/grand-search/CMakeLists.txt
@@ -122,6 +122,18 @@ set(GUISRC
     gui/searchconfig/comboboxwidget/comboboxwidget.cpp
     gui/searchconfig/bestmatchwidget.cpp
     gui/searchconfig/bestmatchwidget.h
+    gui/searchconfig/blacklistview/blacklistview.h
+    gui/searchconfig/blacklistview/blacklistview.cpp
+    gui/searchconfig/blacklistview/blacklistmodel.cpp
+    gui/searchconfig/blacklistview/blacklistmodel.h
+    gui/searchconfig/blacklistview/blacklistdelegate.cpp
+    gui/searchconfig/blacklistview/blacklistdelegate.h
+    gui/searchconfig/blacklistview/deletedialog.cpp
+    gui/searchconfig/blacklistview/deletedialog.h
+    gui/searchconfig/blacklistwidget.cpp
+    gui/searchconfig/blacklistwidget.h
+    gui/searchconfig/indexwidget.cpp
+    gui/searchconfig/indexwidget.h
     )
 
 # business

--- a/src/grand-search/gui/searchconfig/blacklistview/blacklistdelegate.cpp
+++ b/src/grand-search/gui/searchconfig/blacklistview/blacklistdelegate.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2022 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * Maintainer: zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "blacklistdelegate.h"
+#include "blacklistview.h"
+#include "blacklistmodel.h"
+
+#include <DGuiApplicationHelper>
+#include <DPalette>
+#include <DPaletteHelper>
+
+#include <QColor>
+#include <QPainter>
+#include <QTextDocument>
+#include <QTextCursor>
+#include <QTextBlock>
+#include <QAbstractTextDocumentLayout>
+
+#define ListItemHeight      36      // 列表行高
+#define ListItemWidth       456     // 列表行宽
+#define ListIconSize        24      // 列表图标大小
+#define ListItemSpace       10      // 列表图标与文本间间距
+#define ListIconMargin      10      // 列表图标边距
+#define ListTextMaxWidth    362     // 列表文本最长显示宽度
+
+BlackListDelegate::BlackListDelegate(QAbstractItemView *parent)
+    : DStyledItemDelegate(parent)
+{
+
+}
+
+BlackListDelegate::~BlackListDelegate()
+{
+
+}
+
+QSize BlackListDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const
+{
+    Q_UNUSED(option)
+    Q_UNUSED(index)
+    return QSize(ListItemWidth, ListItemHeight);
+}
+
+void BlackListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+{
+    QStyledItemDelegate::paint(painter, option, index);
+    painter->setRenderHint(QPainter::Antialiasing);
+    drawPathsText(painter, option, index);
+    drawItemBackground(painter, option, index);
+}
+
+void BlackListDelegate::drawPathsText(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+{
+      QFont pathFont = DFontSizeManager::instance()->get(DFontSizeManager::T6);
+
+      const QString &path = index.data(DATAROLE).value<QString>();
+      QFontMetrics pathFontMetrics(pathFont);
+      QString elidedPath = pathFontMetrics.elidedText(path, Qt::ElideMiddle, ListTextMaxWidth);
+
+      const BlackListView *listView = qobject_cast<const BlackListView *>(option.widget);
+      auto selected = listView->selectionModel();
+      QColor pathColor;
+      if (selected->isSelected(index)) {
+          pathColor = QColor("#FFFFFF");
+      } else {
+          if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType) {
+              pathColor = QColor("#414D68");
+          } else {
+              pathColor = QColor("#C0C6D4");
+          }
+      }
+
+      QTextDocument pathDocument;
+      pathDocument.setDocumentMargin(0);
+      pathDocument.setPlainText(elidedPath);
+      QTextCursor pathCursor(&pathDocument);
+
+      pathCursor.beginEditBlock();
+      pathCursor.select(QTextCursor::LineUnderCursor);
+      QTextCharFormat pathFmt;
+      pathFmt.setFont(pathFont);
+      pathFmt.setForeground(pathColor);
+      pathCursor.mergeCharFormat(pathFmt);
+      pathCursor.clearSelection();
+      pathCursor.endEditBlock();
+
+      QAbstractTextDocumentLayout::PaintContext paintContext;
+      int pathMargin = static_cast<int>((option.rect.height() - pathFontMetrics.height()) / 2);
+      int actualPathWidth = pathFontMetrics.size(Qt::TextSingleLine, elidedPath).width();
+      int actualStartX = ListIconSize + ListItemSpace + ListIconMargin;
+      QRect pathTextRect(actualStartX, option.rect.y() + pathMargin, actualPathWidth, option.rect.height());
+
+      painter->save();
+      painter->translate(pathTextRect.topLeft());
+      painter->setClipRect(pathTextRect.translated(-pathTextRect.topLeft()));
+      pathDocument.documentLayout()->draw(painter, paintContext);
+      painter->restore();
+}
+
+void BlackListDelegate::drawItemBackground(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+{
+    if (index.row() % 2 == 1)
+        return;
+    painter->save();
+    if (option.widget) {
+        DPalette pl(DPaletteHelper::instance()->palette(option.widget));
+        painter->setPen(Qt::NoPen);
+        painter->setBrush(pl.brush(DPalette::ItemBackground));
+    }
+    QRect rect = option.rect.adjusted(0, 0, -1, -1);
+    painter->drawRoundedRect(rect, 8, 8);
+    painter->restore();
+}

--- a/src/grand-search/gui/searchconfig/blacklistview/blacklistdelegate.h
+++ b/src/grand-search/gui/searchconfig/blacklistview/blacklistdelegate.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * Maintainer: zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef BLACKLISTDELEGATE_H
+#define BLACKLISTDELEGATE_H
+
+#include <DListView>
+#include <DStyledItemDelegate>
+
+class BlackListDelegate : public Dtk::Widget::DStyledItemDelegate
+{
+    Q_OBJECT
+public:
+    explicit BlackListDelegate(QAbstractItemView *parent = Q_NULLPTR);
+    ~BlackListDelegate() override;
+
+protected:
+    QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+
+private:
+    void drawPathsText(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+    void drawItemBackground(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+};
+
+#endif // BLACKLISTDELEGATE_H

--- a/src/grand-search/gui/searchconfig/blacklistview/blacklistmodel.cpp
+++ b/src/grand-search/gui/searchconfig/blacklistview/blacklistmodel.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * Maintainer: zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "blacklistmodel.h"
+
+BlackListModel::BlackListModel(int rows, int columns, QObject *parent)
+    : QStandardItemModel(rows, columns, parent)
+{
+
+}
+
+BlackListModel::~BlackListModel()
+{
+
+}
+
+Qt::ItemFlags BlackListModel::flags(const QModelIndex &index) const
+{
+    auto path = index.data(DATAROLE);
+    auto flags = QStandardItemModel::flags(index);
+
+    if (path.toString().isEmpty())
+        flags &= ~Qt::ItemIsSelectable;
+    else
+        flags |= Qt::ItemIsSelectable;
+    return flags;
+}
+
+QStringList BlackListModel::mimeTypes() const
+{
+    return QStandardItemModel::mimeTypes() << QLatin1String("text/uri-list");
+}
+

--- a/src/grand-search/gui/searchconfig/blacklistview/blacklistmodel.h
+++ b/src/grand-search/gui/searchconfig/blacklistview/blacklistmodel.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * Maintainer: zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef BLACKLISTMODEL_H
+#define BLACKLISTMODEL_H
+
+#include <QStandardItemModel>
+
+#define DATAROLE Qt::UserRole+1
+
+class BlackListModel : public QStandardItemModel
+{
+    Q_OBJECT
+public:
+    explicit BlackListModel(int rows, int columns, QObject *parent = Q_NULLPTR);
+    ~BlackListModel() override;
+
+    virtual Qt::ItemFlags flags(const QModelIndex &index) const override;
+    QStringList mimeTypes() const override;
+
+};
+
+#endif // BLACKLISTMODEL_H

--- a/src/grand-search/gui/searchconfig/blacklistview/blacklistview.cpp
+++ b/src/grand-search/gui/searchconfig/blacklistview/blacklistview.cpp
@@ -1,0 +1,264 @@
+/*
+ * Copyright (C) 2022 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * Maintainer: zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "blacklistview.h"
+#include "blacklistmodel.h"
+#include "blacklistdelegate.h"
+#include "business/config/searchconfig.h"
+#include "global/searchconfigdefine.h"
+
+#include <DGuiApplicationHelper>
+
+#include <QString>
+#include <QMimeData>
+#include <QDropEvent>
+#include <QFileInfo>
+#include <QPainter>
+
+DCORE_USE_NAMESPACE
+
+#define MaxWidth 476
+#define MaxHeight 272
+
+#define IconSize   24
+#define ListItemMaxWidth    362
+#define InitCount       7   // 初始显示数量
+
+BlackListView::BlackListView(QWidget *parent)
+    : DListView(parent)
+{
+    m_model = new BlackListModel(0, 0, this);
+    setModel(m_model);
+    m_delegate = new BlackListDelegate(this);
+    setItemDelegate(m_delegate);
+
+    setViewportMargins(0, 0, 0, 0);
+    setUniformItemSizes(true);
+    setViewMode(QListView::ListMode);
+    setResizeMode(QListView::Adjust);
+    setMovement(QListView::Static);
+    setLayoutMode(QListView::Batched);
+    setBatchSize(2000);
+    setEditTriggers(DListView::NoEditTriggers);
+    setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    setSelectionMode(QAbstractItemView::ExtendedSelection);
+    setAcceptDrops(true);
+
+    init();
+}
+
+BlackListView::~BlackListView()
+{
+
+}
+
+bool BlackListView::removeRows(const int &row, const int &count)
+{
+    if (m_model->removeRows(row, count, QModelIndex())) {
+        m_validRows -= count;
+        updateEmptyRows();
+        blackModelChanged();
+        return true;
+    } else {
+        return false;
+    }
+}
+
+void BlackListView::insertRow(const QString &path)
+{
+    for (int i = 0; i < m_model->rowCount(); ++i) {
+        auto item = m_model->item(i);
+        if (item->data(DATAROLE).toString().isEmpty()){
+            QModelIndex index = m_model->index(i, 0, QModelIndex());
+            setData(index, path);
+            break;
+        }
+    }
+}
+
+void BlackListView::appendRow(const QString &path)
+{
+    QStandardItem *newItem = new QStandardItem;
+    m_model->appendRow(newItem);
+    auto row = m_model->rowCount() - 1;
+    QModelIndex index = m_model->index(row, 0, QModelIndex());
+    setData(index, path);
+}
+
+void BlackListView::updateEmptyRows()
+{
+    for (int i = m_model->rowCount(); i < InitCount; ++i)
+        appendRow(QString(""));
+}
+
+void BlackListView::addModel(const QString &path)
+{
+    if (m_validRows < m_model->rowCount())
+        insertRow(path);
+    else
+        appendRow(path);
+}
+
+void BlackListView::addRow(const QString &path)
+{
+    if (!match(path).isValid()) {
+        addModel(path);
+        blackModelChanged();
+    } else {
+        moveRowToLast(match(path));
+    }
+}
+
+void BlackListView:: moveRowToLast(const QModelIndex &index)
+{
+    if (!index.isValid())
+        return;
+
+    addModel(index.data(DATAROLE).toString());
+
+    if (!removeRows(index.row(), 1))
+        qWarning() << "move item failed";
+}
+
+void BlackListView::dropEvent(QDropEvent *e)
+{
+    auto urls = e->mimeData()->urls();
+    for (auto &url : urls) {
+        QFileInfo info(url.toLocalFile());
+        if (info.isDir() && info.exists()) {
+            addRow(info.absoluteFilePath());
+            e->accept();
+        } else {
+            return;
+        }
+    }
+}
+
+void BlackListView::dragEnterEvent(QDragEnterEvent *e)
+{
+    auto urls = e->mimeData()->urls();
+    for (auto &url : urls) {
+        QFileInfo info(url.toLocalFile());
+        if (info.isSymLink() || !info.isDir() || !info.exists()) {
+            e->setDropAction(Qt::IgnoreAction);
+            return;
+        }
+    }
+    e->setDropAction(Qt::CopyAction);
+    e->accept();
+}
+
+void BlackListView::blackModelChanged() const
+{
+    QStringList blackList;
+    for (int row = 0; row < m_model->rowCount(); ++row) {
+        QString data = m_model->data(m_model->index(row, 0, QModelIndex()), DATAROLE).toString();
+        if (!data.isEmpty())
+            blackList << data.toLocal8Bit().toBase64();
+    }
+    SearchConfig::instance()->setConfig(GRANDSEARCH_BLACKLIST_GROUP, GRANDSEARCH_BLACKLIST_PATH, QVariant::fromValue(blackList));
+}
+
+QModelIndex BlackListView::match(const QString &path) const
+{
+    for (int index = 0; index < m_model->rowCount(); ++index) {
+        if (path == m_model->data(m_model->index(index, 0, QModelIndex()), DATAROLE))
+            return m_model->index(index, 0, QModelIndex());
+    }
+    return QModelIndex();
+}
+
+void BlackListView::setData(const QModelIndex &index, const QString &path)
+{
+    if (!index.isValid())
+        return;
+
+    QVariant pathMeta;
+    pathMeta.setValue(path);
+    m_model->setData(index, pathMeta, DATAROLE);
+
+    if (!path.isEmpty()) {
+        QVariant iconMeta;
+        static const QSize iconSize(IconSize, IconSize);
+        static QIcon icon = QIcon::fromTheme("inode-directory");
+        iconMeta.setValue(icon.pixmap(iconSize));
+        m_model->setData(index, iconMeta, Qt::DecorationRole);
+
+        m_validRows++;
+    }
+}
+
+void BlackListView::init()
+{
+    m_paths = SearchConfig::instance()->getConfig(GRANDSEARCH_BLACKLIST_GROUP, GRANDSEARCH_BLACKLIST_PATH, QStringList()).toStringList();
+    for (QString path : m_paths) {
+        path = QByteArray::fromBase64(path.toLocal8Bit());
+        addRow(path);
+    }
+
+    m_validRows = m_paths.size();
+    updateEmptyRows();
+}
+
+BlackListWrapper::BlackListWrapper(QWidget *parent)
+    : DWidget(parent)
+{
+    m_listView = new BlackListView(this);
+    setFixedSize(MaxWidth, MaxHeight);
+    m_mainLayout = new QVBoxLayout(this);
+    m_mainLayout->setContentsMargins(10, 10, 10, 10);
+    m_mainLayout->addWidget(m_listView);
+
+    connect(m_listView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &BlackListWrapper::selectedChanged);
+}
+
+BlackListWrapper::~BlackListWrapper()
+{
+
+}
+
+QItemSelectionModel *BlackListWrapper::selectionModel() const
+{
+    return m_listView->selectionModel();
+}
+
+void BlackListWrapper::removeRows(int row, int count)
+{
+    m_listView->removeRows(row, count);
+}
+
+void BlackListWrapper::addRow(const QString &path) const
+{
+    m_listView->addRow(path);
+}
+
+void BlackListWrapper::paintEvent(QPaintEvent *event)
+{
+    QWidget::paintEvent(event);
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing);
+    QColor color;
+    if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType)
+        color.setRgb(0, 0, 0, static_cast<int>(255 * 0.1));
+    else
+        color.setRgb(255, 255, 255, static_cast<int>(255 * 0.1));
+    p.setPen(color);
+    p.drawRoundedRect(rect().adjusted(0, 0, -1, -1), 8, 8);
+}

--- a/src/grand-search/gui/searchconfig/blacklistview/blacklistview.h
+++ b/src/grand-search/gui/searchconfig/blacklistview/blacklistview.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2022 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * Maintainer: zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef BLACKLISTVIEW_H
+#define BLACKLISTVIEW_H
+
+#include <DListView>
+#include <DWidget>
+
+#include <QDropEvent>
+#include <QVBoxLayout>
+
+DWIDGET_USE_NAMESPACE
+
+class BlackListModel;
+class BlackListDelegate;
+class BlackListView : public DListView
+{
+    Q_OBJECT
+public:
+    explicit BlackListView(QWidget *parent = Q_NULLPTR);
+    ~BlackListView() override;
+
+    bool removeRows(const int &row, const int &count);
+    void addRow(const QString &path);
+
+protected:
+    void dropEvent(QDropEvent *e) override;
+    void dragEnterEvent(QDragEnterEvent *event) override;
+
+private:
+    void setData(const QModelIndex &index, const QString &path);
+    void init();
+    void insertRow(const QString &path);
+    void appendRow(const QString &path);
+    void moveRowToLast(const QModelIndex &index);
+    void updateEmptyRows();
+    void addModel(const QString &path);
+    void blackModelChanged() const;
+    QModelIndex match(const QString &path) const;
+
+private:
+    BlackListModel *m_model = nullptr;
+    BlackListDelegate *m_delegate = nullptr;
+    QStringList m_paths;
+    int m_validRows = 0;
+};
+
+class BlackListWrapper : public Dtk::Widget::DWidget
+{
+    Q_OBJECT
+public:
+    explicit BlackListWrapper(QWidget *parent = nullptr);
+    ~BlackListWrapper();
+
+    void addRow(const QString &path) const;
+    QItemSelectionModel *selectionModel() const;
+    void removeRows(int row, int count);
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+
+signals:
+    void selectedChanged(const QItemSelection &selected, const QItemSelection &deselected) const;
+
+private:
+    QVBoxLayout *m_mainLayout = nullptr;
+    BlackListView *m_listView = nullptr;
+};
+
+#endif // BLACKLISTVIEW_H

--- a/src/grand-search/gui/searchconfig/blacklistview/deletedialog.cpp
+++ b/src/grand-search/gui/searchconfig/blacklistview/deletedialog.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * Maintainer: zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "deletedialog.h"
+
+DeleteDialog::DeleteDialog(QWidget *parent)
+    : DDialog(parent)
+{
+    const QString content(tr("Do you want to remove the path from the exclusion list?"));
+    setTitle(content);
+    setIcon(QIcon(QString(":/icons/%1.svg").arg("dde-grand-search-setting")));
+    addButton(CancelButton);
+    addButton(ConfirmButton);
+}
+
+DeleteDialog::~DeleteDialog()
+{
+
+}

--- a/src/grand-search/gui/searchconfig/blacklistview/deletedialog.h
+++ b/src/grand-search/gui/searchconfig/blacklistview/deletedialog.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * Maintainer: zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DELETEDIALOG_H
+#define DELETEDIALOG_H
+
+#include <DDialog>
+
+#define CancelButton tr("Cancel")
+#define ConfirmButton tr("Confirm")
+
+class DeleteDialog : public Dtk::Widget::DDialog
+{
+    Q_OBJECT
+public:
+    explicit DeleteDialog(QWidget *parent = nullptr);
+    ~DeleteDialog();
+};
+
+#endif // DELETEDIALOG_H

--- a/src/grand-search/gui/searchconfig/blacklistwidget.cpp
+++ b/src/grand-search/gui/searchconfig/blacklistwidget.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2022 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * Maintainer: zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "blacklistwidget.h"
+#include "blacklistview/blacklistview.h"
+#include "blacklistview/deletedialog.h"
+#include "blacklistview/blacklistmodel.h"
+
+#include <DWidget>
+#include <DFontSizeManager>
+#include <DPushButton>
+
+#include <QVBoxLayout>
+#include <QFileDialog>
+#include <QStandardPaths>
+#include <QItemSelection>
+
+DWIDGET_USE_NAMESPACE
+BlackListWidget::BlackListWidget(QWidget *parent)
+    :DWidget(parent)
+{
+    m_groupLabel = new QLabel(tr("Excluded path"), this);
+    m_groupLabel->adjustSize();
+
+    m_mainLayout = new QVBoxLayout(this);
+    m_mainLayout->setSpacing(0);
+    m_mainLayout->setContentsMargins(0, 0, 0, 0);
+
+    m_childHLayout = new QHBoxLayout(this);
+    m_childHLayout->addWidget(m_groupLabel);
+
+    m_contentLabel = new QLabel(tr("Add paths to the exclusion list to prevent searching in them"), this);
+
+    m_contentLabel->setWordWrap(true);
+    DFontSizeManager::instance()->bind(m_contentLabel, DFontSizeManager::T8);
+    QPalette p(m_contentLabel->palette());
+    p.setColor(QPalette::Active, QPalette::WindowText, QColor("#526A7F"));
+    m_contentLabel->setPalette(p);
+
+    m_childHLayout->addStretch();
+
+    m_deleteButton = new DIconButton(this);
+    m_deleteButton->setFixedSize(36, 36);
+    DStyle style;
+    m_deleteButton->setIcon(style.standardIcon(DStyle::SP_DecreaseElement));
+    m_deleteButton->setEnabled(false);
+    m_addButton = new DIconButton(this);
+    m_addButton->setFixedSize(36, 36);
+    m_addButton->setIcon(style.standardIcon(DStyle::SP_IncreaseElement));
+    m_childHLayout->addWidget(m_deleteButton);
+    m_childHLayout->addSpacerItem(new QSpacerItem(10, 10));
+    m_childHLayout->addWidget(m_addButton);
+    m_mainLayout->addLayout(m_childHLayout);
+
+    m_mainLayout->addWidget(m_contentLabel);
+
+    m_listWrapper = new BlackListWrapper(this);
+    m_mainLayout->addSpacerItem(new QSpacerItem(10, 10));
+    m_mainLayout->addWidget(m_listWrapper);
+
+    m_deletedialog = new DeleteDialog(this);
+
+    connect(m_addButton, &DIconButton::clicked, this, &BlackListWidget::addButtonClicked);
+    connect(m_deleteButton, &DIconButton::clicked, m_deletedialog, &DeleteDialog::exec);
+    connect(m_deletedialog->getButton(m_deletedialog->getButtonIndexByText(ConfirmButton))
+            , &QAbstractButton::clicked
+            , this, &BlackListWidget::confirmButtonClicked);
+    connect(m_listWrapper, &BlackListWrapper::selectedChanged, this, &BlackListWidget::selectedChanged);
+}
+
+BlackListWidget::~BlackListWidget()
+{
+
+}
+
+void BlackListWidget::addButtonClicked()
+{
+    QFileDialog fileDialog;
+    auto url = fileDialog.getExistingDirectoryUrl(this, QString("")
+                                                  , QStandardPaths::standardLocations(QStandardPaths::HomeLocation).first());
+    QFileInfo info(url.toLocalFile());
+    if (!url.isEmpty() && !info.isSymLink() && info.exists()) {
+        m_listWrapper->addRow(info.absoluteFilePath());
+    } else {
+        qInfo() << "add path failed";
+    }
+}
+
+void BlackListWidget::confirmButtonClicked()
+{
+    auto selectedRows = m_listWrapper->selectionModel()->selectedRows();
+    QList<int> rowList;
+    for (auto index : selectedRows) {
+        rowList << index.row();
+    }
+    qStableSort(rowList.begin(), rowList.end(), qGreater<int>());
+    for (auto index : rowList) {
+        m_listWrapper->removeRows(index, 1);
+    }
+}
+
+void BlackListWidget::selectedChanged(const QItemSelection &selected, const QItemSelection &deselected) const
+{
+    Q_UNUSED(selected)
+    Q_UNUSED(deselected)
+    m_deleteButton->setEnabled(!m_listWrapper->selectionModel()->selectedRows().isEmpty());
+}

--- a/src/grand-search/gui/searchconfig/blacklistwidget.h
+++ b/src/grand-search/gui/searchconfig/blacklistwidget.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * Maintainer: zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef BLACKLISTWIDGET_H
+#define BLACKLISTWIDGET_H
+
+#include <DWidget>
+#include <DIconButton>
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QVBoxLayout>
+#include <QItemSelection>
+
+DWIDGET_USE_NAMESPACE
+
+class BlackListWrapper;
+class DeleteDialog;
+class BlackListWidget : public Dtk::Widget::DWidget
+{
+    Q_OBJECT
+public:
+    explicit BlackListWidget(QWidget *parent = nullptr);
+    ~BlackListWidget();
+
+private slots:
+    void addButtonClicked();
+    void confirmButtonClicked();
+    void selectedChanged(const QItemSelection &selected, const QItemSelection &deselected) const;
+
+private:
+    QVBoxLayout *m_mainLayout = nullptr;
+    QHBoxLayout *m_childHLayout = nullptr;
+    QLabel *m_groupLabel = nullptr;
+    QLabel *m_contentLabel = nullptr;
+
+    DIconButton *m_addButton = nullptr;
+    DIconButton *m_deleteButton = nullptr;
+
+    BlackListWrapper *m_listWrapper = nullptr;
+    DeleteDialog *m_deletedialog = nullptr;
+};
+
+#endif // BLACKLISTWIDGET_H

--- a/src/grand-search/gui/searchconfig/configwidget.cpp
+++ b/src/grand-search/gui/searchconfig/configwidget.cpp
@@ -22,9 +22,8 @@
 #include "business/config/searchconfig.h"
 #include "global/builtinsearch.h"
 #include "scopewidget.h"
-#include "planwidget.h"
 #include "customwidget.h"
-#include "tailerwidget.h"
+#include "indexwidget.h"
 
 #include <DSwitchButton>
 #include <DScrollArea>
@@ -86,7 +85,9 @@ void ConfigWidget::initUI()
 
     m_searchGroupWidget = new ScopeWidget(m_scrollAreaContent);
     m_searchCustomWidget = new CustomWidget(m_scrollAreaContent);
+    m_indexWidget = new IndexWidget(m_scrollAreaContent);
     m_scrollLayout->addWidget(m_searchGroupWidget);
+    m_scrollLayout->addWidget(m_indexWidget);
     m_scrollLayout->addWidget(m_searchCustomWidget);
     m_scrollLayout->addStretch();
 

--- a/src/grand-search/gui/searchconfig/configwidget.h
+++ b/src/grand-search/gui/searchconfig/configwidget.h
@@ -27,10 +27,8 @@
 #include <QVBoxLayout>
 
 class ScopeWidget;
-class PlanWidget;
 class CustomWidget;
-class TailerWidget;
-
+class IndexWidget;
 class ConfigWidget : public Dtk::Widget::DMainWindow
 {
     Q_OBJECT
@@ -50,6 +48,7 @@ private:
 
     ScopeWidget *m_searchGroupWidget          = nullptr;
     CustomWidget *m_searchCustomWidget        = nullptr;
+    IndexWidget *m_indexWidget        = nullptr;
 };
 
 #endif // CONFIGWIDGET_H

--- a/src/grand-search/gui/searchconfig/indexwidget.cpp
+++ b/src/grand-search/gui/searchconfig/indexwidget.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * Maintainer: zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "indexwidget.h"
+#include "blacklistwidget.h"
+
+#include <DFontSizeManager>
+#include <QLabel>
+#include <QVBoxLayout>
+
+DWIDGET_USE_NAMESPACE
+IndexWidget::IndexWidget(QWidget *parent)
+    : DWidget(parent)
+{
+    m_mainLayout = new QVBoxLayout(this);
+    m_mainLayout->setContentsMargins(0, 0, 0, 0);
+    m_blackListWidget = new BlackListWidget(this);
+    m_groupLabel = new QLabel(tr("index"));
+    DFontSizeManager::instance()->bind(m_groupLabel, DFontSizeManager::T5, QFont::Bold);
+
+    m_mainLayout->addWidget(m_groupLabel);
+    m_mainLayout->addWidget(m_blackListWidget);
+}
+
+IndexWidget::~IndexWidget()
+{
+
+}

--- a/src/grand-search/gui/searchconfig/indexwidget.h
+++ b/src/grand-search/gui/searchconfig/indexwidget.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2022 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * Maintainer: zhaohanxi<zhaohanxi@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef INDEXWIDGET_H
+#define INDEXWIDGET_H
+
+#include <DWidget>
+
+#include <QVBoxLayout>
+#include <QLabel>
+
+class BlackListWidget;
+class IndexWidget : public Dtk::Widget::DWidget
+{
+    Q_OBJECT
+public:
+    explicit IndexWidget(QWidget *parent = nullptr);
+    ~IndexWidget();
+
+private:
+    QVBoxLayout *m_mainLayout = nullptr;
+    QLabel *m_groupLabel = nullptr;
+    BlackListWidget *m_blackListWidget = nullptr;
+};
+
+#endif // INDEXWIDGET_H

--- a/src/grand-search/gui/searchconfig/searchenginewidget.cpp
+++ b/src/grand-search/gui/searchconfig/searchenginewidget.cpp
@@ -112,7 +112,7 @@ SearchEngineWidget::~SearchEngineWidget()
 
 void SearchEngineWidget::checkedChangedIndex(int index)
 {
-    GrandSearch::ComboboxWidget *ComboboxWidget = static_cast<GrandSearch::ComboboxWidget *>(sender());
+    GrandSearch::ComboboxWidget *ComboboxWidget = qobject_cast<GrandSearch::ComboboxWidget *>(sender());
 
     if (ComboboxWidget) {
         QString text;


### PR DESCRIPTION
add path blacklist configuration in the setting interface

Log: users can add paths to the exclusion list to prevent searching in them

Task: https://pms.uniontech.com/task-view-110869.html
Change-Id: I5014d879557cc063b4822adac5447c2df832db34