### PR TITLE
chore: Bump version to 6.0.6

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-grand-search (6.0.6) unstable; urgency=medium
+
+  * New version 6.0.6. 
+
+ -- Wang Yu <wangyu@uniontch.com>  Thu, 27 Mar 2025 14:01:08 +0800
+
 dde-grand-search (6.0.5) unstable; urgency=medium
 
   * New version 6.0.5. 


### PR DESCRIPTION
Bump version to 6.0.6

Log: Bump version to 6.0.6

## Summary by Sourcery

Chores:
- Update project version number to 6.0.6 in the Debian changelog file