### PR TITLE
fix: 当文件后缀为大写时，未呈现uos ai相关入口

### DIFF
--- a/src/grand-search/gui/exhibition/preview/previewwidget.cpp
+++ b/src/grand-search/gui/exhibition/preview/previewwidget.cpp
@@ -106,8 +106,9 @@ bool PreviewWidget::previewItem(const MatchedItem &item)
     }
 
     // 文档类型的文件添加AI工具栏到预览界面
-    bool isShowAiToolBar = item.name.endsWith(".txt") || item.name.endsWith(".doc") || item.name.endsWith(".docx")  || item.name.endsWith(".xls")
-            || item.name.endsWith(".xlsx") || item.name.endsWith(".ppt") || item.name.endsWith(".pptx") || item.name.endsWith(".pdf");
+    QString lowerName = item.name.toLower();
+    bool isShowAiToolBar = lowerName.endsWith(".txt") || lowerName.endsWith(".doc") || lowerName.endsWith(".docx")  || lowerName.endsWith(".xls")
+            || lowerName.endsWith(".xlsx") || lowerName.endsWith(".ppt") || lowerName.endsWith(".pptx") || lowerName.endsWith(".pdf");
     isShowAiToolBar = isShowAiToolBar && AiToolBar::checkUosAiInstalled();
     m_aiToolBar->setVisible(isShowAiToolBar);
     m_aiToolBar->setFilePath(item.item);

--- a/src/preview-plugin/text-preview/textview.cpp
+++ b/src/preview-plugin/text-preview/textview.cpp
@@ -167,8 +167,9 @@ void TextView::initUI()
 void TextView::setSource(const QString &path)
 {
     m_browser->clear();
-    m_isShowAiToolBar = path.endsWith(".txt") || path.endsWith(".doc") || path.endsWith(".docx")  || path.endsWith(".xls")
-            || path.endsWith(".xlsx") || path.endsWith(".ppt") || path.endsWith(".pptx") || path.endsWith(".pdf");
+    QString lowerPath = path.toLower();
+    m_isShowAiToolBar = lowerPath.endsWith(".txt") || lowerPath.endsWith(".doc") || lowerPath.endsWith(".docx")  || lowerPath.endsWith(".xls")
+            || lowerPath.endsWith(".xlsx") || lowerPath.endsWith(".ppt") || lowerPath.endsWith(".pptx") || lowerPath.endsWith(".pdf");
     m_isShowAiToolBar = m_isShowAiToolBar && TextView::checkUosAiInstalled();
     this->setMinimumHeight(m_isShowAiToolBar ? 350 : 386);
 


### PR DESCRIPTION
Description: 当文件后缀为大写时，未呈现uos ai相关入口

Log:

Bug: BUG-292765