### PR TITLE
fix: should use QStandardPath for Application path

### DIFF
--- a/src/grand-search-daemon/searcher/app/desktopappsearcher.cpp
+++ b/src/grand-search-daemon/searcher/app/desktopappsearcher.cpp
@@ -30,22 +30,14 @@
 
 DCORE_USE_NAMESPACE
 
-#define  APPLICATION_DIR_PATH "/usr/share/applications"
-#define  APPLICATIONLOCAL_DIR_PATH "/usr/local/share/applications"
-
 DesktopAppSearcherPrivate::DesktopAppSearcherPrivate(DesktopAppSearcher *parent)
     : q(parent)
 {
-    m_appDirs << APPLICATION_DIR_PATH << APPLICATIONLOCAL_DIR_PATH;
-
-    // 扩展
-    for (const QString &path : QStandardPaths::standardLocations(QStandardPaths::ApplicationsLocation)) {
-        if (m_appDirs.contains(path))
-            continue;
-        m_appDirs.append(path);
-    }
+    m_appDirs = QStandardPaths::standardLocations(QStandardPaths::ApplicationsLocation);
 
     qInfo() << "application dirs:" << m_appDirs;
+    qInfo() << "XDG_DATA_DIRS:" << qgetenv("XDG_DATA_DIRS");
+
     m_fileWatcher = new QFileSystemWatcher(q);
     m_fileWatcher->addPaths(m_appDirs);
 }


### PR DESCRIPTION
避免硬编码，并解决因原本实现导致的顺序覆盖问题。

原本的实现中，硬编码了 APPLICATION_DIR_PATH （`/usr/share/applications`） 与 APPLICATIONLOCAL_DIR_PATH（`/usr/local/share/applications`），然后将 `QStandardPaths::ApplicationsLocation` 作为补充路径添加到了查找位置中，但这样的实现存在问题：

1. 根据文档，在 Linux 环境中，[`QStandardPaths::ApplicationsLocation` 本身即包含这两个被硬编码进去的路径](https://doc.qt.io/qt-5/qstandardpaths.html#StandardLocation-enum)，故原本的逻辑看上去本身就是多余的。
2. 在常见的情况中，可能存在路径 `~/.local/share/applications`。当此路径存在时，此路径下所放置的 desktop 文件应当**优先于**位于 `/usr/share` 与 `/usr/local/share` 下放置的 desktop 文件。目前的实现逻辑会导致用户目录下的文件无法覆盖系统目录下的 desktop 文件，使行为不符合相关的 XDG 规范。
3. 应当尽可能避免硬编码路径，相关 Issue：https://github.com/linuxdeepin/developer-center/issues/3374

修复验证方式：

1. 从系统 application 目录下复制一个 desktop 文件，放置于用户目录的 application 对应目录下，修改其 Exec 字段使其与原有行为不同，最终保存文件并保持相同的文件名
2. 构建代码，并启动修改或的版本所得到的 dde-grand-search-daemon
3. 尝试从 grand-search 运行修改过的 desktop 文件
4. 观察现象，用户目录下的 desktop 文件应当优先于系统目录下的 desktop 文件，且在 daemon 的日志中，用户目录应当位于系统目录之前