### PR TITLE
fix: fix the bugs

### DIFF
--- a/src/grand-search-daemon/searcher/file/filesearchutils.cpp
+++ b/src/grand-search-daemon/searcher/file/filesearchutils.cpp
@@ -191,11 +191,13 @@ bool FileSearchUtils::fileShouldVisible(const QString &fileName, Group &group, c
 bool FileSearchUtils::filterByBlacklist(const QString &fileName)
 {
     // 过滤黑名单中的结果
+    // add "/" to the end of fileName to distinguish partially identical path
+    QString filePath = fileName + "/";
     auto config = Configer::instance()->group(GRANDSEARCH_BLACKLIST_GROUP);
     auto blacklist = config->value(GRANDSEARCH_BLACKLIST_PATH, QStringList());
     if (!blacklist.isEmpty()) {
         for (const auto &path : blacklist) {
-            if (fileName.startsWith(path))
+            if (filePath.startsWith(path))
                 return true;
         }
     }

--- a/src/grand-search/gui/searchconfig/blacklistview/blacklistview.cpp
+++ b/src/grand-search/gui/searchconfig/blacklistview/blacklistview.cpp
@@ -139,6 +139,7 @@ void BlackListView:: moveRowToLast(const QModelIndex &index)
 
 void BlackListView::dropEvent(QDropEvent *e)
 {
+    this->clearSelection();
     auto urls = e->mimeData()->urls();
     for (auto &url : urls) {
         QFileInfo info(url.toLocalFile());
@@ -242,6 +243,11 @@ QItemSelectionModel *BlackListWrapper::selectionModel() const
 void BlackListWrapper::removeRows(int row, int count)
 {
     m_listView->removeRows(row, count);
+}
+
+void BlackListWrapper::clearSelection()
+{
+    m_listView->clearSelection();
 }
 
 void BlackListWrapper::addRow(const QString &path) const

--- a/src/grand-search/gui/searchconfig/blacklistview/blacklistview.h
+++ b/src/grand-search/gui/searchconfig/blacklistview/blacklistview.h
@@ -74,6 +74,7 @@ public:
     void addRow(const QString &path) const;
     QItemSelectionModel *selectionModel() const;
     void removeRows(int row, int count);
+    void clearSelection();
 
 protected:
     void paintEvent(QPaintEvent *event) override;

--- a/src/grand-search/gui/searchconfig/blacklistview/deletedialog.cpp
+++ b/src/grand-search/gui/searchconfig/blacklistview/deletedialog.cpp
@@ -40,7 +40,7 @@ DeleteDialog::DeleteDialog(QWidget *parent)
 
     // the confirm button
     {
-        auto idx = addButton(tr("Confirm", "button"));
+        auto idx = addButton(tr("Confirm", "button"), false, ButtonWarning);
         auto btn = getButton(idx);
         Q_ASSERT(btn);
         connect(btn, &QAbstractButton::clicked, this, &QDialog::accept);

--- a/src/grand-search/gui/searchconfig/blacklistwidget.cpp
+++ b/src/grand-search/gui/searchconfig/blacklistwidget.cpp
@@ -93,6 +93,7 @@ void BlackListWidget::addButtonClicked()
     auto url = fileDialog.getExistingDirectoryUrl(this, QString("")
                                                   , QStandardPaths::standardLocations(QStandardPaths::HomeLocation).first());
     QFileInfo info(url.toLocalFile());
+    m_listWrapper->clearSelection();
     if (!url.isEmpty() && !info.isSymLink() && info.exists()) {
         m_listWrapper->addRow(info.absoluteFilePath());
     } else {


### PR DESCRIPTION
fix the bugs on blacklist including 144083, 144109, 144171

Log: 确认按钮文本为红色，拖拽目录清除原选中项，屏蔽路径本身目录文件

Bug: https://pms.uniontech.com/bug-view-144083.html https://pms.uniontech.com/bug-view-144109.html https://pms.uniontech.com/bug-view-144171.html
Influence: 按钮颜色调整，拖拽添加清除原选中项，搜索结果屏蔽路径本身