### PR TITLE
fix: Can not run in non-DDE desktops caused by missing dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -37,6 +37,7 @@ Recommends:
  deepin-desktop-schemas (>=5.8.0.34),
  dde-daemon (>=5.12.0.31),
  startdde (>=5.6.0.34),
+ libdeepin-service-framework,
  deepin-anything-server[i386 amd64]
 Description: deepin desktop-environment - search module
  Search module of deepin desktop-environment


### PR DESCRIPTION
* dde-grand-search depend libdeepin-service-framework but did not specify in control file