### PR TITLE
fix: emit visible changed signal when window closing

### DIFF
--- a/src/grand-search/gui/mainwindow.cpp
+++ b/src/grand-search/gui/mainwindow.cpp
@@ -294,6 +294,7 @@ void MainWindow::hideEvent(QHideEvent *event)
 
 void MainWindow::closeEvent(QCloseEvent *event)
 {
+    emit visibleChanged(false);
     // 通知查询控制器停止搜索
     emit terminateSearch();
     // FIXME: DBlurEffectWidget close abort on treeland


### PR DESCRIPTION
- Add visibleChanged signal emission in closeEvent
- Ensure visibility state is properly updated before window closes

Log: emit visible changed signal when window closing