### PR TITLE
fix: 自动更新索引 先显示开启后又自动跳到关闭

### DIFF
--- a/src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp
+++ b/src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp
@@ -282,7 +282,7 @@ void IntelligentRetrievalWidget::checkChanged()
         m_indexWidget->setVisible(on);
         adjustSize();
 
-        m_featIndex->setChecked(on);
+        //m_featIndex->setChecked(on);
         //m_fullTextIndex->setChecked(on);
         if (!on) {
             this->setAutoIndex(on);


### PR DESCRIPTION
Description: 自动更新索引 先显示开启后又自动跳到关闭

Log:

Bug: https://pms.uniontech.com/bug-view-283013.html