### PR TITLE
fix: improve plugin item opening with async dbus call

### DIFF
--- a/src/grand-search/utils/utils.cpp
+++ b/src/grand-search/utils/utils.cpp
@@ -792,7 +792,8 @@ bool Utils::openExtendSearchMatchedItem(const MatchedItem &item)
 {
     // 搜索结果来自扩展插件，使用Dbus通知主控调用扩展插件打开接口打开搜索结果
     DaemonGrandSearchInterface daemonDbus;
-    daemonDbus.OpenWithPlugin(item.searcher, item.item);
+    auto reply = daemonDbus.OpenWithPlugin(item.searcher, item.item);
+    reply.waitForFinished();
 
     return true;
 }


### PR DESCRIPTION
Wait for dbus call to complete when opening extended search matched items

Log: handle dbus call asynchronously for plugin item opening
Bug: https://pms.uniontech.com/bug-view-305007.html
