### PR TITLE
fix: 【ARM64】【LOONG64】if not AMD64 platform, do not show ai search config

### DIFF
--- a/src/grand-search/CMakeLists.txt
+++ b/src/grand-search/CMakeLists.txt
@@ -13,6 +13,17 @@ set(BIN_NAME ${SEARCH_BIN_NAME})
 # 集成测试标签
 ADD_DEFINITIONS(-DENABLE_ACCESSIBILITY)
 
+if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "mips"
+        OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64"
+        OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES "sw"
+        OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES "loongarch64"
+        )
+    message(${CMAKE_SYSTEM_PROCESSOR} ": disable ai search")
+else()
+    message(${CMAKE_SYSTEM_PROCESSOR} ": enable ai search")
+    ADD_DEFINITIONS(-DENABLE_AI_SEARCH)
+endif()
+
 # 依赖包
 find_package(PkgConfig REQUIRED)
 find_package(DtkWidget REQUIRED)

--- a/src/grand-search/gui/searchconfig/indexwidget.cpp
+++ b/src/grand-search/gui/searchconfig/indexwidget.cpp
@@ -25,16 +25,25 @@ IndexWidget::IndexWidget(QWidget *parent)
     m_groupLabel = new QLabel(tr("Index"));
     DFontSizeManager::instance()->bind(m_groupLabel, DFontSizeManager::T5, QFont::Bold);
 
-    m_intelligent = new IntelligentRetrievalWidget(this);
     m_mainLayout->addWidget(m_groupLabel);
+
+#ifdef ENABLE_AI_SEARCH
+    // 目前非amd64架构，用不了AI搜索
+    m_intelligent = new IntelligentRetrievalWidget(this);
     m_mainLayout->addWidget(m_intelligent);
+#endif
+
     m_mainLayout->addSpacing(10);
     m_mainLayout->addWidget(m_blackListWidget);
 }
 
 bool IndexWidget::onCloseEvent()
 {
+#ifdef ENABLE_AI_SEARCH
     return m_intelligent->onCloseEvent();
+#else
+    return true;
+#endif
 }
 
 IndexWidget::~IndexWidget()


### PR DESCRIPTION
Description: 【ARM64】【LOONG64】if not AMD64 platform, do not show ai search config

Log:

Bug: BUG-295519