### PR TITLE
fix: fix the bug 144853

### DIFF
--- a/src/grand-search/gui/searchconfig/blacklistview/blacklistview.cpp
+++ b/src/grand-search/gui/searchconfig/blacklistview/blacklistview.cpp
@@ -254,11 +254,12 @@ void BlackListWrapper::paintEvent(QPaintEvent *event)
     QWidget::paintEvent(event);
     QPainter p(this);
     p.setRenderHint(QPainter::Antialiasing);
+
     QColor color;
     if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType)
         color.setRgb(0, 0, 0, static_cast<int>(255 * 0.1));
     else
         color.setRgb(255, 255, 255, static_cast<int>(255 * 0.1));
     p.setPen(color);
-    p.drawRoundedRect(rect().adjusted(0, 0, -1, -1), 8, 8);
+    p.drawRoundedRect(rect().adjusted(1, 1, -1, -1), 8, 8);
 }

--- a/src/grand-search/gui/searchconfig/blacklistview/deletedialog.cpp
+++ b/src/grand-search/gui/searchconfig/blacklistview/deletedialog.cpp
@@ -27,7 +27,7 @@ DeleteDialog::DeleteDialog(QWidget *parent)
     : DDialog(parent)
 {
     const QString content(tr("Do you want to remove the path from the exclusion list?"));
-    setTitle(content);
+    setMessage(content);
     setIcon(QIcon(QString(":/icons/%1.svg").arg("dde-grand-search-setting")));
 
     // the cancel button


### PR DESCRIPTION
fix the bug 144853

Log: 确认删除对话框文本字体大小与UI一致，路径黑名单设置界面边框显示

Bug: https://pms.uniontech.com/bug-view-144853.html
Influence: 确认删除对话框文本大小与UI一致，路径黑名单设置界面边框正常显示