### PR TITLE
fix: adjust quick panel margins and spacing

### DIFF
--- a/src/grand-search-dock-plugin/gui/grandsearchwidget.cpp
+++ b/src/grand-search-dock-plugin/gui/grandsearchwidget.cpp
@@ -176,7 +176,7 @@ QuickPanel::QuickPanel(const QString &desc, QWidget *parent)
     : QWidget(parent)
 {
     QVBoxLayout *lay = new QVBoxLayout;
-    lay->setContentsMargins(10, 10, 10, 10);
+    lay->setContentsMargins(8, 8, 8, 8);
     lay->setSpacing(0);
     lay->addStretch(1);
 
@@ -190,7 +190,7 @@ QuickPanel::QuickPanel(const QString &desc, QWidget *parent)
     textLabel->setElideMode(Qt::ElideRight);
     textLabel->setAlignment(Qt::AlignCenter);
     DFontSizeManager::instance()->bind(textLabel, DFontSizeManager::T10);
-    lay->addSpacing(15);
+    lay->addSpacing(10);
     lay->addWidget(textLabel, 0, Qt::AlignHCenter);
     lay->addStretch(1);
 


### PR DESCRIPTION
- Reduce content margins from 10px to 8px
- Reduce spacing between elements from 15px to 10px

Log: adjust quick panel margins and spacing
Bug: https://pms.uniontech.com/bug-view-271223.html

## Summary by Sourcery

Adjust quick panel margins and spacing to improve visual appearance by reducing content margins and spacing between elements.

Bug Fixes:
- Reduce content margins from 10px to 8px.
- Reduce spacing between elements from 15px to 10px.