### PR TITLE
chore: migrate to Qt6 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,6 @@ if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "mips")
 endif()
 
 # Find Qt version
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core)
 if (NOT DEFINED QT_VERSION_MAJOR)
     set(QT_VERSION_MAJOR 6)
 endif()

--- a/debian/control
+++ b/debian/control
@@ -4,13 +4,6 @@ Priority: optional
 Maintainer: Deepin Packages Builder <packages@deepin.com>
 Build-Depends: debhelper (>= 9),
  pkg-config,
- qt5-qmake,
- qtbase5-dev,
- libdtkwidget-dev,
- libdtkcore-dev,
- libdtkgui-dev,
- libdtkcore5-bin,
- qttools5-dev-tools,
  qt6-base-dev,
  libqt6core5compat6-dev,
  libdtk6widget-dev,
@@ -32,7 +25,7 @@ Build-Depends: debhelper (>= 9),
  libjpeg62-turbo-dev,
  liblucene++-dev,
  libboost-dev,
- libdeepin-service-framework-dev
+ libdeepin-service-framework-dev (>1.0.9)
 Standards-Version: 3.9.8
 Homepage: http://www.deepin.org/
 

--- a/src/dde-grand-search-daemon/CMakeLists.txt
+++ b/src/dde-grand-search-daemon/CMakeLists.txt
@@ -1,9 +1,6 @@
 # 定义需要的cmake版本
 cmake_minimum_required(VERSION 3.10)
 
-set(QT_NS Qt5)
-set(DTK_NS Dtk)
-
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
@@ -216,9 +213,11 @@ set(SRCS
     ${GDCONFIGURATION}
 )
 
-
-qt5_add_resources(QRC_FILES utils/dict.qrc)
-
+if (${QT_VERSION_MAJOR} EQUAL 5)
+    qt5_add_resources(QRC_FILES utils/dict.qrc)
+else()
+    qt_add_resources(QRC_FILES utils/dict.qrc)
+endif()
 
 # 执行程序
 add_executable(${BIN_NAME}

--- a/src/tools/luceneengine/CMakeLists.txt
+++ b/src/tools/luceneengine/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_AUTOMOC ON)
 
 set(LIB_NAME luceneengine)
 
-find_package(Qt5 COMPONENTS Gui REQUIRED)
+find_package(${QT_NS} COMPONENTS Gui REQUIRED)
 find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(Lucene REQUIRED IMPORTED_TARGET liblucene++ liblucene++-contrib)
@@ -30,6 +30,6 @@ target_include_directories(${LIB_NAME}
 
 target_link_libraries(
     ${LIB_NAME}
-    Qt5::Gui
+    ${QT_NS}::Gui
     PkgConfig::Lucene
 )

--- a/src/tools/semanticparser/CMakeLists.txt
+++ b/src/tools/semanticparser/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_AUTOMOC ON)
 
 set(LIB_NAME semanticparser)
 
-find_package(Qt5 COMPONENTS Gui DBus REQUIRED)
+find_package(${QT_NS} COMPONENTS Gui DBus REQUIRED)
 find_package(PkgConfig REQUIRED)
 
 
@@ -15,8 +15,13 @@ FILE(GLOB_RECURSE SRC_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
 )
 
-qt5_add_dbus_interface(IFS_SRC ${PROJECT_3RDPARTY_PATH}/interfaces/org.deepin.ai.daemon.VectorIndex.xml vectorindex)
-qt5_add_dbus_interface(IFS_SRC ${PROJECT_3RDPARTY_PATH}/interfaces/org.deepin.ai.daemon.QueryLang.xml querylang)
+if (${QT_VERSION_MAJOR} EQUAL 6)
+    qt6_add_dbus_interface(IFS_SRC ${PROJECT_3RDPARTY_PATH}/interfaces/org.deepin.ai.daemon.VectorIndex.xml vectorindex)
+    qt6_add_dbus_interface(IFS_SRC ${PROJECT_3RDPARTY_PATH}/interfaces/org.deepin.ai.daemon.QueryLang.xml querylang)
+else()
+    qt5_add_dbus_interface(IFS_SRC ${PROJECT_3RDPARTY_PATH}/interfaces/org.deepin.ai.daemon.VectorIndex.xml vectorindex)
+    qt5_add_dbus_interface(IFS_SRC ${PROJECT_3RDPARTY_PATH}/interfaces/org.deepin.ai.daemon.QueryLang.xml querylang)
+endif()
 
 add_library(${LIB_NAME} STATIC ${SRC_FILES} ${IFS_SRC})
 
@@ -27,5 +32,5 @@ target_include_directories(${LIB_NAME}
 
 target_link_libraries(
     ${LIB_NAME}
-    Qt5::Gui
+    ${QT_NS}::Gui
 )


### PR DESCRIPTION
- Remove Qt5 dependencies from debian/control
- Update CMake files to support Qt6
- Add version requirement for libdeepin-service-framework-dev (>1.0.9)
- Remove hardcoded Qt5/Dtk namespace settings

Log: migrate to Qt6 by default