### PR TITLE
chore: adapt Qt6 QRegularExpression option

### DIFF
--- a/src/dde-grand-search-daemon/searcher/semantic/dslparser/dslparser.cpp
+++ b/src/dde-grand-search-daemon/searcher/semantic/dslparser/dslparser.cpp
@@ -752,13 +752,8 @@ MetaCond::MetaCond(const QString &text, QList<SemanticWorkerPrivate::QueryFuncti
         m_isTrue = false;
     }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     static QRegularExpression reg("META_TYPEIS\"(.+)\"ANDMETA_VALUEIS\"(.+)\"", QRegularExpression::CaseInsensitiveOption);
     static QRegularExpression reg1("META_TYPEIS\"(.+)\"ANDMETA_VALUEIS NOT\"(.+)\"", QRegularExpression::CaseInsensitiveOption);
-#else
-    static QRegularExpression reg("META_TYPEIS\"(.+)\"ANDMETA_VALUEIS\"(.+)\"", Qt::CaseInsensitive);
-    static QRegularExpression reg1("META_TYPEIS\"(.+)\"ANDMETA_VALUEIS NOT\"(.+)\"", Qt::CaseInsensitive);
-#endif
     if (m_isTrue) {
         QRegularExpressionMatch match = reg.match(m_cond);
         if (match.hasMatch()) {


### PR DESCRIPTION
* Remove Qt version check for QRegularExpression options
* Use QRegularExpression::CaseInsensitiveOption consistently
* Remove Qt5 specific Qt::CaseInsensitive option

Log: adapt Qt6 QRegularExpression option