### PR TITLE
fix: remove unused poppler in dde-grand-search.spec

### DIFF
--- a/rpm/dde-grand-search.spec
+++ b/rpm/dde-grand-search.spec
@@ -24,7 +24,6 @@ BuildRequires:  dtkwidget-devel >= 5.1
 BuildRequires:  dtkgui-devel >= 5.2.2.16
 BuildRequires:  pkgconfig(taglib)
 BuildRequires:  dde-dock-devel
-BuildRequires:  pkgconfig(poppler-qt5)
 BuildRequires:  ffmpeg-devel
 BuildRequires:  ffmpegthumbnailer-devel
 BuildRequires:  libicu-devel
@@ -33,7 +32,6 @@ BuildRequires:  deepin-anything-devel
 Requires:  startdde
 Requires:  dtkwidget
 Requires:  taglib
-Requires:  poppler-qt5
 Requires:  ffmpeg-libs
 Requires:  ffmpegthumbnailer
 


### PR DESCRIPTION
It's no longer in use.