### PR TITLE
feat: using imageeditor to get video information.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,9 +16,6 @@ Build-Depends: debhelper (>= 9),
  dde-dock-dev,
  libglib2.0-dev,
  libpoppler-qt5-dev,
- libffmpegthumbnailer-dev,
- libavformat-dev,
- libavcodec-dev,
  libtag1-dev,
  libicu-dev,
  libgsettings-qt-dev,
@@ -28,18 +25,12 @@ Homepage: http://www.deepin.org/
 
 Package: dde-grand-search
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends},
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Recommends:
+ deepin-anything-server[i386 amd64],
  deepin-desktop-schemas (>=5.8.0.34),
  dde-daemon (>=5.12.0.31),
- libdframeworkdbus2 (>=5.4.6),
  startdde (>=5.6.0.34),
- libpoppler-qt5-1,
- libavformat58(>= 7:4.1),
- libavutil56(>= 7:4.0),
- libavcodec58(>= 7:4.0),
- libffmpegthumbnailer4v5,
- libtag1v5
-Recommends:
- deepin-anything-server[i386 amd64]
+ libimageeditor (>=1.0.19)
 Description: deepin desktop-environment - search module
  Search module of deepin desktop-environment

--- a/src/preview-plugin/audio-preview/CMakeLists.txt
+++ b/src/preview-plugin/audio-preview/CMakeLists.txt
@@ -4,7 +4,6 @@ project(audio-preview)
 set(LIB_NAME audio-preview-plugin)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(TAGLIB REQUIRED taglib)
-pkg_check_modules(AVFORMAT REQUIRED libavformat)
 pkg_check_modules(ICU REQUIRED icu-i18n)
 
 set(SRCS
@@ -16,6 +15,8 @@ set(SRCS
     audiofileinfo.cpp
     audioview.h
     audioview.cpp
+    libaudioviewer.h
+    libaudioviewer.cpp
 )
 
 add_library(${LIB_NAME} SHARED ${SRCS})

--- a/src/preview-plugin/audio-preview/audiopreviewinterface.cpp
+++ b/src/preview-plugin/audio-preview/audiopreviewinterface.cpp
@@ -25,12 +25,13 @@ AudioPreviewInterface::AudioPreviewInterface(QObject *parent)
     : QObject(parent)
     , GrandSearch::PreviewPluginInterface()
 {
-
+    lib.reset(new GrandSearch::LibAudioViewer);
 }
 
 GrandSearch::PreviewPlugin *AudioPreviewInterface::create(const QString &mimetype)
 {
     Q_UNUSED(mimetype)
-
-    return new AudioPreviewPlugin();
+    auto plugin = new AudioPreviewPlugin();
+    plugin->setExtendParser(lib);
+    return plugin;
 }

--- a/src/preview-plugin/audio-preview/audiopreviewinterface.h
+++ b/src/preview-plugin/audio-preview/audiopreviewinterface.h
@@ -22,6 +22,9 @@
 #define AUDIOPREVIEWINTERFACE_H
 
 #include "previewplugininterface.h"
+#include "libaudioviewer.h"
+
+#include <QSharedPointer>
 
 class AudioPreviewInterface : public QObject, public GrandSearch::PreviewPluginInterface
 {
@@ -31,6 +34,8 @@ class AudioPreviewInterface : public QObject, public GrandSearch::PreviewPluginI
 public:
     explicit AudioPreviewInterface(QObject *parent = nullptr);
     virtual GrandSearch::PreviewPlugin *create(const QString &mimetype);
+protected:
+    QSharedPointer<GrandSearch::LibAudioViewer> lib;
 };
 
 #endif // AUDIOPREVIEWINTERFACE_H

--- a/src/preview-plugin/audio-preview/audiopreviewplugin.h
+++ b/src/preview-plugin/audio-preview/audiopreviewplugin.h
@@ -22,6 +22,9 @@
 #define AUDIOPREVIEWPLUGIN_H
 
 #include "previewplugin.h"
+#include "libaudioviewer.h"
+
+#include <QSharedPointer>
 
 class AudioView;
 class AudioPreviewPlugin : public QObject, public GrandSearch::PreviewPlugin
@@ -38,10 +41,12 @@ public:
     GrandSearch::DetailInfoList getAttributeDetailInfo() const Q_DECL_OVERRIDE;
     QWidget *toolBarWidget() const Q_DECL_OVERRIDE;
     bool showToolBar() const Q_DECL_OVERRIDE;
+    void setExtendParser(QSharedPointer<GrandSearch::LibAudioViewer> parser);
 private:
     GrandSearch::ItemInfo m_item;
     GrandSearch::DetailInfoList m_detailInfos;
     AudioView *m_audioView = nullptr;
+    QSharedPointer<GrandSearch::LibAudioViewer> m_parser;
 };
 
 #endif // AUDIOPREVIEWPLUGIN_H

--- a/src/preview-plugin/audio-preview/libaudioviewer.cpp
+++ b/src/preview-plugin/audio-preview/libaudioviewer.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2022 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     zhangyu<zhangyub@uniontech.com>
+ *
+ * Maintainer: zhangyu<zhangyub@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "libaudioviewer.h"
+
+#include <QLibrary>
+#include <QDebug>
+#include <QJsonObject>
+#include <QJsonValue>
+
+using namespace GrandSearch;
+
+LibAudioViewer::LibAudioViewer(QObject *parent) : QObject(parent)
+{
+
+}
+
+bool LibAudioViewer::initLibrary()
+{
+    if (m_imageLib)
+        return true;
+
+    if (loaded) // load failed.
+        return false;
+    loaded = true;
+
+    qInfo() << "load libimageviewer.so....";
+    m_imageLib = new QLibrary("libimageviewer.so", this);
+    if (!m_imageLib->load()) {
+        qWarning() << "fail to load libimageviewer" << m_imageLib->errorString();
+        delete m_imageLib;
+        m_imageLib = nullptr;
+        return false;
+    }
+
+    m_getMovieInfoFunc = reinterpret_cast<GetMovieInfoFunc>(m_imageLib->resolve("getMovieInfoByJson"));
+    if (!m_getMovieInfoFunc) {
+        qWarning() << "can not find getMovieInfoByJson.";
+    }
+
+    qInfo() << "load successfully";
+    return true;
+}
+
+bool LibAudioViewer::getDuration(const QUrl &url, qint64 &duration)
+{
+    if (!m_getMovieInfoFunc)
+        return false;
+
+    QJsonObject json;
+    m_getMovieInfoFunc(url, &json);
+    if (json.contains("Base")) {
+       const QJsonObject &base = json.value("Base").toObject();
+       const QJsonValue &durationJson = base.value("Duration");
+       if (durationJson.isString()) {
+           QString timeStr = durationJson.toString();
+           qDebug() << "get duration" << timeStr;
+           QStringList times = timeStr.split(':');
+           if (times.size() == 3) {
+               duration = times.at(0).toInt() * 3600 + times.at(1).toInt() * 60 + times.at(2).toInt();
+               return true;
+           }
+       }
+    }
+
+    duration = -1;
+    qDebug() << "get duration failed";
+    return false;
+}

--- a/src/preview-plugin/audio-preview/libaudioviewer.h
+++ b/src/preview-plugin/audio-preview/libaudioviewer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Uniontech Software Technology Co., Ltd.
+ * Copyright (C) 2022 Uniontech Software Technology Co., Ltd.
  *
  * Author:     zhangyu<zhangyub@uniontech.com>
  *
@@ -18,25 +18,30 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef VIDEOPREVIEWINTERFACE_H
-#define VIDEOPREVIEWINTERFACE_H
+#ifndef LIBAUDIOVIEWER_H
+#define LIBAUDIOVIEWER_H
 
-#include "libvideoviewer.h"
+#include <QObject>
 
-#include <previewplugininterface.h>
+class QLibrary;
+namespace GrandSearch {
 
-#include <QSharedPointer>
+typedef void (*GetMovieInfoFunc)(const QUrl &url, QJsonObject *json);
 
-class VideoPreviewInterface : public QObject, public GrandSearch::PreviewPluginInterface
+class LibAudioViewer : public QObject
 {
     Q_OBJECT
-    Q_INTERFACES(GrandSearch::PreviewPluginInterface)
-    Q_PLUGIN_METADATA(IID FilePreviewInterface_iid)
 public:
-    explicit VideoPreviewInterface(QObject *parent = nullptr);
-    virtual GrandSearch::PreviewPlugin *create(const QString &mimetype);
-protected:
-    QSharedPointer<GrandSearch::LibVideoViewer> lib;
-};
+    explicit LibAudioViewer(QObject *parent = nullptr);
+    bool initLibrary();
+    bool getDuration(const QUrl &url, qint64 &duration);
+signals:
 
-#endif // VIDEOPREVIEWINTERFACE_H
+private:
+    QLibrary *m_imageLib = nullptr;
+    GetMovieInfoFunc m_getMovieInfoFunc = nullptr;
+    bool loaded = false;
+};
+}
+
+#endif // LIBAUDIOVIEWER_H

--- a/src/preview-plugin/video-preview/CMakeLists.txt
+++ b/src/preview-plugin/video-preview/CMakeLists.txt
@@ -3,14 +3,16 @@ project(video-preview)
 # 定义插件名称
 set(LIB_NAME video-preview-plugin)
 
-pkg_check_modules(Avformat REQUIRED libavformat)
-pkg_check_modules(Ffm REQUIRED libffmpegthumbnailer)
+# run time depends
+#pkg_check_modules(ImageEditor REQUIRED libimageeditor)
 
 set(SRCS
     videopreviewinterface.h
     videopreviewinterface.cpp
     videopreviewplugin.h
     videopreviewplugin.cpp
+    libvideoviewer.h
+    libvideoviewer.cpp
     videoview.h
     videoview.cpp
 )

--- a/src/preview-plugin/video-preview/libvideoviewer.cpp
+++ b/src/preview-plugin/video-preview/libvideoviewer.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2022 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     zhangyu<zhangyub@uniontech.com>
+ *
+ * Maintainer: zhangyu<zhangyub@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "libvideoviewer.h"
+
+#include <QLibrary>
+#include <QDebug>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QSize>
+
+using namespace GrandSearch;
+
+LibVideoViewer::LibVideoViewer(QObject *parent) : QObject(parent)
+{
+}
+
+LibVideoViewer::~LibVideoViewer()
+{
+
+}
+
+bool LibVideoViewer::initLibrary()
+{
+    if (m_imageLib)
+        return true;
+    qInfo() << "load libimageviewer.so....";
+    m_imageLib = new QLibrary("libimageviewer.so", this);
+    if (!m_imageLib->load()) {
+        qWarning() << "fail to load libimageviewer" << m_imageLib->errorString();
+        delete m_imageLib;
+        m_imageLib = nullptr;
+        return false;
+    }
+
+    m_getMovieCoverFunc = reinterpret_cast<GetMovieCoverFunc>(m_imageLib->resolve("getMovieCover"));
+    if (!m_getMovieCoverFunc) {
+        qWarning() << "can not find getMovieCover.";
+    }
+
+    m_getMovieInfoFunc = reinterpret_cast<GetMovieInfoFunc>(m_imageLib->resolve("getMovieInfoByJson"));
+    if (!m_getMovieInfoFunc) {
+        qWarning() << "can not find getMovieInfoByJson.";
+    }
+
+    qInfo() << "load successfully";
+    return true;
+}
+
+bool LibVideoViewer::getMovieInfo(const QUrl &url, QSize &dimension, qint64 &duration)
+{
+    if (!m_getMovieInfoFunc)
+        return false;
+
+    QJsonObject json;
+    m_getMovieInfoFunc(url, &json);
+
+    int ok = 0;
+    if (json.contains("Base")) {
+       const QJsonObject &base = json.value("Base").toObject();
+       const QJsonValue &durationJson = base.value("Duration");
+       if (durationJson.isString()) {
+           QString timeStr = durationJson.toString();
+           qDebug() << "get duration" << timeStr;
+           QStringList times = timeStr.split(':');
+           if (times.size() == 3) {
+               duration = times.at(0).toInt() * 3600 + times.at(1).toInt() * 60 + times.at(2).toInt();
+               ok = ok | 1;
+           }
+       }
+       if (!(ok & 1)) {
+           duration = -1;
+           qDebug() << "get duration failed";
+       }
+
+       const QJsonValue &resolutionValue = base.value("Resolution");
+       if (resolutionValue.isString()) {
+           QString resolutionStr = resolutionValue.toString();
+           qDebug() << "get resolution" << resolutionStr;
+           QStringList strs = resolutionStr.split('x');
+           if (strs.size() == 2) {
+               dimension = QSize(strs.at(0).toInt(), strs.at(1).toInt());
+               ok = ok | 2;
+           }
+       }
+
+       if (!(ok & 2)) {
+            dimension = QSize(-1, -1);
+            qDebug() << "get dimension failed";
+       }
+    } else {
+        return false;
+    }
+
+    return true;
+}
+
+bool LibVideoViewer::getMovieCover(const QUrl &url, QImage &image)
+{
+    if (!m_getMovieCoverFunc)
+        return false;
+
+    m_getMovieCoverFunc(url, "", &image);
+    return true;
+}

--- a/src/preview-plugin/video-preview/libvideoviewer.h
+++ b/src/preview-plugin/video-preview/libvideoviewer.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     zhangyu<zhangyub@uniontech.com>
+ *
+ * Maintainer: zhangyu<zhangyub@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef LIBVIDEOVIEWER_H
+#define LIBVIDEOVIEWER_H
+
+#include <QObject>
+
+class QLibrary;
+namespace GrandSearch {
+
+typedef void (*GetMovieCoverFunc)(const QUrl &url, const QString &savePath, QImage *image);
+typedef void (*GetMovieInfoFunc)(const QUrl &url, QJsonObject *json);
+
+class LibVideoViewer : public QObject
+{
+    Q_OBJECT
+public:
+    explicit LibVideoViewer(QObject *parent = nullptr);
+    ~LibVideoViewer() override;
+    bool initLibrary();
+    bool getMovieInfo(const QUrl &url, QSize &dimension, qint64 &duration);
+    bool getMovieCover(const QUrl &url, QImage &image);
+signals:
+
+public slots:
+private:
+    QLibrary *m_imageLib = nullptr;
+    GetMovieCoverFunc m_getMovieCoverFunc = nullptr;
+    GetMovieInfoFunc m_getMovieInfoFunc = nullptr;
+};
+
+}
+
+#endif // LIBVIDEOVIEWER_H

--- a/src/preview-plugin/video-preview/videopreviewinterface.cpp
+++ b/src/preview-plugin/video-preview/videopreviewinterface.cpp
@@ -26,10 +26,13 @@ VideoPreviewInterface::VideoPreviewInterface(QObject *parent)
   : QObject(parent)
   , GrandSearch::PreviewPluginInterface()
 {
-
+    lib.reset(new GrandSearch::LibVideoViewer);
+    lib->initLibrary();
 }
 
 GrandSearch::PreviewPlugin *VideoPreviewInterface::create(const QString &mimetype)
 {
-    return new VideoPreviewPlugin();
+    auto plugin = new VideoPreviewPlugin();
+    plugin->setParser(lib);
+    return plugin;
 }

--- a/src/preview-plugin/video-preview/videopreviewplugin.h
+++ b/src/preview-plugin/video-preview/videopreviewplugin.h
@@ -21,6 +21,8 @@
 #ifndef VIDEOPREVIEWPLUGIN_H
 #define VIDEOPREVIEWPLUGIN_H
 
+#include "libvideoviewer.h"
+
 #include <previewplugin.h>
 
 #include <QFuture>
@@ -31,7 +33,7 @@ class DecodeBridge : public QObject
 public:
     DecodeBridge();
     ~DecodeBridge();
-    static QVariantHash decode(QSharedPointer<DecodeBridge> self, const QString &file);
+    static QVariantHash decode(QSharedPointer<DecodeBridge> self, const QString &file, QSharedPointer<GrandSearch::LibVideoViewer> parser);
     static QPixmap scaleAndRound(const QImage &img, const QSize &size);
 signals:
     void sigUpdateInfo(const QVariantHash &, bool needUpdate);
@@ -54,6 +56,7 @@ public:
     QWidget *toolBarWidget() const Q_DECL_OVERRIDE;
     bool showToolBar() const Q_DECL_OVERRIDE;
     GrandSearch::DetailInfoList getAttributeDetailInfo() const Q_DECL_OVERRIDE;
+    void setParser(QSharedPointer<GrandSearch::LibVideoViewer> parser);
 protected slots:
     void updateInfo(const QVariantHash &, bool needUpdate);
 protected:
@@ -62,6 +65,7 @@ protected:
     VideoView *m_view = nullptr;
     QObject *m_proxy = nullptr;
     QSharedPointer<DecodeBridge> m_decode;
+    QSharedPointer<GrandSearch::LibVideoViewer> m_parser;
 };
 
 #endif // VIDEOPREVIEWPLUGIN_H

--- a/tests/preview-plugin/audio-preview/ut_libaudioviewer.cpp
+++ b/tests/preview-plugin/audio-preview/ut_libaudioviewer.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2022 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     zhangyu<zhangyub@uniontech.com>
+ *
+ * Maintainer: zhangyu<zhangyub@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "audio-preview/libaudioviewer.h"
+
+#include <stubext.h>
+
+#include <gtest/gtest.h>
+
+#include <QLibrary>
+#include <QUrl>
+#include <QImage>
+
+using namespace GrandSearch;
+
+TEST(LibAudioViewer, ut_initLibrary_load)
+{
+    LibAudioViewer viewer;
+
+    QLibrary *fake = reinterpret_cast<QLibrary *>(0x1);
+    viewer.m_imageLib = fake;
+
+    stub_ext::StubExt stub;
+    QString libName;
+    bool loaded = false;
+    bool retLoad = false;
+    stub.set_lamda(&QLibrary::load, [&loaded, &libName, &retLoad](QLibrary *lib){
+        loaded = true;
+        libName = lib->fileName();
+        return retLoad;
+    });
+
+    EXPECT_TRUE(viewer.initLibrary());
+    EXPECT_FALSE(loaded);
+    EXPECT_EQ(viewer.m_imageLib, fake);
+
+    viewer.m_imageLib = nullptr;
+    libName.clear();
+    loaded = false;
+    retLoad = false;
+    EXPECT_FALSE(viewer.initLibrary());
+    EXPECT_EQ(viewer.m_imageLib, nullptr);
+    EXPECT_TRUE(loaded);
+    EXPECT_EQ(libName, QString("libimageviewer.so"));
+}
+
+static bool movieInfo = false;
+static void getMovieInfoFunc(const QUrl &url, QJsonObject *json){
+    movieInfo = true;
+}
+
+TEST(LibAudioViewer, ut_initLibrary_resolve)
+{
+    LibAudioViewer viewer;
+
+    stub_ext::StubExt stub;
+    bool loaded = false;
+    stub.set_lamda(&QLibrary::load, [&loaded](){
+        loaded = true;
+        return true;
+    });
+
+    bool resolve = false;
+    stub.set_lamda((QFunctionPointer (QLibrary::*)(const char *))&QLibrary::resolve, [&resolve](QLibrary *self, const char *func)-> QFunctionPointer {
+        if (QString(func) == QString("getMovieInfoByJson")) {
+            resolve = true;
+            return (QFunctionPointer)&getMovieInfoFunc;
+        }
+        return (QFunctionPointer)nullptr;
+    });
+
+    ASSERT_TRUE(viewer.initLibrary());
+    EXPECT_NE(viewer.m_imageLib, nullptr);
+
+    EXPECT_TRUE(resolve);
+    EXPECT_EQ(viewer.m_getMovieInfoFunc, &getMovieInfoFunc);
+}
+
+TEST(LibAudioViewer, ut_getMovieInfo_null)
+{
+    LibAudioViewer viewer;
+    stub_ext::StubExt stub;
+    stub.set_lamda(&QLibrary::load, [](){
+        return true;
+    });
+
+    ASSERT_EQ(viewer.m_getMovieInfoFunc, nullptr);
+    QUrl url;
+    qint64 duration;
+    movieInfo = false;
+    EXPECT_FALSE(viewer.getDuration(url, duration));
+    EXPECT_FALSE(movieInfo);
+}
+
+TEST(LibAudioViewer, ut_getMovieInfo_ok)
+{
+    LibAudioViewer viewer;
+    stub_ext::StubExt stub;
+    stub.set_lamda(&QLibrary::load, [](){
+        return true;
+    });
+
+    stub.set_lamda((QFunctionPointer (QLibrary::*)(const char *))&QLibrary::resolve, [](QLibrary *self, const char *func)-> QFunctionPointer {
+        if (QString(func) == QString("getMovieInfoByJson")) {
+            return (QFunctionPointer)&getMovieInfoFunc;
+        }
+        return (QFunctionPointer)nullptr;
+    });
+
+    ASSERT_TRUE(viewer.initLibrary());
+    ASSERT_EQ(viewer.m_getMovieInfoFunc, &getMovieInfoFunc);
+
+    QUrl url;
+    qint64 duration;
+    movieInfo = false;
+    viewer.getDuration(url, duration);
+    EXPECT_TRUE(movieInfo);
+}
+

--- a/tests/preview-plugin/video-preview/ut_libvideoviewer.cpp
+++ b/tests/preview-plugin/video-preview/ut_libvideoviewer.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2022 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     zhangyu<zhangyub@uniontech.com>
+ *
+ * Maintainer: zhangyu<zhangyub@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "video-preview/libvideoviewer.h"
+
+#include <stubext.h>
+
+#include <gtest/gtest.h>
+
+#include <QLibrary>
+#include <QUrl>
+#include <QImage>
+
+using namespace GrandSearch;
+
+TEST(LibVideoViewer, ut_initLibrary_load)
+{
+    LibVideoViewer viewer;
+
+    QLibrary *fake = reinterpret_cast<QLibrary *>(0x1);
+    viewer.m_imageLib = fake;
+
+    stub_ext::StubExt stub;
+    QString libName;
+    bool loaded = false;
+    bool retLoad = false;
+    stub.set_lamda(&QLibrary::load, [&loaded, &libName, &retLoad](QLibrary *lib){
+        loaded = true;
+        libName = lib->fileName();
+        return retLoad;
+    });
+
+    EXPECT_TRUE(viewer.initLibrary());
+    EXPECT_FALSE(loaded);
+    EXPECT_EQ(viewer.m_imageLib, fake);
+
+    viewer.m_imageLib = nullptr;
+    libName.clear();
+    loaded = false;
+    retLoad = false;
+    EXPECT_FALSE(viewer.initLibrary());
+    EXPECT_EQ(viewer.m_imageLib, nullptr);
+    EXPECT_TRUE(loaded);
+    EXPECT_EQ(libName, QString("libimageviewer.so"));
+}
+
+static bool movieCover = false;
+static void getMovieCoverFunc(const QUrl &url, const QString &savePath, QImage *image){
+    movieCover = true;
+}
+
+static bool movieInfo = false;
+static void getMovieInfoFunc(const QUrl &url, QJsonObject *json){
+    movieInfo = true;
+}
+
+TEST(LibVideoViewer, ut_initLibrary_resolve)
+{
+    LibVideoViewer viewer;
+
+    stub_ext::StubExt stub;
+    bool loaded = false;
+    stub.set_lamda(&QLibrary::load, [&loaded](){
+        loaded = true;
+        return true;
+    });
+
+    int resolve = 0;
+    stub.set_lamda((QFunctionPointer (QLibrary::*)(const char *))&QLibrary::resolve, [&resolve](QLibrary *self, const char *func)-> QFunctionPointer {
+        if (QString(func) == QString("getMovieCover")) {
+            resolve = resolve | 1;
+            return (QFunctionPointer)&getMovieCoverFunc;
+        } else if (QString(func) == QString("getMovieInfoByJson")) {
+            resolve = resolve | 2;
+            return (QFunctionPointer)&getMovieInfoFunc;
+        }
+        return (QFunctionPointer)nullptr;
+    });
+
+    ASSERT_TRUE(viewer.initLibrary());
+    EXPECT_NE(viewer.m_imageLib, nullptr);
+
+    EXPECT_EQ(resolve, 3);
+    EXPECT_EQ(viewer.m_getMovieCoverFunc, &getMovieCoverFunc);
+    EXPECT_EQ(viewer.m_getMovieInfoFunc, &getMovieInfoFunc);
+}
+
+TEST(LibVideoViewer, ut_getMovieInfo_null)
+{
+    LibVideoViewer viewer;
+    stub_ext::StubExt stub;
+    stub.set_lamda(&QLibrary::load, [](){
+        return true;
+    });
+
+    ASSERT_EQ(viewer.m_getMovieInfoFunc, nullptr);
+    QUrl url;
+    QSize dimension;
+    qint64 duration;
+    movieInfo = false;
+    EXPECT_FALSE(viewer.getMovieInfo(url, dimension, duration));
+    EXPECT_FALSE(movieInfo);
+}
+
+TEST(LibVideoViewer, ut_getMovieInfo_ok)
+{
+    LibVideoViewer viewer;
+    stub_ext::StubExt stub;
+    stub.set_lamda(&QLibrary::load, [](){
+        return true;
+    });
+
+    stub.set_lamda((QFunctionPointer (QLibrary::*)(const char *))&QLibrary::resolve, [](QLibrary *self, const char *func)-> QFunctionPointer {
+        if (QString(func) == QString("getMovieCover")) {
+            return (QFunctionPointer)&getMovieCoverFunc;
+        } else if (QString(func) == QString("getMovieInfoByJson")) {
+            return (QFunctionPointer)&getMovieInfoFunc;
+        }
+        return (QFunctionPointer)nullptr;
+    });
+
+    ASSERT_TRUE(viewer.initLibrary());
+    ASSERT_EQ(viewer.m_getMovieInfoFunc, &getMovieInfoFunc);
+
+    QUrl url;
+    QSize dimension;
+    qint64 duration;
+    movieInfo = false;
+    viewer.getMovieInfo(url, dimension, duration);
+    EXPECT_TRUE(movieInfo);
+}
+
+TEST(LibVideoViewer, ut_getMovieCover_null)
+{
+    LibVideoViewer viewer;
+    stub_ext::StubExt stub;
+    stub.set_lamda(&QLibrary::load, [](){
+        return true;
+    });
+
+    ASSERT_EQ(viewer.m_getMovieCoverFunc, nullptr);
+    QUrl url;
+    QImage img;
+    movieCover = false;
+    EXPECT_FALSE(viewer.getMovieCover(url, img));
+    EXPECT_FALSE(movieCover);
+}
+
+TEST(LibVideoViewer, ut_getMovieCover_ok)
+{
+    LibVideoViewer viewer;
+    stub_ext::StubExt stub;
+    stub.set_lamda(&QLibrary::load, [](){
+        return true;
+    });
+
+    stub.set_lamda((QFunctionPointer (QLibrary::*)(const char *))&QLibrary::resolve, [](QLibrary *self, const char *func)-> QFunctionPointer {
+        if (QString(func) == QString("getMovieCover")) {
+            return (QFunctionPointer)&getMovieCoverFunc;
+        } else if (QString(func) == QString("getMovieInfoByJson")) {
+            return (QFunctionPointer)&getMovieInfoFunc;
+        }
+        return (QFunctionPointer)nullptr;
+    });
+
+    ASSERT_TRUE(viewer.initLibrary());
+    ASSERT_EQ(viewer.m_getMovieCoverFunc, &getMovieCoverFunc);
+
+    QUrl url;
+    QImage img;
+    movieCover = false;
+    EXPECT_TRUE(viewer.getMovieCover(url, img));
+    EXPECT_TRUE(movieCover);
+}


### PR DESCRIPTION
1, loading imageeditor dynamically to   get video or audion information.
2. remove remove duplicate dependencies in debian/control.

Log: 使用imageeditor预览音视频。
 
Task: https://pms.uniontech.com/task-view-165263.html
Influence: 音频、视频预览