### PR TITLE
chore: add replacement for dde-shell in package control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -33,6 +33,7 @@ Homepage: http://www.deepin.org/
 
 Package: dde-grand-search
 Architecture: any
+Replaces: dde-shell (<=1.99.30)
 Depends: ${shlibs:Depends}, ${misc:Depends},
 Recommends:
  deepin-desktop-schemas (>=5.8.0.34),


### PR DESCRIPTION
- Added Replaces field for dde-shell (<=1.99.30) in the dde-grand-search package control file.

Log: update package control to manage dde-shell replacement

## Summary by Sourcery

Chores:
- Add Replaces field for dde-shell in the dde-grand-search package control file to manage package replacement