### PR TITLE
fix: 【ARM64】【LOONG64】全局搜索结果页，缺失“AI搜索”

### DIFF
--- a/src/grand-search/CMakeLists.txt
+++ b/src/grand-search/CMakeLists.txt
@@ -13,6 +13,17 @@ set(BIN_NAME ${SEARCH_BIN_NAME})
 # 集成测试标签
 ADD_DEFINITIONS(-DENABLE_ACCESSIBILITY)
 
+if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "mips"
+        OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64"
+        OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES "sw"
+        OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES "loongarch64"
+        )
+    message(${CMAKE_SYSTEM_PROCESSOR} ": using fsearch")
+    ADD_DEFINITIONS(-DENABLE_FSEARCH)
+else()
+    message(${CMAKE_SYSTEM_PROCESSOR} ": using deepin-anything.")
+endif()
+
 # 依赖包
 find_package(PkgConfig REQUIRED)
 find_package(DtkWidget REQUIRED)

--- a/src/grand-search/gui/searchconfig/indexwidget.cpp
+++ b/src/grand-search/gui/searchconfig/indexwidget.cpp
@@ -30,6 +30,11 @@ IndexWidget::IndexWidget(QWidget *parent)
     m_mainLayout->addWidget(m_intelligent);
     m_mainLayout->addSpacing(10);
     m_mainLayout->addWidget(m_blackListWidget);
+
+#ifdef ENABLE_FSEARCH
+    // 非amd64架构，用不了AI搜索
+    m_intelligent->setVisible(false);
+#endif
 }
 
 bool IndexWidget::onCloseEvent()


### PR DESCRIPTION
Description: 【ARM64】【LOONG64】全局搜索结果页，缺失“AI搜索”

Log:

Bug: BUG-295519