### PR TITLE
chore: add OS version build configuration option

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-grand-search (6.0.9) unstable; urgency=medium
+
+  * New version 6.0.9
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Thu, 10 Apr 2025 20:14:55 +0800
+
 dde-grand-search (6.0.8) unstable; urgency=medium
 
   * New version 6.0.8

--- a/debian/rules
+++ b/debian/rules
@@ -30,4 +30,5 @@ override_dh_auto_configure:
 		-DCMAKE_BUILD_TYPE=Release \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DVERSION=$(DEB_VERSION_UPSTREAM) \
-		-DQT_DIR=$(QT_DIR)
+		-DQT_DIR=$(QT_DIR) \
+		-DBUILD_OS_VERSION=$(BUILD_OS_VERSION)


### PR DESCRIPTION
- Added BUILD_OS_VERSION variable to the CMake configuration in the debian rules file.

Log: enhance build configuration with OS version detection

## Summary by Sourcery

Enhance build configuration by adding an OS version detection option to the CMake build process

Build:
- Add a new BUILD_OS_VERSION variable to the CMake configuration in the Debian build rules

Chores:
- Update Debian changelog to reflect the build configuration enhancement