### PR TITLE
fix: The daemon crashed during exit

### DIFF
--- a/3rdparty/fsearch/fsearch_thread_pool.c
+++ b/3rdparty/fsearch/fsearch_thread_pool.c
@@ -157,7 +157,7 @@ fsearch_thread_pool_free (FsearchThreadPool *pool)
         thread = thread->next;
     }
     pool->num_threads = 0;
-    g_free(pool->threads);
+    g_list_free(pool->threads);
     pool->threads = NULL;
     g_free (pool);
     pool = NULL;


### PR DESCRIPTION
It is recommended to use 'g_list_free' to free GList objects

Log: fix issue
