### PR TITLE
fix: Pinyin.dict is covered by same one in dfmbase

### DIFF
--- a/src/libgrand-search-daemon/utils/chineseletterhelper.cpp
+++ b/src/libgrand-search-daemon/utils/chineseletterhelper.cpp
@@ -47,7 +47,7 @@ void ChineseLetterHelper::initDict()
 
     m_inited = true;
 
-    const QString dictPath = ":/misc/pinyin.dict";
+    const QString dictPath = ":/misc/grand-search-daemon/pinyin.dict";
     const int maxWord = 25333;
     QHash<uint, QString> dict;
     dict.reserve(maxWord);

--- a/src/libgrand-search-daemon/utils/dict.qrc
+++ b/src/libgrand-search-daemon/utils/dict.qrc
@@ -1,5 +1,5 @@
 <RCC>
-    <qresource prefix="/misc">
+    <qresource prefix="/misc/grand-search-daemon">
         <file>pinyin.dict</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
The grand search library contains the pinyin.dict file which is also contained in dfmbase . It results that the grand search read the pinyin.dict that is in dfmbase instead of itself  one after attaching grand search to dfm server.

Log: 

Bug: https://pms.uniontech.com/bug-view-200093.html
Influence: 全局搜索