### PR TITLE
fix: config widget is incomplete

### DIFF
--- a/src/grand-search/gui/searchconfig/configwidget.cpp
+++ b/src/grand-search/gui/searchconfig/configwidget.cpp
@@ -57,6 +57,7 @@ void ConfigWidget::initUI()
 
     m_scrollArea = new DScrollArea;
     m_scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    m_scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
     m_scrollArea->setWidgetResizable(true);
     m_scrollArea->setLineWidth(0);
     m_mainLayout->addWidget(m_scrollArea);


### PR DESCRIPTION
QScrollArea reduce width of viewport if its width is wider than scroll area with ScrollBarAsNeeded. Set scroll bar policy to ScrollBarAlwaysOn to work around.

Log:
Bug: https://pms.uniontech.com/bug-view-184053.html