### PR TITLE
全局搜索日志整改

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ build/
 *.qm
 
 .unioncode
+.cursor
+.vscode
 
 dist/
 3rdparty/antlr4

--- a/src/dde-grand-search-daemon/configuration/configer.cpp
+++ b/src/dde-grand-search-daemon/configuration/configer.cpp
@@ -15,16 +15,20 @@
 #include <QReadLocker>
 #include <QDebug>
 #include <QDBusInterface>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logDaemon)
 
 using namespace GrandSearch;
 
-class ConfigerGlobal : public Configer {};
+class ConfigerGlobal : public Configer
+{
+};
 Q_GLOBAL_STATIC(ConfigerGlobal, configerGlobal)
 
 ConfigerPrivate::ConfigerPrivate(Configer *parent)
     : q(parent)
 {
-
 }
 
 UserPreferencePointer ConfigerPrivate::defaultSearcher()
@@ -42,13 +46,14 @@ UserPreferencePointer ConfigerPrivate::defaultSearcher()
 
 UserPreferencePointer ConfigerPrivate::fileSearcher()
 {
-    QVariantHash data = {{GRANDSEARCH_GROUP_FOLDER, true},
-                         {GRANDSEARCH_GROUP_FILE, true},
-                         {GRANDSEARCH_GROUP_FILE_VIDEO, true},
-                         {GRANDSEARCH_GROUP_FILE_AUDIO, true},
-                         {GRANDSEARCH_GROUP_FILE_PICTURE, true},
-                         {GRANDSEARCH_GROUP_FILE_DOCUMNET, true},
-                        };
+    QVariantHash data = {
+        { GRANDSEARCH_GROUP_FOLDER, true },
+        { GRANDSEARCH_GROUP_FILE, true },
+        { GRANDSEARCH_GROUP_FILE_VIDEO, true },
+        { GRANDSEARCH_GROUP_FILE_AUDIO, true },
+        { GRANDSEARCH_GROUP_FILE_PICTURE, true },
+        { GRANDSEARCH_GROUP_FILE_DOCUMNET, true },
+    };
 
     return UserPreferencePointer(new UserPreference(data));
 }
@@ -56,8 +61,8 @@ UserPreferencePointer ConfigerPrivate::fileSearcher()
 UserPreferencePointer ConfigerPrivate::tailerData()
 {
     QVariantHash data = {
-        {GRANDSEARCH_TAILER_PARENTDIR, false},
-        {GRANDSEARCH_TAILER_TIMEMODEFIED, true}
+        { GRANDSEARCH_TAILER_PARENTDIR, false },
+        { GRANDSEARCH_TAILER_TIMEMODEFIED, true }
     };
 
     return UserPreferencePointer(new UserPreference(data));
@@ -66,7 +71,7 @@ UserPreferencePointer ConfigerPrivate::tailerData()
 UserPreferencePointer ConfigerPrivate::blacklist()
 {
     QVariantHash data = {
-        {GRANDSEARCH_BLACKLIST_PATH, QStringList("")}
+        { GRANDSEARCH_BLACKLIST_PATH, QStringList("") }
     };
 
     return UserPreferencePointer(new UserPreference(data));
@@ -74,15 +79,14 @@ UserPreferencePointer ConfigerPrivate::blacklist()
 
 UserPreferencePointer ConfigerPrivate::webSearchEngine()
 {
-    QVariantHash data{{GRANDSEARCH_WEB_SEARCHENGINE, ""}};
+    QVariantHash data { { GRANDSEARCH_WEB_SEARCHENGINE, "" } };
 
     return UserPreferencePointer(new UserPreference(data));
 }
 
 UserPreferencePointer ConfigerPrivate::semanticEngine()
 {
-    QVariantHash data{{GRANDSEARCH_CLASS_GENERALFILE_SEMANTIC_ANALYSIS, true}
-                     , {GRANDSEARCH_CLASS_GENERALFILE_SEMANTIC_VECTOR, true}};
+    QVariantHash data { { GRANDSEARCH_CLASS_GENERALFILE_SEMANTIC_ANALYSIS, true }, { GRANDSEARCH_CLASS_GENERALFILE_SEMANTIC_VECTOR, true } };
 
     return UserPreferencePointer(new UserPreference(data));
 }
@@ -95,11 +99,11 @@ bool ConfigerPrivate::updateConfig1(QSettings *set)
     set->beginGroup(GRANDSEARCH_SEARCH_GROUP);
     UserPreferencePointer searcherConfig = m_root->group(GRANDSEARCH_PREF_SEARCHERENABLED);
 
-    //文件搜索相关配置
+    // 文件搜索相关配置
     {
         //初始化文件搜索的子类目
         if (UserPreferencePointer conf = m_root->group(GRANDSEARCH_CLASS_FILE_DEEPIN)) {
-            //若所有的文件类搜索都关闭，则关闭文件搜索项
+            // 若所有的文件类搜索都关闭，则关闭文件搜索项
             bool on = false;
             bool ret = set->value(GRANDSEARCH_GROUP_FOLDER, true).toBool();
             conf->setValue(GRANDSEARCH_GROUP_FOLDER, ret);
@@ -125,32 +129,32 @@ bool ConfigerPrivate::updateConfig1(QSettings *set)
             conf->setValue(GRANDSEARCH_GROUP_FILE_DOCUMNET, ret);
             on |= ret;
 
-            //设置是否启用文件搜索项
+            // 设置是否启用文件搜索项
             searcherConfig->setValue(GRANDSEARCH_CLASS_FILE_DEEPIN, on);
         } else {
-            qWarning() << "no shuch config:" << GRANDSEARCH_CLASS_FILE_DEEPIN;
+            qCWarning(logDaemon) << "Configuration not found:" << GRANDSEARCH_CLASS_FILE_DEEPIN;
         }
     }
 
-    //设置是否启用设置搜索项
+    // 设置是否启用设置搜索项
     {
         bool on = set->value(GRANDSEARCH_GROUP_SETTING, true).toBool();
         searcherConfig->setValue(GRANDSEARCH_CLASS_SETTING_CONTROLCENTER, on);
     }
 
-    //设置是否启用应用搜索项
+    // 设置是否启用应用搜索项
     {
         bool on = set->value(GRANDSEARCH_GROUP_APP, true).toBool();
         searcherConfig->setValue(GRANDSEARCH_CLASS_APP_DESKTOP, on);
     }
 
-    //设置是否启用设置搜索项
+    // 设置是否启用设置搜索项
     {
         bool on = set->value(GRANDSEARCH_GROUP_SETTING, true).toBool();
         searcherConfig->setValue(GRANDSEARCH_CLASS_SETTING_CONTROLCENTER, on);
     }
 
-    //设置是否启用web搜索项
+    // 设置是否启用web搜索项
     {
         bool on = set->value(GRANDSEARCH_GROUP_WEB, true).toBool();
         searcherConfig->setValue(GRANDSEARCH_CLASS_WEB_STATICTEXT, on);
@@ -174,10 +178,10 @@ bool ConfigerPrivate::updateConfig1(QSettings *set)
             ret = set->value(GRANDSEARCH_CLASS_GENERALFILE_SEMANTIC_FULLTEXT, false).toBool();
             conf->setValue(GRANDSEARCH_CLASS_GENERALFILE_SEMANTIC_FULLTEXT, ret);
 
-            //设置是否启用AI搜索项
+            // 设置是否启用AI搜索项
             searcherConfig->setValue(GRANDSEARCH_CLASS_GENERALFILE_SEMANTIC, on);
         } else {
-            qWarning() << "no shuch config:" << GRANDSEARCH_SEMANTIC_GROUP;
+            qCWarning(logDaemon) << "Configuration not found:" << GRANDSEARCH_SEMANTIC_GROUP;
         }
 
         set->endGroup();
@@ -192,7 +196,7 @@ bool ConfigerPrivate::updateConfig1(QSettings *set)
         ret = set->value(GRANDSEARCH_TAILER_TIMEMODEFIED, true).toBool();
         conf->setValue(GRANDSEARCH_TAILER_TIMEMODEFIED, ret);
     } else {
-        qWarning() << "no shuch config:" << GRANDSEARCH_TAILER_GROUP;
+        qCWarning(logDaemon) << "Configuration not found:" << GRANDSEARCH_TAILER_GROUP;
     }
 
     set->endGroup();
@@ -233,7 +237,7 @@ bool ConfigerPrivate::updateConfig1(QSettings *set)
         auto searchEngineCustomAddr = set->value(GRANDSEARCH_WEB_SEARCHENGINE_CUSTOM_ADDR).toString();
         conf->setValue(GRANDSEARCH_WEB_SEARCHENGINE_CUSTOM_ADDR, searchEngineCustomAddr);
     } else {
-        qWarning() << "no shuch config:" << GRANDSEARCH_WEB_SEARCHENGINE;
+        qCWarning(logDaemon) << "Configuration not found:" << GRANDSEARCH_WEB_SEARCHENGINE;
     }
     set->endGroup();
 
@@ -254,8 +258,9 @@ void ConfigerPrivate::resetPath(QString &path) const
     path += "/";
 }
 
-Configer::Configer(QObject *parent) : QObject(parent)
-  , d(new ConfigerPrivate(this))
+Configer::Configer(QObject *parent)
+    : QObject(parent),
+      d(new ConfigerPrivate(this))
 {
     d->m_delayLoad.setSingleShot(true);
     d->m_delayLoad.setInterval(50);
@@ -279,19 +284,19 @@ bool Configer::init()
 
     auto configPath = QStandardPaths::standardLocations(QStandardPaths::ConfigLocation).first();
     configPath = configPath
-                 + "/" + QCoreApplication::organizationName()
-                 + "/" + GRANDSEARCH_DAEMON_NAME
-                 + "/" + GRANDSEARCH_DAEMON_NAME + ".conf";
+            + "/" + QCoreApplication::organizationName()
+            + "/" + GRANDSEARCH_DAEMON_NAME
+            + "/" + GRANDSEARCH_DAEMON_NAME + ".conf";
 
     QFileInfo configFile(configPath);
     if (!configFile.exists()) {
         configFile.absoluteDir().mkpath(".");
 
-        //生成文件
+        // 生成文件
         QFile file(configPath);
         file.open(QFile::NewOnly);
         file.close();
-        qInfo() << "create conf " << configPath;
+        qCInfo(logDaemon) << "Created configuration file:" << configPath;
     }
     d->m_configPath = configFile.absoluteFilePath();
 
@@ -321,7 +326,7 @@ void Configer::initDefault()
 {
     QVariantHash rootData;
 
-    //初始化搜索项是否可用
+    // 初始化搜索项是否可用
     rootData.insert(GRANDSEARCH_PREF_SEARCHERENABLED, QVariant::fromValue(d->defaultSearcher()));
 
     //初始化文件搜索的子类目
@@ -348,25 +353,25 @@ void Configer::initDefault()
 
 void Configer::onFileChanged(const QString &path)
 {
-    qDebug() << "config-file changed" << path;
+    qCDebug(logDaemon) << "Configuration file changed:" << path;
     d->m_delayLoad.start();
 }
 
 void Configer::onLoadConfig()
 {
-    qDebug() << __FUNCTION__;
+    qCDebug(logDaemon) << "Loading configuration";
     if (d->m_configPath.isEmpty())
         return;
 
     QFileInfo configFile(d->m_configPath);
     if (!configFile.exists()) {
-        qWarning() << "config file losted";
+        qCWarning(logDaemon) << "Configuration file not found:" << d->m_configPath;
         return;
     }
 
     QSettings set(d->m_configPath, QSettings::IniFormat);
     if (set.status() != QSettings::NoError) {
-        qWarning() << "config file error" << set.status();
+        qCWarning(logDaemon) << "Configuration file error - Status:" << set.status();
         return;
     }
 
@@ -375,10 +380,10 @@ void Configer::onLoadConfig()
 
     QString ver = set.value("Version_Group/version.config", QString()).toString();
     if (ver.isEmpty()) {
-        qWarning() << "config file error: no version.";
+        qCWarning(logDaemon) << "Configuration file error: Version not found";
         return;
     }
 
-    qInfo() << "config file version is" << ver;
+    qCInfo(logDaemon) << "Configuration file version:" << ver;
     d->updateConfig1(&set);
 }

--- a/src/dde-grand-search-daemon/dbusservice/grandsearchinterface.cpp
+++ b/src/dde-grand-search-daemon/dbusservice/grandsearchinterface.cpp
@@ -14,17 +14,20 @@
 #include <QThread>
 #include <QCoreApplication>
 #include <QDebug>
+#include <QLoggingCategory>
 
-#define CHECKINVOKER(ret) if (!d->isAccessable(message()))\
-                            return ret
+Q_DECLARE_LOGGING_CATEGORY(logDaemon)
+#define CHECKINVOKER(ret)            \
+    if (!d->isAccessable(message())) \
+    return ret
 
 using namespace GrandSearch;
 
 GrandSearchInterfacePrivate::GrandSearchInterfacePrivate(GrandSearchInterface *parent)
-    : QObject(parent)
-    , q(parent)
+    : QObject(parent),
+      q(parent)
 {
-    //允许调用dbus接口的可执行程序名单
+    // 允许调用dbus接口的可执行程序名单
     m_permit.insert("/usr/bin/dde-grand-search", true);
 }
 
@@ -41,10 +44,10 @@ bool GrandSearchInterfacePrivate::isAccessable(const QDBusMessage &msg) const
     QDBusConnectionInterface *ifs = QDBusConnection::sessionBus().interface();
     Q_ASSERT(ifs);
 
-    //获取调用方的进程ID
+    // 获取调用方的进程ID
     uint invokerPid = ifs->servicePid(msg.service()).value();
 
-    //读取进程的可执行程序路径
+    // 读取进程的可执行程序路径
     QFileInfo fileInfo(QString("/proc/%1/exe").arg(invokerPid));
     if (!fileInfo.exists())
         return false;
@@ -52,9 +55,9 @@ bool GrandSearchInterfacePrivate::isAccessable(const QDBusMessage &msg) const
 
     bool accessable = m_permit.value(invokerPath, false);
     if (!accessable)
-        qWarning() << "invalid invoker:" << invokerPath << "pid" << invokerPid << accessable;
+        qCWarning(logDaemon) << "Access denied: Invalid invoker path:" << invokerPath << "PID:" << invokerPid;
 
-//调试使用
+// 调试使用
 #ifdef QT_DEBUG
     return true;
 #endif
@@ -65,15 +68,15 @@ void GrandSearchInterfacePrivate::terminate()
 {
     m_deadline.stop();
 
-    //停止搜索
+    // 停止搜索
     if (m_main)
         m_main->terminate();
 }
 
 void GrandSearchInterfacePrivate::onMatched()
 {
-    //控制在主线程
-    qInfo() << "notify matched" << m_session;
+    // 控制在主线程
+    qCInfo(logDaemon) << "Search results matched for session:" << m_session;
     Q_ASSERT(QThread::currentThread() == qApp->thread());
     if (!m_session.isEmpty()) {
         emit q->Matched(m_session);
@@ -82,8 +85,8 @@ void GrandSearchInterfacePrivate::onMatched()
 
 void GrandSearchInterfacePrivate::onSearchCompleted()
 {
-    //控制在主线程
-    qInfo() << "notify finished" << m_session;
+    // 控制在主线程
+    qCInfo(logDaemon) << "Search completed for session:" << m_session;
     Q_ASSERT(QThread::currentThread() == qApp->thread());
     if (!m_session.isEmpty()) {
         emit q->SearchCompleted(m_session);
@@ -91,8 +94,8 @@ void GrandSearchInterfacePrivate::onSearchCompleted()
 }
 
 GrandSearchInterface::GrandSearchInterface(QObject *parent)
-    : QDBusService(parent)
-    , d(new GrandSearchInterfacePrivate(this))
+    : QDBusService(parent),
+      d(new GrandSearchInterfacePrivate(this))
 {
     initPolicy(QDBusConnection::SessionBus, QString(SERVICE_CONFIG_DIR) + "other/grand-search-daemon.json");
 }
@@ -105,13 +108,13 @@ bool GrandSearchInterface::init()
 {
     Q_ASSERT(d->m_main == nullptr);
 
-    //超时后强制结束任务
+    // 超时后强制结束任务
     d->m_deadline.setInterval(40000);
     d->m_deadline.setSingleShot(true);
     connect(&d->m_deadline, &QTimer::timeout, d, &GrandSearchInterfacePrivate::terminate);
 
     d->m_main = new MainController;
-    //直连，防止被事件循环打乱时序
+    // 直连，防止被事件循环打乱时序
     connect(d->m_main, &MainController::matched, d, &GrandSearchInterfacePrivate::onMatched, Qt::DirectConnection);
     connect(d->m_main, &MainController::searchCompleted, d, &GrandSearchInterfacePrivate::onSearchCompleted, Qt::DirectConnection);
 
@@ -120,18 +123,20 @@ bool GrandSearchInterface::init()
 
 bool GrandSearchInterface::Search(const QString &session, const QString &key)
 {
-    qDebug() << __FUNCTION__ << "session " << session;
+    qCDebug(logDaemon) << "Search request received - Session:" << session;
     CHECKINVOKER(false);
 
-    //会话ID检查，符合UUID宽度36。
+    // 会话ID检查，符合UUID宽度36。
     static int sessionLength = 36;
-    //关键词检查，最大长度不超过512
+    // 关键词检查，最大长度不超过512
     static int maxKeyLength = 512;
     if (session.size() != sessionLength || key.isEmpty() || key.size() > maxKeyLength) {
+        qCWarning(logDaemon) << "Invalid search parameters - Session length:" << session.size()
+                             << "Key length:" << key.size();
         return false;
     }
 
-    //发起新的搜索
+    // 发起新的搜索
     if (d->m_main->newSearch(key)) {
         d->m_session = session;
         d->m_deadline.start();
@@ -145,14 +150,14 @@ bool GrandSearchInterface::Search(const QString &session, const QString &key)
 
 void GrandSearchInterface::Terminate()
 {
-    qDebug() << __FUNCTION__;
+    qCDebug(logDaemon) << "Terminating search operation";
     CHECKINVOKER();
     d->terminate();
 }
 
 QByteArray GrandSearchInterface::MatchedResults(const QString &session)
 {
-    qDebug() << __FUNCTION__ << "session " << session;
+    qCDebug(logDaemon) << "Retrieving matched results for session:" << session;
     QByteArray ret;
     CHECKINVOKER(ret);
 
@@ -165,7 +170,7 @@ QByteArray GrandSearchInterface::MatchedResults(const QString &session)
 
 QByteArray GrandSearchInterface::MatchedBuffer(const QString &session)
 {
-    qDebug() << __FUNCTION__ << "session " << session;
+    qCDebug(logDaemon) << "Reading matched buffer for session:" << session;
     QByteArray ret;
     CHECKINVOKER(ret);
 
@@ -178,39 +183,41 @@ QByteArray GrandSearchInterface::MatchedBuffer(const QString &session)
 
 bool GrandSearchInterface::OpenWithPlugin(const QString &searcher, const QString &item)
 {
+    qCDebug(logDaemon) << "Opening item with plugin - Searcher:" << searcher << "Item:" << item;
     CHECKINVOKER(false);
     return d->m_main->searcherAction(searcher, PLUGININTERFACE_PROTOCOL_ACTION_OPEN, item);
 }
 
-//bool GrandSearchInterface::Configure(const QVariantMap &)
+// bool GrandSearchInterface::Configure(const QVariantMap &)
 //{
-//    CHECKINVOKER(false);
+//     CHECKINVOKER(false);
 
 //    return false;
 //}
 
-//QVariantMap GrandSearchInterface::Configuration() const
+// QVariantMap GrandSearchInterface::Configuration() const
 //{
-//    return QVariantMap();
-//}
+//     return QVariantMap();
+// }
 
-//bool GrandSearchInterface::SetFeedBackStrategy(const QVariantMap &)
+// bool GrandSearchInterface::SetFeedBackStrategy(const QVariantMap &)
 //{
-//    CHECKINVOKER(false);
+//     CHECKINVOKER(false);
 
 //    return false;
 //}
 
-//QVariantMap GrandSearchInterface::FeedBackStrategy() const
+// QVariantMap GrandSearchInterface::FeedBackStrategy() const
 //{
-//    return QVariantMap();
-//}
+//     return QVariantMap();
+// }
 
 bool GrandSearchInterface::KeepAlive(const QString &session)
 {
+    qCDebug(logDaemon) << "Keep alive request for session:" << session;
     CHECKINVOKER(false);
 
-    //重新计时
+    // 重新计时
     if (d->vaildSession(session)) {
         d->m_deadline.start();
         return true;

--- a/src/dde-grand-search-daemon/searcher/app/desktopappworker.cpp
+++ b/src/dde-grand-search-daemon/searcher/app/desktopappworker.cpp
@@ -6,78 +6,82 @@
 #include "global/builtinsearch.h"
 #include "global/searchhelper.h"
 
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logDaemon)
+
 using namespace GrandSearch;
 
-DesktopAppWorker::DesktopAppWorker(const QString &name, QObject *parent) : ProxyWorker(name, parent)
+DesktopAppWorker::DesktopAppWorker(const QString &name, QObject *parent)
+    : ProxyWorker(name, parent)
 {
-
 }
 
 void DesktopAppWorker::setContext(const QString &context)
 {
     if (context.isEmpty())
-        qWarning() << "search key is empty.";
-
+        qCWarning(logDaemon) << "Search key is empty";
     m_context = buildKeyword(context);
 }
 
 bool DesktopAppWorker::isAsync() const
 {
-    //同步搜索，需分配线程资源
+    // 同步搜索，需分配线程资源
     return false;
 }
 
 bool DesktopAppWorker::working(void *context)
 {
-    //准备状态切运行中，否则直接返回
+    // 准备状态切运行中，否则直接返回
     if (!m_status.testAndSetRelease(Ready, Runing))
         return false;
 
     Q_UNUSED(context);
     if (m_context.isEmpty() || m_indexTable.isEmpty()) {
+        qCDebug(logDaemon) << "Search context or index table is empty, completing search";
         m_status.storeRelease(Completed);
         return true;
     }
 
-    //计时
+    // 计时
     QElapsedTimer time;
     time.start();
     int lastEmit = 0;
 
-    //遍历查找
+    // 遍历查找
     QHash<MatchedItem *, bool> found;
     for (auto iter = m_indexTable.begin(); iter != m_indexTable.end(); ++iter) {
-        //中断
+        // 中断
         if (m_status.loadAcquire() != Runing)
             return false;
 
-        //匹配
+        // 匹配
         QRegularExpression regExp(m_context, QRegularExpression::CaseInsensitiveOption);
         if (iter.key().contains(regExp)) {
-            //遍历该关键词匹配的项目检查是否已经被添加
+            // 遍历该关键词匹配的项目检查是否已经被添加
             for (const QSharedPointer<MatchedItem> &item : iter.value()) {
-                //检查是否已经添加过
+                // 检查是否已经添加过
                 if (found.contains(item.data()))
                     continue;
 
-                //中断
+                // 中断
                 if (m_status.loadAcquire() != Runing)
                     return false;
 
-                //加入搜索结果中
+                // 加入搜索结果中
                 {
                     QMutexLocker lk(&m_mtx);
                     m_items.append(*item);
                     found.insert(item.data(), true);
 
-                    //数据从无到有发送通知
-                    //50ms推送一次
+                    // 数据从无到有发送通知
+                    // 50ms推送一次
                     int cur = time.elapsed();
                     if ((cur - lastEmit) > 50) {
                         lastEmit = cur;
-                        qDebug() << "unearthed, current spend:" << cur;
+                        qCDebug(logDaemon) << "New results found - Time elapsed:" << cur << "ms";
 
-                        //发送信号前必须解锁
+                        // 发送信号前必须解锁
                         lk.unlock();
                         emit unearthed(this);
                     }
@@ -94,9 +98,11 @@ bool DesktopAppWorker::working(void *context)
         leave = m_items.size();
     }
 
-    qInfo() << "search completed, found items:" << found.size() << "total spend:" << time.elapsed()
-            << "current items" << leave;
-    //还有数据再发一次
+    qCInfo(logDaemon) << "Search completed - Found items:" << found.size()
+                      << "Total time:" << time.elapsed() << "ms"
+                      << "Current items:" << leave;
+
+    // 还有数据再发一次
     if (leave > 0)
         emit unearthed(this);
 
@@ -127,17 +133,17 @@ MatchedItemMap DesktopAppWorker::takeAll()
     Q_ASSERT(m_items.isEmpty());
     lk.unlock();
 
-    //添加分组
+    // 添加分组
     MatchedItemMap ret;
     ret.insert(group(), items);
 
     return ret;
 }
 
-void DesktopAppWorker::setIndexTable(const QHash<QString, QList<QSharedPointer<MatchedItem> > > &table)
+void DesktopAppWorker::setIndexTable(const QHash<QString, QList<QSharedPointer<MatchedItem>>> &table)
 {
-    qDebug() << "index table count" << table.size();
-    //搜索中不允许设置索引表, 已有数据后不允许更新
+    qCDebug(logDaemon) << "Setting index table - Entry count:" << table.size();
+    // 搜索中不允许设置索引表, 已有数据后不允许更新
     if (m_status.loadAcquire() == Runing || !m_indexTable.isEmpty())
         return;
 

--- a/src/dde-grand-search-daemon/searcher/extend/extendsearcher.cpp
+++ b/src/dde-grand-search-daemon/searcher/extend/extendsearcher.cpp
@@ -9,33 +9,44 @@
 
 #include <QDBusConnectionInterface>
 #include <QDBusInterface>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logDaemon)
 
 using namespace GrandSearch;
 
 ExtendSearcherPrivate::ExtendSearcherPrivate(ExtendSearcher *parent)
     : QObject(parent)
 {
-
 }
 
 ExtendSearcher::ExtendSearcher(const QString &name, QObject *parent)
-    : Searcher(parent)
-    , d(new ExtendSearcherPrivate(this))
+    : Searcher(parent),
+      d(new ExtendSearcherPrivate(this))
 {
     d->m_name = name;
+    qCDebug(logDaemon) << "Initializing extend searcher:" << name;
 }
 
 void ExtendSearcher::setService(const QString &service, const QString &address, const QString &interface, const QString &ver)
 {
     if (Q_UNLIKELY(address.isEmpty()
-            || service.isEmpty() || interface.isEmpty()
-            || ver.isEmpty()))
-        return ;
+                   || service.isEmpty() || interface.isEmpty()
+                   || ver.isEmpty())) {
+        qCWarning(logDaemon) << "Invalid service configuration - Service:" << service
+                             << "Address:" << address
+                             << "Interface:" << interface << "Version:" << ver;
+        return;
+    }
 
     d->m_service = service;
     d->m_address = address;
     d->m_interface = interface;
     d->m_version = ver;
+    qCDebug(logDaemon) << "Service configured for searcher:" << d->m_name
+                       << "- Service:" << service
+                       << "Address:" << address
+                       << "Interface:" << interface << "Version:" << ver;
 }
 
 void ExtendSearcher::setActivatable(Activatable act)
@@ -61,19 +72,22 @@ bool ExtendSearcher::isActive() const
 
 bool ExtendSearcher::activate()
 {
-    //受管理的插件通过进程激活
+    // 受管理的插件通过进程激活
     if (d->m_activatable == InnerActivation) {
         bool ret = false;
+        qCDebug(logDaemon) << "Requesting inner activation for searcher:" << d->m_name;
         emit activateRequest(name(), ret);
         return ret;
     } else if (d->m_activatable == Trigger) {
         // 激活DBus服务
+        qCDebug(logDaemon) << "Triggering DBus service activation for:" << d->m_service;
         auto msg = QDBusMessage::createMethodCall(d->m_service, d->m_address,
                                                   "org.freedesktop.DBus.Peer", "Ping");
         QDBusConnection::sessionBus().asyncCall(msg, 5);
         return true;
     }
 
+    qCWarning(logDaemon) << "No activation method available for searcher:" << d->m_name;
     return false;
 }
 
@@ -84,20 +98,30 @@ ProxyWorker *ExtendSearcher::createWorker() const
         return worker;
 
     delete worker;
-    qWarning() << "ExtendWorker: fial to set service";
+    qCWarning(logDaemon) << "Failed to create worker - Service configuration invalid:"
+                         << "Service:" << d->m_service
+                         << "Address:" << d->m_address
+                         << "Interface:" << d->m_interface
+                         << "Version:" << d->m_version;
     return nullptr;
 }
 
 bool ExtendSearcher::action(const QString &action, const QString &item)
 {
     PluginLiaison cont;
-    if (cont.init(d->m_service, d->m_address, d->m_interface, d->m_version , d->m_name)) {
+    if (cont.init(d->m_service, d->m_address, d->m_interface, d->m_version, d->m_name)) {
         if (cont.action(action, item))
             return true;
         else
-            qWarning() << "action: invaild action:" << action;
+            qCWarning(logDaemon) << "Invalid action requested - Action:" << action
+                                 << "Item:" << item
+                                 << "Searcher:" << d->m_name;
     } else {
-        qWarning() << "action: invaild searcher" << name();
+        qCWarning(logDaemon) << "Failed to initialize plugin liaison - Searcher:" << d->m_name
+                             << "Service:" << d->m_service
+                             << "Address:" << d->m_address
+                             << "Interface:" << d->m_interface
+                             << "Version:" << d->m_version;
     }
 
     return false;

--- a/src/dde-grand-search-daemon/searcher/extend/extendworker.cpp
+++ b/src/dde-grand-search-daemon/searcher/extend/extendworker.cpp
@@ -3,8 +3,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "extendworker.h"
-
 #include "searchplugin/pluginliaison.h"
+
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logDaemon)
 
 using namespace GrandSearch;
 
@@ -13,40 +16,48 @@ ExtendWorker::ExtendWorker(const QString &name, QObject *parent)
 {
     m_timeout.setInterval(25 * 1000);
     m_timeout.setSingleShot(true);
-    connect(&m_timeout, &QTimer::timeout, this, [this](){
-        qDebug() << m_name << "working time out.";
+    connect(&m_timeout, &QTimer::timeout, this, [this]() {
+        qCWarning(logDaemon) << "Worker timeout - Name:" << m_name;
         onWorkFinished({});
     });
 }
 
 ExtendWorker::~ExtendWorker()
 {
-
 }
 
 bool ExtendWorker::setService(const QString &service, const QString &address, const QString &interface, const QString &ver)
 {
     if (Q_UNLIKELY(address.isEmpty()
-            || service.isEmpty() || interface.isEmpty()
-            || ver.isEmpty()))
+                   || service.isEmpty() || interface.isEmpty()
+                   || ver.isEmpty())) {
+        qCWarning(logDaemon) << "Invalid service configuration - Service:" << service
+                             << "Address:" << address
+                             << "Interface:" << interface << "Version:" << ver;
         return false;
+    }
 
-    if (m_liaison)
+    if (m_liaison) {
+        qCWarning(logDaemon) << "Service already configured for worker:" << name();
         return false;
+    }
 
-    //创建通信模块
+    // 创建通信模块
     auto liaison = new PluginLiaison(this);
     if (!liaison->init(service, address, interface, ver, name())) {
-        qWarning() << "fail to create PluginLiaison: " << service << address << interface << ver;
+        qCWarning(logDaemon) << "Failed to initialize PluginLiaison - Service:" << service
+                             << "Address:" << address
+                             << "Interface:" << interface << "Version:" << ver;
         delete liaison;
         return false;
     }
 
     m_liaison = liaison;
+    qCDebug(logDaemon) << "Service configured successfully for worker:" << name();
 
-    //插件返回数据解析完毕，使用队列切入主线程，信号会来自子线程，也会来自主线程
-    connect(m_liaison, &PluginLiaison::searchFinished, this, &ExtendWorker::onWorkFinished,Qt::QueuedConnection);
-    //dbus服务就绪尝试调用,在working函数中,可能服务还未启动,因此需在服务启动后再次尝试调用
+    // 插件返回数据解析完毕，使用队列切入主线程，信号会来自子线程，也会来自主线程
+    connect(m_liaison, &PluginLiaison::searchFinished, this, &ExtendWorker::onWorkFinished, Qt::QueuedConnection);
+    // dbus服务就绪尝试调用,在working函数中,可能服务还未启动,因此需在服务启动后再次尝试调用
     connect(m_liaison, &PluginLiaison::ready, this, &ExtendWorker::tryWorking, Qt::QueuedConnection);
     return true;
 }
@@ -63,45 +74,51 @@ bool ExtendWorker::isAsync() const
 
 bool ExtendWorker::working(void *context)
 {
-    //准备状态切运行中，否则直接返回
+    // 准备状态切运行中，否则直接返回
     if (!m_status.testAndSetRelease(Ready, Runing))
         return false;
 
     QString id = *static_cast<QString *>(context);
     if (!m_liaison || id.isEmpty() || m_context.isEmpty()) {
+        qCWarning(logDaemon) << "Invalid working state - Worker:" << name()
+                             << "Has liaison:" << (m_liaison != nullptr)
+                             << "Task ID:" << id
+                             << "Context empty:" << m_context.isEmpty();
         m_status.storeRelease(Completed);
         return false;
     }
 
     m_taskID = id;
 
-    //服务是否可用
+    // 服务是否可用
     QMutexLocker lk(&m_callMtx);
     if (m_liaison->isVaild()) {
         m_callSerach = Called;
         lk.unlock();
 
-        //直接调用
-        qDebug() << m_name << "working, search.";
+        // 直接调用
+        qCDebug(logDaemon) << "Starting search - Worker:" << name() << "Task ID:" << id;
         if (m_liaison->search(m_taskID, m_context)) {
             return true;
         } else {
+            qCWarning(logDaemon) << "Search request failed - Worker:" << name() << "Task ID:" << id;
             m_status.storeRelease(Completed);
             return false;
         }
     }
 
-    //等待服务启动后再调用
-    qDebug() << m_name << "working, wait starting.";
+    // 等待服务启动后再调用
+    qCDebug(logDaemon) << "Waiting for service to start - Worker:" << name() << "Task ID:" << id;
     m_callSerach = WaitCall;
 
-    //主线程中启动超时
+    // 主线程中启动超时
     QMetaObject::invokeMethod(&m_timeout, "start", Qt::QueuedConnection);
     return true;
 }
 
 void ExtendWorker::terminate()
 {
+    qCDebug(logDaemon) << "Terminating worker - Name:" << name() << "Task ID:" << m_taskID;
     m_status.storeRelease(Terminated);
 
     if (m_liaison)
@@ -137,19 +154,20 @@ void ExtendWorker::tryWorking()
     //! 由dbus服务启动信号触发，在主线程执行
     QMutexLocker lk(&m_callMtx);
     if (m_callSerach != WaitCall) {
-        qDebug() << m_name << "service started, but called.";
+        qCDebug(logDaemon) << "Service started but search already called - Worker:" << name();
         return;
     }
     m_callSerach = Called;
     m_timeout.stop();
     lk.unlock();
 
-    qInfo() << m_name << "service started, search.";
+    qCInfo(logDaemon) << "Service started, initiating search - Worker:" << name() << "Task ID:" << m_taskID;
     if (!m_liaison->search(m_taskID, m_context)) {
-        //发起搜索失败
+        // 发起搜索失败
+        qCWarning(logDaemon) << "Search request failed after service start - Worker:" << name() << "Task ID:" << m_taskID;
         m_status.storeRelease(Completed);
 
-        //发送结束信号
+        // 发送结束信号
         emit asyncFinished(this);
     }
 }
@@ -164,7 +182,8 @@ void ExtendWorker::onWorkFinished(const MatchedItemMap &ret)
     if (!ret.isEmpty())
         emit unearthed(this);
 
-    qDebug() << name() << "work finished" << ret.size();
-    //异步搜索结束
+    qCDebug(logDaemon) << "Search completed - Worker:" << name() << "Task ID:" << m_taskID
+                       << "Results:" << ret.size();
+    // 异步搜索结束
     emit asyncFinished(this);
 }

--- a/src/dde-grand-search-daemon/searcher/file/filenamesearcher.cpp
+++ b/src/dde-grand-search-daemon/searcher/file/filenamesearcher.cpp
@@ -11,10 +11,14 @@
 #include <QDBusInterface>
 #include <QDBusReply>
 #include <QDBusConnectionInterface>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logDaemon)
 
 using namespace GrandSearch;
 
-FileNameSearcher::FileNameSearcher(QObject *parent) : Searcher(parent)
+FileNameSearcher::FileNameSearcher(QObject *parent)
+    : Searcher(parent)
 {
 }
 
@@ -42,7 +46,7 @@ ProxyWorker *FileNameSearcher::createWorker() const
 bool FileNameSearcher::action(const QString &action, const QString &item)
 {
     Q_UNUSED(item)
-    qWarning() << "no such action:" << action << ".";
+    qCWarning(logDaemon) << "Unsupported action requested - Action:" << action;
     return false;
 }
 

--- a/src/dde-grand-search-daemon/searcher/searchergroup.cpp
+++ b/src/dde-grand-search-daemon/searcher/searchergroup.cpp
@@ -6,12 +6,15 @@
 #include "searchergroup_p.h"
 
 #include <QDebug>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logDaemon)
 
 using namespace GrandSearch;
 
 SearcherGroupPrivate::SearcherGroupPrivate(SearcherGroup *parent)
-    : QObject(parent)
-    , q(parent)
+    : QObject(parent),
+      q(parent)
 {
 }
 
@@ -19,16 +22,16 @@ void SearcherGroupPrivate::initBuiltin()
 {
     Q_ASSERT(m_builtin.isEmpty());
 
-    qInfo() << "create FileNameSearcher";
+    qCInfo(logDaemon) << "Initializing FileNameSearcher";
     auto fileSearcher = new FileNameSearcher(this);
     m_builtin << fileSearcher;
 
-    qInfo() << "create DesktopAppSearcher.";
+    qCInfo(logDaemon) << "Initializing DesktopAppSearcher";
     auto appSearcher = new DesktopAppSearcher(this);
     appSearcher->asyncInit();
     m_builtin << appSearcher;
 
-    qInfo() << "create StaticTextEchoer.";
+    qCInfo(logDaemon) << "Initializing StaticTextEchoer";
     auto stWebSearcher = new StaticTextEchoer(this);
     m_builtin << stWebSearcher;
 
@@ -37,34 +40,37 @@ void SearcherGroupPrivate::initBuiltin()
     auto semanticSearcher = new SemanticSearcher(this);
     m_builtin << semanticSearcher;
 #endif
-
 }
 
 bool SearcherGroupPrivate::addExtendSearcher(const SearchPluginInfo &pluginInfo)
 {
-    //在插件模块需对以下信息做严格的校验，此处不再做有效性检查
+    // 在插件模块需对以下信息做严格的校验，此处不再做有效性检查
     if (Q_UNLIKELY(pluginInfo.name.isEmpty() || pluginInfo.address.isEmpty()
-            || pluginInfo.service.isEmpty() || pluginInfo.interface.isEmpty()
-            || pluginInfo.ifsVersion.isEmpty()))
-        return false;
-
-    if (q->searcher(pluginInfo.name)) {
-        qWarning() << "searcher has existed." << pluginInfo.name;
+                   || pluginInfo.service.isEmpty() || pluginInfo.interface.isEmpty()
+                   || pluginInfo.ifsVersion.isEmpty())) {
+        qCWarning(logDaemon) << "Invalid plugin info - Missing required fields";
         return false;
     }
 
-    qDebug() << "cretate ExtendSearcher" << pluginInfo.name;
+    if (q->searcher(pluginInfo.name)) {
+        qCWarning(logDaemon) << "Searcher already exists:" << pluginInfo.name;
+        return false;
+    }
+
+    qCDebug(logDaemon) << "Creating ExtendSearcher:" << pluginInfo.name;
     ExtendSearcher *extend = new ExtendSearcher(pluginInfo.name, this);
     extend->setService(pluginInfo.service, pluginInfo.address,
-                         pluginInfo.interface, pluginInfo.ifsVersion);
+                       pluginInfo.interface, pluginInfo.ifsVersion);
 
-    //自动启动的插件设置为可激活
+    // 自动启动的插件设置为可激活
     if (pluginInfo.mode == SearchPluginInfo::Auto) {
+        qCDebug(logDaemon) << "Setting up auto-activation for plugin:" << pluginInfo.name;
         extend->setActivatable(ExtendSearcher::InnerActivation);
 
-        //激活操作,必须直连
+        // 激活操作,必须直连
         connect(extend, &ExtendSearcher::activateRequest, this, &SearcherGroupPrivate::onActivatePlugin, Qt::DirectConnection);
-    } else if (pluginInfo.mode == SearchPluginInfo::Trigger) { //dbus触发启动
+    } else if (pluginInfo.mode == SearchPluginInfo::Trigger) {   // dbus触发启动
+        qCDebug(logDaemon) << "Setting up trigger activation for plugin:" << pluginInfo.name;
         extend->setActivatable(ExtendSearcher::Trigger);
     }
 
@@ -75,6 +81,7 @@ bool SearcherGroupPrivate::addExtendSearcher(const SearchPluginInfo &pluginInfo)
 void SearcherGroupPrivate::onActivatePlugin(const QString &name, bool &ret)
 {
     Q_ASSERT(m_pluginManager);
+    qCDebug(logDaemon) << "Activating plugin:" << name;
     ret = m_pluginManager->activatePlugin(name);
 }
 
@@ -82,41 +89,49 @@ bool SearcherGroupPrivate::initPluinManager()
 {
     Q_ASSERT(m_pluginManager == nullptr);
 
+    qCDebug(logDaemon) << "Initializing plugin manager";
     m_pluginManager = new PluginManager(this);
-    return m_pluginManager->loadPlugin();
+    bool success = m_pluginManager->loadPlugin();
+    if (!success) {
+        qCCritical(logDaemon) << "Failed to initialize plugin manager";
+    }
+    return success;
 }
 
 void SearcherGroupPrivate::initExtendSearcher()
 {
     Q_ASSERT(m_pluginManager);
 
+    qCDebug(logDaemon) << "Initializing extended searchers";
     QList<SearchPluginInfo> plugins = m_pluginManager->plugins();
-    for (const SearchPluginInfo &info : plugins)
-        if (!addExtendSearcher(info))
-            qWarning() << "create ExtendSearcher error:" << info.name;
+    for (const SearchPluginInfo &info : plugins) {
+        if (!addExtendSearcher(info)) {
+            qCWarning(logDaemon) << "Failed to create ExtendSearcher:" << info.name;
+        }
+    }
 }
 
 SearcherGroup::SearcherGroup(QObject *parent)
-    : QObject(parent)
-    , d(new SearcherGroupPrivate(this))
+    : QObject(parent),
+      d(new SearcherGroupPrivate(this))
 {
 }
 
 bool SearcherGroup::init()
 {
-    //初始化内置搜索项
+    // 初始化内置搜索项
     d->initBuiltin();
 
-    //初始化插件
+    // 初始化插件
     if (!d->initPluinManager()) {
-        qCritical() << "error: fail to init PluinManager.";
+        qCCritical(logDaemon) << "Failed to initialize plugin manager";
         return false;
     }
 
-    //创建扩展搜索项
+    // 创建扩展搜索项
     d->initExtendSearcher();
 
-    //启动高优先级插件
+    // 启动高优先级插件
     d->m_pluginManager->autoActivate();
 
     return true;
@@ -146,12 +161,12 @@ void SearcherGroup::dormancy()
     if (d->m_pluginManager) {
         QList<SearchPluginInfo> plugins = d->m_pluginManager->plugins();
         for (const SearchPluginInfo &plugin : plugins) {
-            //停用低优先级的Auto类型插件
+            // 停用低优先级的Auto类型插件
             if (plugin.mode == SearchPluginInfo::Auto
-                    && plugin.priority == SearchPluginInfo::Low) {
+                && plugin.priority == SearchPluginInfo::Low) {
+                qCDebug(logDaemon) << "Deactivating low priority plugin:" << plugin.name;
                 d->m_pluginManager->inactivate(plugin.name);
             }
         }
     }
 }
-

--- a/src/dde-grand-search-daemon/searcher/web/statictextechoer.cpp
+++ b/src/dde-grand-search-daemon/searcher/web/statictextechoer.cpp
@@ -7,12 +7,15 @@
 #include "statictextworker.h"
 
 #include <QDebug>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logDaemon)
 
 using namespace GrandSearch;
 
-StaticTextEchoer::StaticTextEchoer(QObject *parent): Searcher(parent)
+StaticTextEchoer::StaticTextEchoer(QObject *parent)
+    : Searcher(parent)
 {
-
 }
 
 QString StaticTextEchoer::name() const
@@ -38,6 +41,6 @@ ProxyWorker *StaticTextEchoer::createWorker() const
 bool StaticTextEchoer::action(const QString &action, const QString &item)
 {
     Q_UNUSED(item);
-    qWarning() << "no such action:" << action << ".";
+    qCWarning(logDaemon) << "Unsupported action requested:" << action;
     return false;
 }

--- a/src/dde-grand-search-daemon/searcher/web/statictextworker.cpp
+++ b/src/dde-grand-search-daemon/searcher/web/statictextworker.cpp
@@ -9,52 +9,62 @@
 #include "global/searchhelper.h"
 
 #include <QByteArray>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logDaemon)
 
 using namespace GrandSearch;
 
-StaticTextWorker::StaticTextWorker(const QString &name, QObject *parent) : ProxyWorker(name, parent)
+StaticTextWorker::StaticTextWorker(const QString &name, QObject *parent)
+    : ProxyWorker(name, parent)
 {
-
 }
 
 void StaticTextWorker::setContext(const QString &context)
 {
-    if (context.isEmpty())
-        qWarning() << "search key is empty.";
+    if (context.isEmpty()) {
+        qCWarning(logDaemon) << "Search context is empty";
+        return;
+    }
+    qCDebug(logDaemon) << "Setting search context:" << context;
     m_context = context;
 }
 
 bool StaticTextWorker::isAsync() const
 {
-    //同步搜索，需分配线程资源
+    // 同步搜索，需分配线程资源
     return false;
 }
 
 bool StaticTextWorker::working(void *context)
 {
-    //准备状态切运行中，否则直接返回
-    if (!m_status.testAndSetRelease(Ready, Runing))
+    if (!m_status.testAndSetRelease(Ready, Runing)) {
+        qCWarning(logDaemon) << "Failed to start worker - Invalid state transition";
         return false;
+    }
 
     Q_UNUSED(context);
     if (m_context.isEmpty()) {
+        qCDebug(logDaemon) << "Empty search context, completing search";
         m_status.storeRelease(Completed);
         return true;
     }
 
+    qCDebug(logDaemon) << "Starting web search with context:" << m_context;
+
     auto config = ConfigerIns->group(GRANDSEARCH_WEB_GROUP);
     auto searchEngine = config->value(GRANDSEARCH_WEB_SEARCHENGINE, QString(""));
     QString defaultUrl = createUrl(searchEngine);
+    qCDebug(logDaemon) << "Using search engine:" << searchEngine << "URL template:" << defaultUrl;
 
     MatchedItem ret;
-
     QString encodeString(QUrl::toPercentEncoding(m_context));
     QString url = defaultUrl.arg(QString(encodeString));
 
     ret.item = url;
     ret.name = tr("Search for \"%1\"").arg(m_context);
     ret.type = "x-scheme-handler/http";
-    ret.icon = ret.type; //给一个无效的图标名，由前端寻找默认浏览器图标
+    ret.icon = ret.type;   // 给一个无效的图标名，由前端寻找默认浏览器图标
     ret.searcher = name();
 
     {
@@ -64,8 +74,8 @@ bool StaticTextWorker::working(void *context)
 
     m_status.storeRelease(Completed);
 
-    qDebug() << "echo text...";
-    //不能使用QTimer延迟发送，会出现任务结束后再发信号，此时已经无效。
+    qCInfo(logDaemon) << "Search completed - Generated URL:" << url;
+    // 不能使用QTimer延迟发送，会出现任务结束后再发信号，此时已经无效。
     QThread::msleep(100);
     emit unearthed(this);
 
@@ -96,9 +106,10 @@ MatchedItemMap StaticTextWorker::takeAll()
     Q_ASSERT(m_items.isEmpty());
     lk.unlock();
 
-    //添加分组
+    // 添加分组
     MatchedItemMap ret;
     ret.insert(group(), items);
+    qCDebug(logDaemon) << "Retrieved" << items.size() << "items from group:" << group();
 
     return ret;
 }
@@ -113,21 +124,22 @@ QString StaticTextWorker::createUrl(const QString &searchEngine) const
     static const QString baidu("https://www.baidu.com/s?&wd=%0");
     static const QString google("https://www.google.com/search?q=%0");
 
-    static const QHash<QString, QString> searchEngineChinese{{GRANDSEARCH_WEB_SEARCHENGINE_GOOGLE, "https://www.google.com/search?q=%0"},
-                                                {GRANDSEARCH_WEB_SEARCHENGINE_BING, "https://bing.com/search?q=%0"},
-                                                {GRANDSEARCH_WEB_SEARCHENGINE_YAHOO, "https://search.yahoo.com/search?p=%0"},
-                                                {GRANDSEARCH_WEB_SEARCHENGINE_360, "https://www.so.com/s?&q=%0"},
-                                                {GRANDSEARCH_WEB_SEARCHENGINE_SOGOU, "https://www.sogou.com/web?query=%0"},
-                                                {GRANDSEARCH_WEB_SEARCHENGINE_360AI, "https://www.sou.com/?q=%0&src=ec_tongxin"}};
-    static const QHash<QString, QString> searchEngineEnglish{{GRANDSEARCH_WEB_SEARCHENGINE_BING, "https://bing.com/search?q=%0"},
-                                                {GRANDSEARCH_WEB_SEARCHENGINE_YAHOO, "https://search.yahoo.com/search?p=%0"},
-                                                {GRANDSEARCH_WEB_SEARCHENGINE_BAIDU, "https://www.baidu.com/s?&wd=%0"}};
+    static const QHash<QString, QString> searchEngineChinese { { GRANDSEARCH_WEB_SEARCHENGINE_GOOGLE, "https://www.google.com/search?q=%0" },
+                                                               { GRANDSEARCH_WEB_SEARCHENGINE_BING, "https://bing.com/search?q=%0" },
+                                                               { GRANDSEARCH_WEB_SEARCHENGINE_YAHOO, "https://search.yahoo.com/search?p=%0" },
+                                                               { GRANDSEARCH_WEB_SEARCHENGINE_360, "https://www.so.com/s?&q=%0" },
+                                                               { GRANDSEARCH_WEB_SEARCHENGINE_SOGOU, "https://www.sogou.com/web?query=%0" },
+                                                               { GRANDSEARCH_WEB_SEARCHENGINE_360AI, "https://www.sou.com/?q=%0&src=ec_tongxin" } };
+    static const QHash<QString, QString> searchEngineEnglish { { GRANDSEARCH_WEB_SEARCHENGINE_BING, "https://bing.com/search?q=%0" },
+                                                               { GRANDSEARCH_WEB_SEARCHENGINE_YAHOO, "https://search.yahoo.com/search?p=%0" },
+                                                               { GRANDSEARCH_WEB_SEARCHENGINE_BAIDU, "https://www.baidu.com/s?&wd=%0" } };
 
     if (searchEngine == GRANDSEARCH_WEB_SEARCHENGINE_CUSTOM) {
         auto config = Configer::instance()->group(GRANDSEARCH_WEB_GROUP);
         QString searchEngineAddr = config->value(GRANDSEARCH_WEB_SEARCHENGINE_CUSTOM_ADDR, QString(""));
         searchEngineAddr = QString::fromStdString(QByteArray::fromBase64(searchEngineAddr.toUtf8()).toStdString());
         if (searchEngineAddr.isEmpty() || !searchEngineAddr.contains("%0")) {
+            qCWarning(logDaemon) << "Invalid custom search engine address, falling back to default";
             if (SearchHelper::instance()->isSimplifiedChinese()) {
                 searchEngineAddr = baidu;
             } else {
@@ -137,9 +149,12 @@ QString StaticTextWorker::createUrl(const QString &searchEngine) const
         return searchEngineAddr;
     }
 
+    QString url;
     if (SearchHelper::instance()->isSimplifiedChinese()) {
-        return searchEngineChinese.value(searchEngine, baidu);
+        url = searchEngineChinese.value(searchEngine, baidu);
     } else {
-        return searchEngineEnglish.value(searchEngine, google);
+        url = searchEngineEnglish.value(searchEngine, google);
     }
+    qCDebug(logDaemon) << "Selected search engine URL:" << url;
+    return url;
 }

--- a/src/dde-grand-search-daemon/searchplugin/pluginliaison.cpp
+++ b/src/dde-grand-search-daemon/searchplugin/pluginliaison.cpp
@@ -8,12 +8,15 @@
 
 #include <QDBusPendingCallWatcher>
 #include <QtConcurrent>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logDaemon)
 
 using namespace GrandSearch;
 
 PluginLiaisonPrivate::PluginLiaisonPrivate(PluginLiaison *parent)
-    : QObject(parent)
-    , q(parent)
+    : QObject(parent),
+      q(parent)
 {
     QDBusConnection::sessionBus().connect("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
                                           "NameOwnerChanged", this, SLOT(onServiceStarted(QString, QString, QString)));
@@ -21,13 +24,13 @@ PluginLiaisonPrivate::PluginLiaisonPrivate(PluginLiaison *parent)
 
 PluginLiaisonPrivate::~PluginLiaisonPrivate()
 {
-    qDebug() << "parse thread: waiting exit";
+    qCDebug(logDaemon) << "Waiting for parse thread to exit";
     m_parseThread.waitForFinished();
     if (m_replyWatcher) {
         delete m_replyWatcher;
         m_replyWatcher = nullptr;
     }
-    qDebug() << "parse thread: exited.";
+    qCDebug(logDaemon) << "Parse thread exited successfully";
 }
 
 bool PluginLiaisonPrivate::isVaild() const
@@ -36,7 +39,7 @@ bool PluginLiaisonPrivate::isVaild() const
         return false;
 
     if (m_inteface->isValid()) {
-        //init() 已经做过检查，这处只判空即可
+        // init() 已经做过检查，这处只判空即可
         return !m_ver.isEmpty();
     }
 
@@ -50,16 +53,16 @@ void PluginLiaisonPrivate::parseResult(const QString &json, PluginLiaisonPrivate
     QJsonParseError error;
     QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8(), &error);
     if (error.error != QJsonParseError::NoError) {
-        qWarning() << "search results: is not a json data.";
+        qCWarning(logDaemon) << "Invalid JSON data in search results - Error:" << error.errorString();
         emit d->q->searchFinished({});
         return;
     }
 
-    //中断
+    // 中断
     if (!d->m_searching.loadAcquire())
         return;
 
-    //输入
+    // 输入
     QVariantList in;
     QJsonObject root = doc.object();
     {
@@ -69,15 +72,16 @@ void PluginLiaisonPrivate::parseResult(const QString &json, PluginLiaisonPrivate
         in << var;
     }
 
-    //解析数据耗时
+    // 解析数据耗时
     DataConvIns->convert(d->m_ver, PLUGININTERFACE_TYPE_RESULT, &in, &ret);
-    qDebug() << "convert size" << json.size() << ret.size();
+    qCDebug(logDaemon) << "Data conversion completed - Input size:" << json.size()
+                       << "Output size:" << ret.size();
 
     if (ret.size() == 2) {
         auto id = ret.first().toString();
         if (!id.isEmpty()) {
             MatchedItemMap items = ret.at(1).value<MatchedItemMap>();
-            //修改状态，发送结果
+            // 修改状态，发送结果
             if (d->m_searching.testAndSetRelease(true, false))
                 emit d->q->searchFinished(items);
 
@@ -85,7 +89,7 @@ void PluginLiaisonPrivate::parseResult(const QString &json, PluginLiaisonPrivate
         }
     }
 
-    qWarning() << "error result from" << d->m_pluginName;
+    qCWarning(logDaemon) << "Invalid result format from plugin:" << d->m_pluginName;
     emit d->q->searchFinished({});
 }
 
@@ -97,20 +101,22 @@ void PluginLiaisonPrivate::onSearchReplied()
     if (watcher == nullptr || m_replyWatcher != watcher)
         return;
 
-    //中断
+    // 中断
     if (!m_searching.loadAcquire())
         return;
 
     auto reply = m_replyWatcher->reply();
     if (m_replyWatcher->isError() || reply.arguments().size() < 1) {
-        qWarning() << m_pluginName << reply.errorMessage();
+        qCWarning(logDaemon) << "Search error from plugin:" << m_pluginName
+                             << "Error:" << reply.errorMessage();
 
-        //发送结束
+        // 发送结束
         emit q->searchFinished({});
-    } else if (m_searching.loadAcquire()) { //需要解析
+    } else if (m_searching.loadAcquire()) {   // 需要解析
         QString ret = reply.arguments().at(0).toString();
 
-        qDebug() << "get reply" << m_pluginName << ret.size();
+        qCDebug(logDaemon) << "Received search reply from plugin:" << m_pluginName
+                           << "Data size:" << ret.size();
         m_parseThread = QtConcurrent::run(PluginLiaisonPrivate::parseResult, ret, this);
     }
 }
@@ -122,6 +128,7 @@ void PluginLiaisonPrivate::onServiceStarted(QString name, QString oldOwner, QStr
     auto con = QDBusConnection::sessionBus();
     if (m_inteface) {
         if (name == m_inteface->service() && con.interface()->isServiceRegistered(name)) {
+            qCDebug(logDaemon) << "Plugin service started:" << name;
             con.disconnect("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
                            "NameOwnerChanged", this, nullptr);
             emit q->ready();
@@ -130,22 +137,28 @@ void PluginLiaisonPrivate::onServiceStarted(QString name, QString oldOwner, QStr
 }
 
 PluginLiaison::PluginLiaison(QObject *parent)
-    : QObject(parent)
-    , d(new PluginLiaisonPrivate(this))
+    : QObject(parent),
+      d(new PluginLiaisonPrivate(this))
 {
-
 }
 
 bool PluginLiaison::init(const QString &service, const QString &address, const QString &interface, const QString &ver, const QString &pluginName)
 {
     if (Q_UNLIKELY(address.isEmpty()
-            || service.isEmpty() || interface.isEmpty()
-            || ver.isEmpty() || pluginName.isEmpty()))
+                   || service.isEmpty() || interface.isEmpty()
+                   || ver.isEmpty() || pluginName.isEmpty())) {
+        qCWarning(logDaemon) << "Invalid initialization parameters - Service:" << service
+                             << "Address:" << address
+                             << "Interface:" << interface << "Version:" << ver
+                             << "Plugin:" << pluginName;
         return false;
+    }
 
-    //检查版本
-    if (Q_UNLIKELY(d->m_inteface || !DataConvIns->isSupported(ver)))
+    // 检查版本
+    if (Q_UNLIKELY(d->m_inteface || !DataConvIns->isSupported(ver))) {
+        qCWarning(logDaemon) << "Unsupported interface version or interface already exists - Version:" << ver;
         return false;
+    }
 
     d->m_ver = ver;
     d->m_pluginName = pluginName;
@@ -153,8 +166,11 @@ bool PluginLiaison::init(const QString &service, const QString &address, const Q
     auto stdString = interface.toStdString();
     d->m_inteface = new SearchPluginInterfaceV1(service, address, stdString.c_str(),
                                                 QDBusConnection::sessionBus(), this);
-    //插件搜索超时暂定为25s
+    // 插件搜索超时暂定为25s
     d->m_inteface->setTimeout(25 * 1000);
+    qCDebug(logDaemon) << "Initialized plugin liaison - Service:" << service
+                       << "Interface:" << interface << "Version:" << ver
+                       << "Plugin:" << pluginName;
     return true;
 }
 
@@ -165,19 +181,26 @@ bool PluginLiaison::isVaild() const
 
 bool PluginLiaison::search(const QString &task, const QString &context)
 {
-    if (Q_UNLIKELY(task.isEmpty() || context.isEmpty() || !d->m_inteface))
+    if (Q_UNLIKELY(task.isEmpty() || context.isEmpty() || !d->m_inteface)) {
+        qCWarning(logDaemon) << "Invalid search parameters - Task:" << task
+                             << "Context:" << context;
         return false;
+    }
 
-    //转换成json数据
-    QStringList args{d->m_ver, task, context};
+    // 转换成json数据
+    QStringList args { d->m_ver, task, context };
     QJsonDocument doc;
     QJsonObject root;
-    if (DataConvIns->convert(d->m_ver, PLUGININTERFACE_TYPE_SEARCH, &args, &root) != 0)
+    if (DataConvIns->convert(d->m_ver, PLUGININTERFACE_TYPE_SEARCH, &args, &root) != 0) {
+        qCWarning(logDaemon) << "Failed to convert search parameters to JSON";
         return false;
+    }
 
-    //搜索中则直接返回
-    if (!d->m_searching.testAndSetRelease(false, true))
+    // 搜索中则直接返回
+    if (!d->m_searching.testAndSetRelease(false, true)) {
+        qCDebug(logDaemon) << "Search already in progress";
         return false;
+    }
 
     doc.setObject(root);
     QString input = doc.toJson(QJsonDocument::Compact);
@@ -187,19 +210,19 @@ bool PluginLiaison::search(const QString &task, const QString &context)
         d->m_replyWatcher = nullptr;
     }
 
-    //异步调用，监听返回
-    qDebug() << "call search" << d->m_inteface->service();
+    // 异步调用，监听返回
+    qCDebug(logDaemon) << "Initiating search on service:" << d->m_inteface->service();
     auto call = d->m_inteface->Search(input);
     d->m_replyWatcher = new QDBusPendingCallWatcher(call);
 
-    //不在主线程，需将watcher移到主线程
+    // 不在主线程，需将watcher移到主线程
     if (QThread::currentThread() != qApp->thread()) {
         d->m_replyWatcher->moveToThread(qApp->thread());
     }
 
     d->m_replyWatcher->setParent(this);
 
-    //回到主线程响应信号
+    // 回到主线程响应信号
     connect(d->m_replyWatcher, &QDBusPendingCallWatcher::finished, d, &PluginLiaisonPrivate::onSearchReplied, Qt::QueuedConnection);
     return true;
 }
@@ -209,15 +232,18 @@ bool PluginLiaison::stop(const QString &task)
     if (d->m_searching.testAndSetRelease(true, false)) {
         if (!task.isEmpty() && d->m_inteface) {
 
-            //转换成json数据
-            QStringList args{d->m_ver, task};
+            // 转换成json数据
+            QStringList args { d->m_ver, task };
             QJsonObject root;
-            if (DataConvIns->convert(d->m_ver, PLUGININTERFACE_TYPE_STOP, &args, &root) != 0)
+            if (DataConvIns->convert(d->m_ver, PLUGININTERFACE_TYPE_STOP, &args, &root) != 0) {
+                qCWarning(logDaemon) << "Failed to convert stop parameters to JSON";
                 return false;
+            }
 
             QJsonDocument doc;
             doc.setObject(root);
             QString input = doc.toJson(QJsonDocument::Compact);
+            qCDebug(logDaemon) << "Stopping search task:" << task;
             d->m_inteface->Stop(input);
         }
     }
@@ -226,20 +252,25 @@ bool PluginLiaison::stop(const QString &task)
 
 bool PluginLiaison::action(const QString &type, const QString &item)
 {
-    if (Q_UNLIKELY(type.isEmpty() || item.isEmpty() || !d->m_inteface))
+    if (Q_UNLIKELY(type.isEmpty() || item.isEmpty() || !d->m_inteface)) {
+        qCWarning(logDaemon) << "Invalid action parameters - Type:" << type
+                             << "Item:" << item;
         return false;
+    }
 
-    //转换成json数据
-    QStringList args{d->m_ver, type, item};
+    // 转换成json数据
+    QStringList args { d->m_ver, type, item };
     QJsonObject root;
-    if (DataConvIns->convert(d->m_ver, PLUGININTERFACE_TYPE_ACTION, &args, &root) != 0)
+    if (DataConvIns->convert(d->m_ver, PLUGININTERFACE_TYPE_ACTION, &args, &root) != 0) {
+        qCWarning(logDaemon) << "Failed to convert action parameters to JSON";
         return false;
+    }
 
     QJsonDocument doc;
     doc.setObject(root);
     QString input = doc.toJson(QJsonDocument::Compact);
+    qCDebug(logDaemon) << "Executing action - Type:" << type << "Item:" << item;
     d->m_inteface->Action(input);
 
     return true;
 }
-

--- a/src/dde-grand-search-daemon/searchplugin/process/pluginprocess.cpp
+++ b/src/dde-grand-search-daemon/searchplugin/process/pluginprocess.cpp
@@ -7,12 +7,16 @@
 
 #include <QProcess>
 #include <QTimerEvent>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logDaemon)
 
 using namespace GrandSearch;
 
 #define MAXRESTARTCOUNT 3
 
-PluginProcess::PluginProcess(QObject *parent) : QObject(parent)
+PluginProcess::PluginProcess(QObject *parent)
+    : QObject(parent)
 {
     qRegisterMetaType<QProcess::ProcessState>();
 }
@@ -27,28 +31,31 @@ bool PluginProcess::addProgram(const QString &name, const QString &path)
     Q_ASSERT(!name.isEmpty());
     Q_ASSERT(!path.isEmpty());
 
-    //解析出可执行程序与参数
+    // 解析出可执行程序与参数
     QString exec;
     QStringList args;
     {
         if (!SpecialTools::splitCommand(path, exec, args)) {
-            qWarning() << "error cmd:" << path;
+            qCWarning(logDaemon) << "Invalid command format:" << path;
             return false;
         }
     }
 
-    if (m_programs.contains(name))
+    if (m_programs.contains(name)) {
+        qCWarning(logDaemon) << "Program already exists:" << name;
         return false;
+    }
 
+    qCDebug(logDaemon) << "Adding program - Name:" << name << "Path:" << path;
     m_programs.insert(name, path);
 
-    //创建进程
+    // 创建进程
     QProcess *process = new QProcess;
     process->setProgram(exec);
     process->setArguments(args);
     m_processes.insert(name, process);
 
-    //进程状态改变,必须使用队列，否则在槽函数中继续启动进程会导致无法发出进程状态的信号
+    // 进程状态改变,必须使用队列，否则在槽函数中继续启动进程会导致无法发出进程状态的信号
     connect(process, &QProcess::stateChanged, this, &PluginProcess::processStateChanged, Qt::QueuedConnection);
     return true;
 }
@@ -64,6 +71,7 @@ void PluginProcess::setWatched(const QString &name, bool watch)
 
 void PluginProcess::clear()
 {
+    qCDebug(logDaemon) << "Clearing all programs and processes";
     m_programs.clear();
     m_watch.clear();
     m_restartCount.clear();
@@ -84,11 +92,12 @@ void PluginProcess::timerEvent(QTimerEvent *event)
 {
     int id = event->timerId();
     if (auto process = m_checklist.key(id, nullptr)) {
-        qDebug() << "check" << id << process->program();
-        //检查
+        qCDebug(logDaemon) << "Checking process stability - Timer ID:" << id
+                           << "Program:" << process->program();
+        // 检查
         checkStability(process);
 
-        //只检查一次，移除timer
+        // 只检查一次，移除timer
         removeChecklist(process);
         return;
     }
@@ -98,19 +107,21 @@ void PluginProcess::timerEvent(QTimerEvent *event)
 bool PluginProcess::startProgram(const QString &name)
 {
     if (!m_processes.contains(name)) {
-        qWarning() << "no such program:" << name;
+        qCWarning(logDaemon) << "Program not found:" << name;
         return false;
     }
 
     auto process = m_processes.value(name);
     Q_ASSERT(process);
 
-    QMap<QProcess*, int>::iterator iter = m_restartCount.find(process);
+    QMap<QProcess *, int>::iterator iter = m_restartCount.find(process);
     if (iter != m_restartCount.end()) {
         iter.value() += 1;
         if (iter.value() > MAXRESTARTCOUNT) {
             if (iter.value() == (MAXRESTARTCOUNT + 1))
-                qWarning() << "reject to start program:" << name << process->program() << "too many failures" << iter.value();
+                qCWarning(logDaemon) << "Rejecting program start - Name:" << name
+                                     << "Program:" << process->program()
+                                     << "Too many failures:" << iter.value();
             return false;
         }
     } else {
@@ -119,7 +130,9 @@ bool PluginProcess::startProgram(const QString &name)
 
     process->terminate();
     process->start();
-    qInfo() << "start program:" << name << process->program() << process->arguments();
+    qCInfo(logDaemon) << "Starting program - Name:" << name
+                      << "Program:" << process->program()
+                      << "Arguments:" << process->arguments();
     return true;
 }
 
@@ -129,28 +142,30 @@ void PluginProcess::terminate(const QString &name)
     if (iter != m_processes.end()) {
         QProcess *process = iter.value();
         Q_ASSERT(process);
-        if (process->state() == QProcess::NotRunning)
+        if (process->state() == QProcess::NotRunning) {
+            qCDebug(logDaemon) << "Process already terminated:" << name;
             return;
+        }
 
-        //取消状态监控，防止被重启
+        // 取消状态监控，防止被重启
         disconnect(process, nullptr, this, nullptr);
 
-        qInfo() << "terminate" << name;
+        qCInfo(logDaemon) << "Terminating process:" << name;
         process->terminate();
 
-        //等待1s退出
-        if(!process->waitForFinished(1000)) {
-            //没有退出，直接kill
+        // 等待1s退出
+        if (!process->waitForFinished(1000)) {
+            // 没有退出，直接kill
             process->kill();
-            qWarning() << "kill proccess" << name;
+            qCWarning(logDaemon) << "Process killed - Name:" << name;
         }
-        qInfo() << name << "is terminated";
+        qCInfo(logDaemon) << "Process terminated successfully:" << name;
 
-        //清理启动状态
+        // 清理启动状态
         removeChecklist(process);
         m_restartCount.remove(process);
 
-        //再次连接，进程状态改变,必须使用队列，否则在槽函数中继续启动进程会导致无法发出进程状态的信号
+        // 再次连接，进程状态改变,必须使用队列，否则在槽函数中继续启动进程会导致无法发出进程状态的信号
         connect(process, &QProcess::stateChanged, this, &PluginProcess::processStateChanged, Qt::QueuedConnection);
     }
 }
@@ -162,18 +177,23 @@ void PluginProcess::processStateChanged()
         return;
 
     auto state = process->state();
-    qInfo() << "process state:" << m_processes.key(process) << state << process->processId();
+    qCInfo(logDaemon) << "Process state changed - Name:" << m_processes.key(process)
+                      << "State:" << state
+                      << "PID:" << process->processId();
+
     if (state == QProcess::Running) {
-        //校验启动成功的时间
+        // 校验启动成功的时间
         addChecklist(process);
         return;
     }
 
     if (state == QProcess::NotRunning) {
         auto name = m_processes.key(process);
-        //守护程序，自动启动
-        if (m_watch.contains(name))
+        // 守护程序，自动启动
+        if (m_watch.contains(name)) {
+            qCDebug(logDaemon) << "Auto-restarting watched process:" << name;
             startProgram(name);
+        }
     }
 }
 
@@ -181,7 +201,7 @@ void PluginProcess::removeChecklist(QProcess *process)
 {
     auto iter = m_checklist.find(process);
     if (iter != m_checklist.end()) {
-        //停止定时器
+        // 停止定时器
         if (iter.value() > 0)
             killTimer(iter.value());
 
@@ -193,15 +213,18 @@ void PluginProcess::addChecklist(QProcess *process)
 {
     Q_ASSERT(process);
 
-    //先移除旧的
+    // 先移除旧的
     removeChecklist(process);
 
-    //1min后检查进程是否已稳定运行
+    // 1min后检查进程是否已稳定运行
     int id = startTimer(60 * 1000);
     if (id > 0) {
         m_checklist.insert(process, id);
+        qCDebug(logDaemon) << "Added stability check - Timer ID:" << id
+                           << "Process:" << m_processes.key(process);
     } else {
-       qCritical() << "fialed to start timer :" << id << m_processes.key(process);
+        qCCritical(logDaemon) << "Failed to start stability check timer - ID:" << id
+                              << "Process:" << m_processes.key(process);
     }
 }
 
@@ -209,13 +232,13 @@ void PluginProcess::checkStability(QProcess *process)
 {
     Q_ASSERT(process);
     if (process->state() == QProcess::Running) {
-        qInfo() << "process" << m_processes.key(process)
-                << "is stable. pid:" << process->processId()
-                << m_restartCount.value(process);
+        qCInfo(logDaemon) << "Process is stable - Name:" << m_processes.key(process)
+                          << "PID:" << process->processId()
+                          << "Restart count:" << m_restartCount.value(process);
         m_restartCount.remove(process);
     } else {
-        qWarning() << "process" << m_processes.key(process)
-                   << "is unstable." << process->program()
-                   << m_restartCount.value(process);
+        qCWarning(logDaemon) << "Process is unstable - Name:" << m_processes.key(process)
+                             << "Program:" << process->program()
+                             << "Restart count:" << m_restartCount.value(process);
     }
 }

--- a/src/global/framelogmanager.cpp
+++ b/src/global/framelogmanager.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "framelogmanager.h"
+
+#include <DLog>
+
+using namespace GrandSearch;
+DCORE_USE_NAMESPACE
+
+FrameLogManager::FrameLogManager(QObject *parent)
+    : QObject(parent)
+{
+}
+
+FrameLogManager::~FrameLogManager()
+{
+}
+
+FrameLogManager *FrameLogManager::instance()
+{
+    static FrameLogManager ins;
+    return &ins;
+}
+
+void FrameLogManager::applySuggestedLogSettings()
+{
+// DtkCore 5.6.8版本，支持journal方式日志存储，
+#if (DTK_VERSION >= DTK_VERSION_CHECK(5, 6, 8, 0))
+    DLogManager::registerJournalAppender();   // 开启journal日志存储
+#ifdef QT_DEBUG
+    DLogManager::registerConsoleAppender();   // Release下，标准输出需要禁止，否则会导致一系列问题
+#endif
+// 为保证兼容性，在该版本以下，采用原有log文件日志输出方式保存日志
+#else
+    // 设置终端和文件记录日志
+    const QString logFormat = "%{time}{yyyyMMdd.HH:mm:ss.zzz}[%{type:1}][%{function:-35} %{line:-4} %{threadid} ] %{message}\n";
+    DLogManager::setLogFormat(logFormat);
+    DLogManager::registerConsoleAppender();
+    DLogManager::registerFileAppender();
+#endif
+}
+
+Dtk::Core::Logger *FrameLogManager::globalDtkLogger()
+{
+    return DTK_CORE_NAMESPACE::Logger::globalInstance();
+}

--- a/src/global/framelogmanager.h
+++ b/src/global/framelogmanager.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef FRAMELOGMANAGER_H
+#define FRAMELOGMANAGER_H
+
+#include <QObject>
+
+namespace Dtk {
+namespace Core {
+class Logger;
+}
+}
+
+namespace GrandSearch {
+
+class FrameLogManager : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(FrameLogManager)
+
+public:
+    static FrameLogManager *instance();
+    void applySuggestedLogSettings();
+    Dtk::Core::Logger *globalDtkLogger();
+
+private:
+    explicit FrameLogManager(QObject *parent = nullptr);
+    ~FrameLogManager();
+};
+
+}   // namespace GrandSearch
+
+#define dgsLogManager ::GrandSearch::FrameLogManager::instance()
+
+#endif   // FRAMELOGMANAGER_H

--- a/src/grand-search-dock-plugin/ddegrandsearchdockplugin.cpp
+++ b/src/grand-search-dock-plugin/ddegrandsearchdockplugin.cpp
@@ -12,6 +12,7 @@
 #include <QGSettings>
 #endif
 #include <QLabel>
+#include <QLoggingCategory>
 
 #define GrandSearchPlugin "grand-search"
 #define MenuOpenSetting "menu_open_setting"
@@ -21,6 +22,7 @@
 #define SchemaPath "/com/deepin/dde/dock/module/grand-search/"
 #define SchemaKeyMenuEnable "menuEnable"
 
+Q_LOGGING_CATEGORY(logDock, "org.deepin.dde.dock.plugin.grandsearch")
 using namespace GrandSearch;
 DWIDGET_USE_NAMESPACE
 
@@ -77,7 +79,7 @@ void DdeGrandSearchDockPlugin::init(PluginProxyInterface *proxyInter)
         m_gsettings.reset(new QGSettings(SchemaId, SchemaPath));
         connect(m_gsettings.data(), &QGSettings::changed, this, &DdeGrandSearchDockPlugin::onGsettingsChanged);
     } else {
-        qWarning() << "no such schema id" << SchemaId;
+        qCWarning(logDock) << "GSettings schema not found - Schema:" << SchemaId;
     }
 #endif
 }
@@ -108,7 +110,7 @@ bool DdeGrandSearchDockPlugin::pluginIsAllowDisable()
 
 bool DdeGrandSearchDockPlugin::pluginIsDisable()
 {
-    // 第二个参数 “disabled” 表示存储这个值的键（所有配置都是以键值对的方式存储）
+    // 第二个参数 "disabled" 表示存储这个值的键（所有配置都是以键值对的方式存储）
     // 第三个参数表示默认值，即默认不禁用
     return m_proxyInter->getValue(this, "disabled", false).toBool();
 }
@@ -192,10 +194,10 @@ void DdeGrandSearchDockPlugin::onGsettingsChanged(const QString &key)
 {
     Q_ASSERT(m_gsettings);
 
-    qDebug() << "gsettings changed,and key:" << key << "    value:" << m_gsettings->get(key);
+    qCDebug(logDock) << "GSettings value changed - Key:" << key << "Value:" << m_gsettings->get(key);
     if (key == SchemaKeyMenuEnable) {
         bool enable = m_gsettings->get(key).toBool();
-        qInfo() << "The status of whether the grand search right-click menu is enabled changes to:" << enable;
+        qCInfo(logDock) << "Grand search context menu state changed - Enabled:" << enable;
     }
 }
 #endif
@@ -203,7 +205,7 @@ void DdeGrandSearchDockPlugin::onVisibleChanged(bool visible)
 {
 #ifdef USE_DOCK_2_0
     if (!m_messageCallback) {
-        qWarning() << "Message callback function is nullptr";
+        qCWarning(logDock) << "Message callback function not initialized";
         return;
     }
 

--- a/src/grand-search/business/matchresult/matchcontroller.cpp
+++ b/src/grand-search/business/matchresult/matchcontroller.cpp
@@ -12,6 +12,10 @@
 
 #include "interfaces/daemongrandsearchinterface.h"
 
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logGrandSearch)
+
 using namespace GrandSearch;
 
 MatchControllerPrivate::MatchControllerPrivate(MatchController *parent)
@@ -23,6 +27,11 @@ MatchControllerPrivate::MatchControllerPrivate(MatchController *parent)
     m_firstItemLimit = SearchConfig::instance()->getConfig(GRANDSEARCH_CUSTOM_GROUP, GRANDSEARCH_CUSTOM_BESTMATCH_FIRSTITEMLIMIT, m_firstItemLimit).toInt();
     m_firstWaitTime = SearchConfig::instance()->getConfig(GRANDSEARCH_CUSTOM_GROUP, GRANDSEARCH_CUSTOM_BESTMATCH_FIRSTWAITTIME, m_firstWaitTime).toInt();
     m_bestItemMaxCount = SearchConfig::instance()->getConfig(GRANDSEARCH_CUSTOM_GROUP, GRANDSEARCH_CUSTOM_BESTMATCH_MAXCOUNT, m_bestItemMaxCount).toInt();
+
+    qCDebug(logGrandSearch) << "Match controller configuration - Best match:" << m_enableBestMatch
+                            << "First item limit:" << m_firstItemLimit
+                            << "First wait time:" << m_firstWaitTime
+                            << "Best item max count:" << m_bestItemMaxCount;
 
     initConnect();
 }
@@ -39,9 +48,10 @@ void MatchControllerPrivate::onMatched(const QString &missionId)
         return;
 
     // 获取数据解析
-    qDebug() << QString("m_daemonDbus->MatchedBuffer begin missionId:%1").arg(m_missionId);
+    qCDebug(logGrandSearch) << "Processing matched results for mission:" << missionId;
     QByteArray matchedBytes = m_daemonDbus->MatchedBuffer(m_missionId);
-    qDebug() << QString("m_daemonDbus->MatchedBuffer end   missionId:%1").arg(m_missionId);
+    qCDebug(logGrandSearch) << "Received matched buffer for mission:" << missionId
+                            << "Size:" << matchedBytes.size() << "bytes";
 
     QDataStream stream(&matchedBytes, QIODevice::ReadOnly);
 
@@ -56,10 +66,12 @@ void MatchControllerPrivate::onMatched(const QString &missionId)
         for (const MatchedItems &itemValues : items.values()) {
             count += itemValues.count();
         }
-        qDebug() << "first recive data count:" << count << "limit count:" << m_firstItemLimit;
+        qCDebug(logGrandSearch) << "First data reception - Items:" << count
+                                << "Limit:" << m_firstItemLimit;
 
         // 总数不够时，将数据放入到缓存中，并开启延迟定时器
         if (count < m_firstItemLimit) {
+            qCDebug(logGrandSearch) << "Insufficient items, caching data and starting wait timer";
             Utils::updateItemsWeight(items, m_missionContent);
             for (const QString &groupName : items.keys()) {
                 m_cacheItems[groupName].append(items.value(groupName));
@@ -69,6 +81,7 @@ void MatchControllerPrivate::onMatched(const QString &missionId)
 
             return;
         } else {
+            qCDebug(logGrandSearch) << "Processing initial items with best match:" << m_enableBestMatch;
             Utils::updateItemsWeight(items, m_missionContent);
             Utils::sortByWeight(items);
             if (m_enableBestMatch)
@@ -78,6 +91,7 @@ void MatchControllerPrivate::onMatched(const QString &missionId)
 
     if (m_waitTimer.get() && m_waitTimer->isActive()) {
         // 首次数据不够，正在缓存数据
+        qCDebug(logGrandSearch) << "Caching additional items while waiting";
         Utils::updateItemsWeight(items, m_missionContent);
         for (const QString &groupName : items.keys()) {
             m_cacheItems[groupName].append(items.value(groupName));
@@ -89,7 +103,7 @@ void MatchControllerPrivate::onMatched(const QString &missionId)
     // 非首次、非缓存数据，不使用动态排序策略，直接发送
     emit q_p->matchedResult(items);
 
-    qDebug() << QString("matched %1 groups.").arg(items.size());
+    qCDebug(logGrandSearch) << "Emitted matched results - Groups:" << items.size();
 }
 
 void MatchControllerPrivate::onSearchCompleted(const QString &missionId)
@@ -97,12 +111,11 @@ void MatchControllerPrivate::onSearchCompleted(const QString &missionId)
     if (missionId != m_missionId || m_missionId.isEmpty())
         return;
 
+    qCDebug(logGrandSearch) << "Search completed for mission:" << missionId;
     sendCacheItems();
 
-    //通知界面刷新，若界面有数据不做处理，否则就刷新
+    // 通知界面刷新，若界面有数据不做处理，否则就刷新
     emit q_p->searchCompleted();
-
-    qDebug() << QString("search Completed.");
 }
 
 void MatchControllerPrivate::sendCacheItems()
@@ -114,26 +127,26 @@ void MatchControllerPrivate::sendCacheItems()
     if (m_enableBestMatch)
         Utils::packageBestMatch(m_cacheItems, m_bestItemMaxCount);
     emit q_p->matchedResult(m_cacheItems);
-    qDebug() << QString("send cache items %1 groups.").arg(m_cacheItems.size());
+    qCDebug(logGrandSearch) << "Emitted cached results - Groups:" << m_cacheItems.size();
     m_cacheItems.clear();
 }
 
 MatchController::MatchController(QObject *parent)
-    : QObject(parent)
-    , d_p(new MatchControllerPrivate(this))
+    : QObject(parent), d_p(new MatchControllerPrivate(this))
 {
-
 }
 
 MatchController::~MatchController()
 {
-
 }
 
 void MatchController::onMissionChanged(const QString &missionId, const QString &missionContent)
 {
     if (Q_UNLIKELY(missionId == d_p->m_missionId))
         return;
+
+    qCDebug(logGrandSearch) << "Mission changed - ID:" << missionId
+                            << "Content:" << missionContent;
 
     d_p->m_missionId = missionId;
     d_p->m_missionContent = missionContent;
@@ -145,4 +158,3 @@ void MatchController::onMissionChanged(const QString &missionId, const QString &
     d_p->m_waitTimer.reset(new QTimer);
     d_p->m_waitTimer->setSingleShot(true);
 }
-

--- a/src/grand-search/contacts/services/grandsearchservice.cpp
+++ b/src/grand-search/contacts/services/grandsearchservice.cpp
@@ -7,26 +7,26 @@
 #include "gui/mainwindow.h"
 
 #include <QDebug>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logGrandSearch)
 
 using namespace GrandSearch;
 
 GrandSearchServicePrivate::GrandSearchServicePrivate(MainWindow *mainWindow, GrandSearchService *parent)
-    : q_p(parent)
-    , m_mainWindow(mainWindow)
+    : q_p(parent),
+      m_mainWindow(mainWindow)
 {
-
 }
 
 GrandSearchService::GrandSearchService(MainWindow *mainWindow, QObject *parent)
-    : QObject(parent)
-    , d_p(new GrandSearchServicePrivate(mainWindow, this))
+    : QObject(parent), d_p(new GrandSearchServicePrivate(mainWindow, this))
 {
     connect(d_p->m_mainWindow, &MainWindow::visibleChanged, this, &GrandSearchService::VisibleChanged);
 }
 
 GrandSearchService::~GrandSearchService()
 {
-
 }
 
 bool GrandSearchService::IsVisible() const
@@ -34,7 +34,7 @@ bool GrandSearchService::IsVisible() const
     Q_ASSERT(d_p->m_mainWindow);
 
     bool isvisble = d_p->m_mainWindow->isVisible();
-    qDebug() << "get by dbus and isvisible:" << isvisble;
+    qCDebug(logGrandSearch) << "Retrieved window visibility state:" << isvisble;
     return isvisble;
 }
 
@@ -43,12 +43,16 @@ void GrandSearchService::SetVisible(const bool visible)
     Q_ASSERT(d_p->m_mainWindow);
 
     // todo 二阶段：根据情况，可能需要设置为隐藏，而不能直接退出
-    if (d_p->m_mainWindow->isVisible() == visible)
+    if (d_p->m_mainWindow->isVisible() == visible) {
+        qCDebug(logGrandSearch) << "Window visibility unchanged:" << visible;
         return;
+    }
+
     if (!visible) {
-        qInfo() << "set visible is:" << visible <<",and exit it.";
+        qCInfo(logGrandSearch) << "Closing window as visibility set to:" << visible;
         d_p->m_mainWindow->close();
     } else {
+        qCDebug(logGrandSearch) << "Setting window visibility to:" << visible;
         d_p->m_mainWindow->setVisible(visible);
     }
 }

--- a/src/grand-search/gui/exhibition/matchresult/groupwidget.cpp
+++ b/src/grand-search/gui/exhibition/matchresult/groupwidget.cpp
@@ -25,26 +25,28 @@
 
 #include <QHBoxLayout>
 #include <QVBoxLayout>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logGrandSearch)
 
 using namespace GrandSearch;
 DWIDGET_USE_NAMESPACE
 
-#define ListItemHeight            36       // 列表行高
-#define GroupLabelHeight          28       // 组标签高度
-#define MoreBtnMaxHeight          25       // 查看更多按钮最大高度
-#define LayoutMagrinSize          10       // 布局边距
-#define SpacerWidth               40       // 弹簧宽度
-#define SpacerHeight              20       // 弹簧高度
+#define ListItemHeight 36   // 列表行高
+#define GroupLabelHeight 28   // 组标签高度
+#define MoreBtnMaxHeight 25   // 查看更多按钮最大高度
+#define LayoutMagrinSize 10   // 布局边距
+#define SpacerWidth 40   // 弹簧宽度
+#define SpacerHeight 20   // 弹簧高度
 
 GroupWidgetPrivate::GroupWidgetPrivate(GroupWidget *parent)
     : q_p(parent)
 {
-
 }
 
 GroupWidget::GroupWidget(QWidget *parent)
-    : DWidget(parent)
-    , d_p(new GroupWidgetPrivate(this))
+    : DWidget(parent),
+      d_p(new GroupWidgetPrivate(this))
 {
     m_firstFiveItems.clear();
     m_restShowItems.clear();
@@ -57,7 +59,6 @@ GroupWidget::GroupWidget(QWidget *parent)
 
 GroupWidget::~GroupWidget()
 {
-
 }
 
 void GroupWidget::setGroupName(const QString &groupName)
@@ -70,7 +71,7 @@ void GroupWidget::setGroupName(const QString &groupName)
     AC_SET_ACCESSIBLE_NAME(m_listView, groupName);
 }
 
-void GroupWidget::appendMatchedItems(const MatchedItems &newItems, const QString& searchGroupName)
+void GroupWidget::appendMatchedItems(const MatchedItems &newItems, const QString &searchGroupName)
 {
     Q_UNUSED(searchGroupName)
 
@@ -83,8 +84,8 @@ void GroupWidget::appendMatchedItems(const MatchedItems &newItems, const QString
         if (0 == m_listView->rowCount()) {
             const MatchedItem &item = newItems.first();
             if (!item.extra.isNull()
-                    && item.extra.type() == QVariant::Hash
-                    && item.extra.toHash().keys().contains(GRANDSEARCH_PROPERTY_ITEM_WEIGHT)) {
+                && item.extra.type() == QVariant::Hash
+                && item.extra.toHash().keys().contains(GRANDSEARCH_PROPERTY_ITEM_WEIGHT)) {
                 // 已经排序过，直接显示
                 m_cacheWeightItems << newItems;
                 updateShowItems(m_cacheWeightItems);
@@ -99,7 +100,7 @@ void GroupWidget::appendMatchedItems(const MatchedItems &newItems, const QString
         updateShowItems(m_cacheItems);
     } else {
         // 结果列表已展开，已经显示的数据保持不变，仅对新增数据排序，然后追加到列表末尾
-        MatchedItems& tempNewItems = const_cast<MatchedItems&>(newItems);
+        MatchedItems &tempNewItems = const_cast<MatchedItems &>(newItems);
         Utils::sortByWeight(tempNewItems);
         m_listView->addRows(tempNewItems);
     }
@@ -116,7 +117,7 @@ bool GroupWidget::isHorLineVisilbe()
 {
     Q_ASSERT(m_line);
 
-    return  m_line->isVisible();
+    return m_line->isVisible();
 }
 
 GrandSearchListView *GroupWidget::getListView()
@@ -223,10 +224,10 @@ QString GroupWidget::groupName() const
 void GroupWidget::setIcon(const QIcon &icon)
 {
     if (icon.isNull()) {
-       m_groupIcon->hide();
+        m_groupIcon->hide();
     } else {
-       m_groupIcon->setPixmap(icon.pixmap(QSize(18, 18)));
-       m_groupIcon->show();
+        m_groupIcon->setPixmap(icon.pixmap(QSize(18, 18)));
+        m_groupIcon->show();
     }
 }
 
@@ -253,7 +254,10 @@ void GroupWidget::showLabel(bool bShow)
         bool isUpdateIdx = IntelligentRetrievalWidget::isUpdateIndex();
         // 有无安装大模型
         bool hasModel = IntelligentRetrievalWidget::isQueryLangSupported();
-        qDebug() << QString("idxDir(%1) hasIdx(%2) isUpdateIdx(%3) hasModel(%4)").arg(idxDir).arg(hasIdx).arg(isUpdateIdx).arg(hasModel);
+        qCDebug(logGrandSearch) << "AI inference state - Index directory:" << idxDir
+                                << "Has index:" << hasIdx
+                                << "Auto-update enabled:" << isUpdateIdx
+                                << "Model available:" << hasModel;
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         const QColor &color = DPaletteHelper::instance()->palette(m_resultLabel).color(DPalette::Normal, DPalette::Highlight);
@@ -263,16 +267,16 @@ void GroupWidget::showLabel(bool bShow)
         if (!hasIdx && !isUpdateIdx && !hasModel) {
             // 请先前往搜索配置安装UOS AI大模型，并开启自动更新索引 Please go to Search configration to install the ULLM, and turn on Automatic index update.
             m_resultLabel->setText(tr("Please go to %1 to install the ULLM, and %2 Automatic index update.")
-                                   .arg(QString("<a href=\"config\" style=\"color:%1; text-decoration: none;\">%2</a>").arg(color.name()).arg(tr("Search configration")))
-                                   .arg(QString("<a href=\"update index\" style=\"color:%1; text-decoration: none;\">%2</a>").arg(color.name()).arg(tr("turn on"))));
+                                           .arg(QString("<a href=\"config\" style=\"color:%1; text-decoration: none;\">%2</a>").arg(color.name()).arg(tr("Search configration")))
+                                           .arg(QString("<a href=\"update index\" style=\"color:%1; text-decoration: none;\">%2</a>").arg(color.name()).arg(tr("turn on"))));
         } else if (!hasIdx && !isUpdateIdx) {
             // 请先开启自动更新索引 Please turn on Automatic index update.
             m_resultLabel->setText(tr("Please %1 Automatic index update.")
-                                   .arg(QString("<a href=\"update index\" style=\"color:%1; text-decoration: none;\">%2</a>").arg(color.name()).arg(tr("turn on"))));
+                                           .arg(QString("<a href=\"update index\" style=\"color:%1; text-decoration: none;\">%2</a>").arg(color.name()).arg(tr("turn on"))));
         } else if (!hasModel) {
             // 请先前往搜索配置安装UOS AI大模型 Please go to Search configration to install the UOS AI large model.
             m_resultLabel->setText(tr("Please go to %1 to install the ULLM.")
-                                   .arg(QString("<a href=\"config\" style=\"color:%1; text-decoration: none;\">%2</a>").arg(color.name()).arg(tr("Search configration"))));
+                                           .arg(QString("<a href=\"config\" style=\"color:%1; text-decoration: none;\">%2</a>").arg(color.name()).arg(tr("Search configration"))));
         } else {
             m_resultLabel->setText(tr("No search results"));
         }
@@ -281,18 +285,8 @@ void GroupWidget::showLabel(bool bShow)
 
 QString GroupWidget::convertDisplayName(const QString &searchGroupName)
 {
-    static const QHash<QString, QString> groupDisplayName{
-        {GRANDSEARCH_GROUP_BEST, GroupName_Best}
-        , {GRANDSEARCH_GROUP_APP, GroupName_App}
-        , {GRANDSEARCH_GROUP_SETTING, GroupName_Setting}
-        , {GRANDSEARCH_GROUP_FILE_VIDEO, GroupName_Video}
-        , {GRANDSEARCH_GROUP_FILE_AUDIO, GroupName_Audio}
-        , {GRANDSEARCH_GROUP_FILE_PICTURE, GroupName_Picture}
-        , {GRANDSEARCH_GROUP_FILE_DOCUMNET, GroupName_Document}
-        , {GRANDSEARCH_GROUP_FOLDER, GroupName_Folder}
-        , {GRANDSEARCH_GROUP_FILE, GroupName_File}
-        , {GRANDSEARCH_GROUP_WEB, GroupName_Web}
-        , {GRANDSEARCH_GROUP_FILE_INFERENCE, GroupName_Inference}
+    static const QHash<QString, QString> groupDisplayName {
+        { GRANDSEARCH_GROUP_BEST, GroupName_Best }, { GRANDSEARCH_GROUP_APP, GroupName_App }, { GRANDSEARCH_GROUP_SETTING, GroupName_Setting }, { GRANDSEARCH_GROUP_FILE_VIDEO, GroupName_Video }, { GRANDSEARCH_GROUP_FILE_AUDIO, GroupName_Audio }, { GRANDSEARCH_GROUP_FILE_PICTURE, GroupName_Picture }, { GRANDSEARCH_GROUP_FILE_DOCUMNET, GroupName_Document }, { GRANDSEARCH_GROUP_FOLDER, GroupName_Folder }, { GRANDSEARCH_GROUP_FILE, GroupName_File }, { GRANDSEARCH_GROUP_WEB, GroupName_Web }, { GRANDSEARCH_GROUP_FILE_INFERENCE, GroupName_Inference }
     };
 
     return groupDisplayName.value(searchGroupName, searchGroupName);
@@ -301,9 +295,9 @@ QString GroupWidget::convertDisplayName(const QString &searchGroupName)
 void GroupWidget::initUi()
 {
     // 获取设置当前窗口文本颜色
-    QColor groupTextColor = QColor(0, 0, 0, static_cast<int>(255*0.6));
+    QColor groupTextColor = QColor(0, 0, 0, static_cast<int>(255 * 0.6));
     if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType)
-        groupTextColor = QColor(255, 255, 255, static_cast<int>(255*0.6));
+        groupTextColor = QColor(255, 255, 255, static_cast<int>(255 * 0.6));
     QPalette labelPalette;
     labelPalette.setColor(QPalette::WindowText, groupTextColor);
 
@@ -322,7 +316,7 @@ void GroupWidget::initUi()
 
     // 组名图标
     m_groupIcon = new DLabel("", this);
-    m_groupIcon->setFixedSize(QSize(23, GroupLabelHeight)); // 18px of icon and 5px space
+    m_groupIcon->setFixedSize(QSize(23, GroupLabelHeight));   // 18px of icon and 5px space
     m_groupIcon->setAlignment(Qt::AlignVCenter | Qt::AlignLeft);
     m_groupLabel->setContentsMargins(0, 5, 5, 5);
     m_groupIcon->hide();
@@ -345,7 +339,7 @@ void GroupWidget::initUi()
 
     QWidget *spinnerContainer = new QWidget(this);
     {
-        spinnerContainer->setFixedSize(38, 18); //20px space on right.
+        spinnerContainer->setFixedSize(38, 18);   // 20px space on right.
         m_spinner = new DSpinner(spinnerContainer);
         m_spinner->setAttribute(Qt::WA_TransparentForMouseEvents);
         m_spinner->setFocusPolicy(Qt::NoFocus);
@@ -360,7 +354,7 @@ void GroupWidget::initUi()
     m_hTitelLayout->setSpacing(0);
     m_hTitelLayout->addWidget(m_groupIcon);
     m_hTitelLayout->addWidget(m_groupLabel);
-    m_hTitelLayout->addSpacerItem(new QSpacerItem(SpacerWidth,SpacerHeight,QSizePolicy::Expanding, QSizePolicy::Minimum));
+    m_hTitelLayout->addSpacerItem(new QSpacerItem(SpacerWidth, SpacerHeight, QSizePolicy::Expanding, QSizePolicy::Minimum));
     m_hTitelLayout->addWidget(m_viewMoreButton);
     m_hTitelLayout->addWidget(spinnerContainer);
 
@@ -373,8 +367,7 @@ void GroupWidget::initUi()
     DFontSizeManager::instance()->bind(m_resultLabel, DFontSizeManager::T8, QFont::Normal);
     // color
     {
-        QColor colorText = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType ?
-                    Qt::white : Qt::black;
+        QColor colorText = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType ? Qt::white : Qt::black;
         colorText.setAlphaF(0.5);
         auto pal = m_resultLabel->palette();
         pal.setColor(m_resultLabel->foregroundRole(), colorText);
@@ -464,9 +457,9 @@ void GroupWidget::onMoreBtnClicked()
     m_bListExpanded = true;
 }
 
-void GroupWidget::onOpenConfig(const QString& link)
+void GroupWidget::onOpenConfig(const QString &link)
 {
-    const QStringList args = {"-s", "--position", "aiconfig"};
+    const QStringList args = { "-s", "--position", "aiconfig" };
     if (link == "update index") {
         IntelligentRetrievalWidget::setAutoIndex(true);
         QProcess::startDetached("dde-grand-search", args);

--- a/src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp
+++ b/src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp
@@ -20,13 +20,17 @@
 #include <QDBusReply>
 #include <QVariantMap>
 #include <QtDBus>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logGrandSearch)
 
 DWIDGET_USE_NAMESPACE
 DGUI_USE_NAMESPACE
 DCORE_USE_NAMESPACE
 using namespace GrandSearch;
 
-bool AiToolBar::checkUosAiInstalled() {
+bool AiToolBar::checkUosAiInstalled()
+{
     QDBusInterface iface("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus");
     QDBusReply<QStringList> reply = iface.call("ListActivatableNames");
     if (reply.isValid())
@@ -35,7 +39,8 @@ bool AiToolBar::checkUosAiInstalled() {
     return false;
 }
 
-void AiToolBar::showWarningDialog(QString name) {
+void AiToolBar::showWarningDialog(QString name)
+{
     DDialog *warningDlg = new DDialog();
     warningDlg->setWindowFlags((warningDlg->windowFlags() | Qt::WindowType::WindowStaysOnTopHint));
     warningDlg->setFixedWidth(380);
@@ -54,38 +59,46 @@ void AiToolBar::showWarningDialog(QString name) {
     warningDlg->show();
 }
 
-AiToolBar::AiToolBar(QWidget *parent) : DWidget(parent) {
+AiToolBar::AiToolBar(QWidget *parent)
+    : DWidget(parent)
+{
     m_inner = new AiToolBarInner(this);
     this->initUi();
 }
 
-AiToolBar::~AiToolBar() {
+AiToolBar::~AiToolBar()
+{
     if (m_inner) {
         delete m_inner;
     }
 }
 
-void AiToolBar::initUi() {
+void AiToolBar::initUi()
+{
     this->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
     m_mainLayout = new QHBoxLayout(this);
-    m_left  = 10;
+    m_left = 10;
     m_right = 10;
     m_mainLayout->setContentsMargins(m_left, m_top, m_right, 0);
     m_mainLayout->addWidget(m_inner);
     this->setLayout(m_mainLayout);
 }
 
-void AiToolBar::setFilePath(QString filePath) {
+void AiToolBar::setFilePath(QString filePath)
+{
     m_inner->setFilePath(filePath);
 }
 
-AiToolBarInner::AiToolBarInner(QWidget *parent) : DWidget(parent) {
+AiToolBarInner::AiToolBarInner(QWidget *parent)
+    : DWidget(parent)
+{
     this->initUi();
     this->initConnect();
 }
 
-void AiToolBarInner::initUi() {
+void AiToolBarInner::initUi()
+{
     this->setFixedSize(360, 36);
 
     m_iconBt = new TransButton(this);
@@ -96,10 +109,10 @@ void AiToolBarInner::initUi() {
     m_omitBt = new OmitButton(this);
     m_omitBt->setIconSize(QSize(20, 20));
 
-    m_summaryBt     = new LinkButton(tr("Summary"), this);
+    m_summaryBt = new LinkButton(tr("Summary"), this);
     m_translationBt = new LinkButton(tr("Translation"), this);
-    m_extensionBt   = new LinkButton(tr("Extension"), this);
-    m_knowledgeBt   = new LinkButton(tr("Add to knowledge base"), this);
+    m_extensionBt = new LinkButton(tr("Extension"), this);
+    m_knowledgeBt = new LinkButton(tr("Add to knowledge base"), this);
     DFontSizeManager::instance()->bind(m_summaryBt, DFontSizeManager::T8, QFont::Normal);
     DFontSizeManager::instance()->bind(m_translationBt, DFontSizeManager::T8, QFont::Normal);
     DFontSizeManager::instance()->bind(m_extensionBt, DFontSizeManager::T8, QFont::Normal);
@@ -115,10 +128,10 @@ void AiToolBarInner::initUi() {
     m_extensionBt->setToolTip(tr("Extend document content with UOS AI"));
     m_knowledgeBt->setToolTip(tr("Add document to UOS AI knowledge base"));
 
-    m_summarySpace     = new DWidget(this);
+    m_summarySpace = new DWidget(this);
     m_translationSpace = new DWidget(this);
-    m_extensionSpace   = new DWidget(this);
-    m_knowledgeSpace   = new DWidget(this);
+    m_extensionSpace = new DWidget(this);
+    m_knowledgeSpace = new DWidget(this);
     m_translationSpace->setFixedWidth(1);
     m_extensionSpace->setFixedWidth(1);
     m_knowledgeSpace->setFixedWidth(1);
@@ -146,10 +159,10 @@ void AiToolBarInner::initUi() {
     this->setLayout(mainLayout);
 
     m_menu = new DMenu(this);
-    m_summaryAction     = new QAction(tr("Summary"));
+    m_summaryAction = new QAction(tr("Summary"));
     m_translationAction = new QAction(tr("Translation"));
-    m_extensionAction   = new QAction(tr("Extension"));
-    m_knowledgeAction   = new QAction(tr("Add to knowledge base"));
+    m_extensionAction = new QAction(tr("Extension"));
+    m_knowledgeAction = new QAction(tr("Add to knowledge base"));
     m_menu->addAction(m_summaryAction);
     m_menu->addAction(m_translationAction);
     m_menu->addAction(m_extensionAction);
@@ -161,7 +174,8 @@ void AiToolBarInner::initUi() {
     m_actionList.append(m_knowledgeAction);
 }
 
-void AiToolBarInner::initConnect() {
+void AiToolBarInner::initConnect()
+{
     connect(m_iconBt, &TransButton::clicked, this, &AiToolBarInner::onBtClicked);
     connect(m_omitBt, &OmitButton::clicked, this, &AiToolBarInner::onBtClicked);
     connect(m_summaryBt, &LinkButton::clicked, this, &AiToolBarInner::onBtClicked);
@@ -170,7 +184,8 @@ void AiToolBarInner::initConnect() {
     connect(m_knowledgeBt, &LinkButton::clicked, this, &AiToolBarInner::onBtClicked);
 }
 
-void AiToolBarInner::paintEvent(QPaintEvent *event) {
+void AiToolBarInner::paintEvent(QPaintEvent *event)
+{
     QPainter p(this);
     p.setPen(Qt::NoPen);
     p.setBrush(QColor(0, 0, 0, int(255 * 0.05)));
@@ -207,12 +222,14 @@ void AiToolBarInner::paintEvent(QPaintEvent *event) {
     return QWidget::paintEvent(event);
 }
 
-void AiToolBarInner::showEvent(QShowEvent *event) {
+void AiToolBarInner::showEvent(QShowEvent *event)
+{
     DWidget::showEvent(event);
     this->adjustBts();
 }
 
-void AiToolBarInner::onBtClicked() {
+void AiToolBarInner::onBtClicked()
+{
     if (sender() == m_iconBt) {
         this->onOpenUosAi();
         return;
@@ -245,7 +262,8 @@ void AiToolBarInner::onBtClicked() {
     }
 }
 
-void AiToolBarInner::onMenuTriggered(QAction *action) {
+void AiToolBarInner::onMenuTriggered(QAction *action)
+{
     if (action == m_summaryAction) {
         this->onSummary();
         return;
@@ -267,12 +285,14 @@ void AiToolBarInner::onMenuTriggered(QAction *action) {
     }
 }
 
-void AiToolBarInner::onOpenUosAi() {
+void AiToolBarInner::onOpenUosAi()
+{
     QDBusInterface notification("com.deepin.copilot", "/com/deepin/copilot", "com.deepin.copilot", QDBusConnection::sessionBus());
     notification.call(QDBus::Block, "launchChatPage");
 }
 
-void AiToolBarInner::onSummary() {
+void AiToolBarInner::onSummary()
+{
     qDBusRegisterMetaType<QMap<QString, QString>>();
     QMap<QString, QString> params;
     params.insert("file", m_filePath);
@@ -280,14 +300,15 @@ void AiToolBarInner::onSummary() {
     QDBusInterface notification("com.deepin.copilot", "/org/deepin/copilot/chat", "org.deepin.copilot.chat", QDBusConnection::sessionBus());
     QString error = notification.call(QDBus::Block, "inputPrompt", "", QVariant::fromValue(params)).errorMessage();
     if (!error.isEmpty()) {
-        qWarning() << QString("inputPrompt ERROR(%1)").arg(error);
+        qCWarning(logGrandSearch) << "Failed to send prompt to UOS AI - Operation:" << m_summaryAction->text() << "Error:" << error;
         this->showWarningDialog(m_summaryAction->text());
     } else {
         this->closeMainWindow();
     }
 }
 
-void AiToolBarInner::onTranslation() {
+void AiToolBarInner::onTranslation()
+{
     qDBusRegisterMetaType<QMap<QString, QString>>();
     QMap<QString, QString> params;
     params.insert("file", m_filePath);
@@ -295,14 +316,15 @@ void AiToolBarInner::onTranslation() {
     QDBusInterface notification("com.deepin.copilot", "/org/deepin/copilot/chat", "org.deepin.copilot.chat", QDBusConnection::sessionBus());
     QString error = notification.call(QDBus::Block, "inputPrompt", "", QVariant::fromValue(params)).errorMessage();
     if (!error.isEmpty()) {
-        qWarning() << QString("inputPrompt ERROR(%1)").arg(error);
+        qCWarning(logGrandSearch) << "Failed to send prompt to UOS AI - Operation:" << m_translationAction->text() << "Error:" << error;
         this->showWarningDialog(m_translationAction->text());
     } else {
         this->closeMainWindow();
     }
 }
 
-void AiToolBarInner::onExtension() {
+void AiToolBarInner::onExtension()
+{
     qDBusRegisterMetaType<QMap<QString, QString>>();
     QMap<QString, QString> params;
     params.insert("file", m_filePath);
@@ -310,26 +332,28 @@ void AiToolBarInner::onExtension() {
     QDBusInterface notification("com.deepin.copilot", "/org/deepin/copilot/chat", "org.deepin.copilot.chat", QDBusConnection::sessionBus());
     QString error = notification.call(QDBus::Block, "inputPrompt", "", QVariant::fromValue(params)).errorMessage();
     if (!error.isEmpty()) {
-        qWarning() << QString("inputPrompt ERROR(%1)").arg(error);
+        qCWarning(logGrandSearch) << "Failed to send prompt to UOS AI - Operation:" << m_extensionAction->text() << "Error:" << error;
         this->showWarningDialog(m_extensionAction->text());
     } else {
         this->closeMainWindow();
     }
 }
 
-void AiToolBarInner::onKnowledge() {
+void AiToolBarInner::onKnowledge()
+{
     QDBusInterface notification("com.deepin.copilot", "/org/deepin/copilot/chat", "org.deepin.copilot.chat", QDBusConnection::sessionBus());
     QString error = notification.call(QDBus::Block, "sendToKnowledgeBase", QStringList(m_filePath)).errorMessage();
     if (!error.isEmpty()) {
-        qWarning() << QString("sendToKnowledgeBase ERROR(%1)").arg(error);
+        qCWarning(logGrandSearch) << "Failed to add file to knowledge base - File:" << m_filePath << "Error:" << error;
         this->showWarningDialog(m_knowledgeAction->text());
     } else {
         this->closeMainWindow();
     }
 }
 
-void AiToolBarInner::adjustBts() {
-    const int MAX_WIDTH  = this->width() - 15 - 10 - m_iconBt->sizeHint().width() - 4;
+void AiToolBarInner::adjustBts()
+{
+    const int MAX_WIDTH = this->width() - 15 - 10 - m_iconBt->sizeHint().width() - 4;
     const int MAX_WIDTH1 = this->width() - 15 - 10 - m_iconBt->sizeHint().width() - 4 - m_omitBt->sizeHint().width();
 
     m_knowledgeBt->setText(m_knowledgeAction->text());
@@ -359,7 +383,7 @@ void AiToolBarInner::adjustBts() {
     m_omitBt->setVisible(true);
     // 1、确定哪些显示在工具栏，哪些放入菜单
     int actionCounts = 0;
-    for (int i = m_btList.size() - 1; i >= 0; i++) {
+    for (int i = m_btList.size() - 1; i >= 0; i--) {
         sumWidth -= m_btList[i]->sizeHint().width() + 4;
         sumWidth -= 5;
         m_btList[i]->setVisible(false);
@@ -412,12 +436,13 @@ void AiToolBarInner::adjustBts() {
 #endif
 }
 
-void AiToolBarInner::showWarningDialog(QString name) {
+void AiToolBarInner::showWarningDialog(QString name)
+{
     QString tmpPath = QString("/tmp/%1_notify.png").arg(DApplication::instance()->applicationName());
     QIcon tmpIcon(":icons/dde-grand-search-setting.svg");
     QPixmap tmpPixmap = tmpIcon.pixmap(QSize(32, 32));
     bool isSaved = tmpPixmap.save(tmpPath);
-    qDebug() << "isSaved:" << isSaved << "path:" << tmpPath;
+    qCDebug(logGrandSearch) << "Notification icon saved - Success:" << isSaved << "Path:" << tmpPath;
 
     DUtil::DNotifySender notify(tr("DDE Grand Search"));
     notify.appName(DApplication::instance()->applicationName());
@@ -425,13 +450,14 @@ void AiToolBarInner::showWarningDialog(QString name) {
     notify.appBody(QString(tr("Unable to use %1, please go to the App Store to update the UOS AI version first.").arg(name)));
     notify.actions(QStringList() << "_open" << tr("Open App Stroe"));
     QVariantMap hints;
-    hints["x-deepin-action-_open"] = QString("dbus-send,--print-reply,--dest=com.home.appstore.client,/com/home/appstore/client,com.home.appstore.client.openBusinessUri,string:app_detail_info/uos-ai"); // 通过命令定位到应用商店uos-ai页
+    hints["x-deepin-action-_open"] = QString("dbus-send,--print-reply,--dest=com.home.appstore.client,/com/home/appstore/client,com.home.appstore.client.openBusinessUri,string:app_detail_info/uos-ai");   // 通过命令定位到应用商店uos-ai页
     notify.hints(hints);
     notify.timeOut(3000);
     notify.call();
 }
 
-void AiToolBarInner::closeMainWindow() {
+void AiToolBarInner::closeMainWindow()
+{
     if (this->parent()->parent() && this->parent()->parent()->parent()) {
         ExhibitionWidget *ptr = dynamic_cast<ExhibitionWidget *>(this->parent()->parent()->parent());
         if (ptr) {

--- a/src/grand-search/gui/exhibition/preview/pluginproxy.cpp
+++ b/src/grand-search/gui/exhibition/preview/pluginproxy.cpp
@@ -6,6 +6,9 @@
 #include "generalwidget/detailwidget.h"
 
 #include <QDebug>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logGrandSearch)
 
 using namespace GrandSearch;
 
@@ -19,12 +22,12 @@ PluginProxy::PluginProxy(PreviewWidget *parent)
 void PluginProxy::updateDetailInfo(PreviewPlugin *plugin)
 {
     if (plugin == nullptr || plugin != q->m_preview) {
-        qWarning() << "updateDetailInfo: invaild plugin.";
+        qCWarning(logGrandSearch) << "Invalid plugin provided to updateDetailInfo - Plugin is null or not the current preview plugin";
         return;
     }
 
     if (thread() != qApp->thread()) {
-        qWarning() << __FUNCTION__ << "could not be called in other thread.";
+        qCWarning(logGrandSearch) << "Thread violation - updateDetailInfo must be called from the main thread";
         return;
     }
 

--- a/src/grand-search/gui/exhibition/preview/previewpluginmanager.cpp
+++ b/src/grand-search/gui/exhibition/preview/previewpluginmanager.cpp
@@ -8,10 +8,14 @@
 #include "utils/previewpluginconf.h"
 #include "utils/utils.h"
 
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logGrandSearch)
+
 using namespace GrandSearch;
 
 PreviewPluginManager::PreviewPluginManager()
-    : QObject ()
+    : QObject()
 {
     readPluginConfig();
 }
@@ -23,7 +27,7 @@ PreviewPluginManager::~PreviewPluginManager()
 
 PreviewPlugin *PreviewPluginManager::getPreviewPlugin(const MatchedItem &item)
 {
-    PreviewPlugin* previewPlugin = nullptr;
+    PreviewPlugin *previewPlugin = nullptr;
 
     QString mimeType = item.type;
     if (mimeType.isEmpty())
@@ -34,13 +38,13 @@ PreviewPlugin *PreviewPluginManager::getPreviewPlugin(const MatchedItem &item)
             if (!pluginInfo.bValid)
                 continue;
 
-            //需支持正则表达式 todo
+            // 需支持正则表达式 todo
             if (isMimeTypeMatch(mimeType, pluginInfo.mimeTypes)) {
                 if (nullptr == pluginInfo.pPlugin) {
                     // 加载预览插件
                     QPluginLoader *loader = new QPluginLoader(pluginInfo.path, this);
                     if (!loader->load()) {
-                        qWarning() << QString("load %0 error: %1").arg(pluginInfo.path).arg(loader->errorString());
+                        qCWarning(logGrandSearch) << "Failed to load preview plugin - Path:" << pluginInfo.path << "Error:" << loader->errorString();
                         loader->deleteLater();
                         continue;
                     }
@@ -50,7 +54,7 @@ PreviewPlugin *PreviewPluginManager::getPreviewPlugin(const MatchedItem &item)
 
                 // 从预览插件创建或获取预览界面
                 QObject *pluginObject = pluginInfo.pPlugin->instance();
-                if (PreviewPluginInterface *pluginIFace = qobject_cast<PreviewPluginInterface*>(pluginObject))
+                if (PreviewPluginInterface *pluginIFace = qobject_cast<PreviewPluginInterface *>(pluginObject))
                     previewPlugin = pluginIFace->create(mimeType);
                 break;
             }
@@ -94,7 +98,7 @@ bool PreviewPluginManager::readPluginConfig()
 {
     // 获取预览插件路径
 #ifdef QT_DEBUG
-    char path[PATH_MAX] = {0};
+    char path[PATH_MAX] = { 0 };
     const char *defaultPath = realpath("./", path);
 #else
     auto defaultPath = PLUGIN_PREVIEW_DIR;
@@ -102,7 +106,7 @@ bool PreviewPluginManager::readPluginConfig()
     static_assert(std::is_same<decltype(defaultPath), const char *>::value, "PLUGIN_PREVIEW_DIR is not a string.");
 
     // 设置预览插件路径
-    setPluginPath({QString(defaultPath)});
+    setPluginPath({ QString(defaultPath) });
 
     // 从预览插件路径加载预览插件信息
     return loadConfig();
@@ -118,20 +122,22 @@ bool PreviewPluginManager::loadConfig()
         if (!dir.isReadable())
             continue;
 
-        auto entrys = dir.entryInfoList({"*.conf"}, QDir::Files, QDir::Name);
+        auto entrys = dir.entryInfoList({ "*.conf" }, QDir::Files, QDir::Name);
         for (const QFileInfo &entry : entrys) {
             PreviewPluginInfo info;
             if (readInfo(entry.absoluteFilePath(), info)) {
                 // 检查插件版本是否向下兼容
                 if (!downwardCompatibility(info.version)) {
-                    qWarning() << QString("do not support this version(%1), plugin name:%2 plugin version:%3").arg(m_mainVersion).arg(info.name).arg(info.version);
+                    qCWarning(logGrandSearch) << "Plugin version not supported - Version:" << info.version
+                                              << "Plugin:" << info.name
+                                              << "Required version:" << m_mainVersion;
                     continue;
                 }
 
-                qInfo() << "add plugin info" << entry.fileName() << info.name;
+                qCInfo(logGrandSearch) << "Plugin loaded successfully - File:" << entry.fileName() << "Name:" << info.name;
                 m_plugins.push_back(info);
             } else {
-                qWarning() << "plugin info error:" << entry.absoluteFilePath();
+                qCWarning(logGrandSearch) << "Failed to read plugin configuration - Path:" << entry.absoluteFilePath();
             }
         }
     }
@@ -141,7 +147,7 @@ bool PreviewPluginManager::loadConfig()
 
 bool PreviewPluginManager::readInfo(const QString &path, PreviewPluginInfo &info)
 {
-    qDebug() << "load conf" << path;
+    qCDebug(logGrandSearch) << "Loading plugin configuration - Path:" << path;
     QSettings conf(path, QSettings::IniFormat);
 
     if (!conf.childGroups().contains(PREVIEW_PLUGINIFACE_CONF_ROOT))
@@ -154,7 +160,7 @@ bool PreviewPluginManager::readInfo(const QString &path, PreviewPluginInfo &info
     if (info.name.isEmpty())
         return false;
     if (getPreviewPlugin(info.name)) {
-        qWarning() << "duplicate plugin name" << path << info.name;
+        qCWarning(logGrandSearch) << "Duplicate plugin name found - Path:" << path << "Name:" << info.name;
         return false;
     }
 
@@ -163,7 +169,7 @@ bool PreviewPluginManager::readInfo(const QString &path, PreviewPluginInfo &info
     if (info.version.isEmpty())
         return false;
 
-    // 支持预览的mimetype列表
+        // 支持预览的mimetype列表
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     info.mimeTypes = conf.value(PREVIEW_PLUGINIFACE_CONF_MIMETYPES, "").toString().split(':', QString::SkipEmptyParts);
 #else
@@ -189,8 +195,8 @@ PreviewPluginInfo *PreviewPluginManager::getPreviewPlugin(const QString &name)
 
     int nPluginCount = m_plugins.count();
     for (int i = 0; i < nPluginCount; i++) {
-      if(m_plugins[i].name == name)
-          return &m_plugins[i];
+        if (m_plugins[i].name == name)
+            return &m_plugins[i];
     }
 
     return nullptr;
@@ -202,14 +208,14 @@ void PreviewPluginManager::setPluginPath(const QStringList &dirPaths)
     for (const QString &path : dirPaths) {
         QDir dir(path);
         if (dir.isReadable()) {
-            qDebug() << "add plugin path:" << path;
+            qCDebug(logGrandSearch) << "Adding plugin path - Path:" << path;
             paths << path;
+        } else {
+            qCWarning(logGrandSearch) << "Invalid plugin path - Path:" << path;
         }
-        else
-            qWarning() << "invaild plugin path:" << path;
     }
 
-    qDebug() << "update plugin paths" << paths.size();
+    qCDebug(logGrandSearch) << "Updated plugin paths - Total paths:" << paths.size();
     m_paths = paths;
 }
 

--- a/src/grand-search/gui/handlevisibility/handlevisibility.cpp
+++ b/src/grand-search/gui/handlevisibility/handlevisibility.cpp
@@ -9,6 +9,9 @@
 
 #include <QtDebug>
 #include <QTimer>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logGrandSearch)
 
 #define SessionManagerService "org.deepin.dde.SessionManager1"
 #define SessionManagerPath "/org/deepin/dde/SessionManager1"
@@ -17,9 +20,9 @@ using namespace GrandSearch;
 DWIDGET_USE_NAMESPACE
 
 HandleVisibility::HandleVisibility(MainWindow *mainWindow, QObject *parent)
-    : QObject(parent)
-    , m_mainWindow(mainWindow)
-    // , m_sessionManagerInter(new com::deepin::SessionManager(SessionManagerService, SessionManagerPath, QDBusConnection::sessionBus(), this))
+    : QObject(parent),
+      m_mainWindow(mainWindow)
+// , m_sessionManagerInter(new com::deepin::SessionManager(SessionManagerService, SessionManagerPath, QDBusConnection::sessionBus(), this))
 {
     init();
 }
@@ -46,10 +49,10 @@ void HandleVisibility::onApplicationStateChanged(const Qt::ApplicationState stat
 
     if (Qt::ApplicationInactive == state) {
         // todo 二阶段：截图导致本进程窗口变为非激活，不退出。截图退出后，主动激活本进程主窗口。
-        qDebug() << "application state change to inactive,so i will exit.";
+        qCInfo(logGrandSearch) << "Application state changed to inactive - Closing main window";
         m_mainWindow->close();
     } else if (Qt::ApplicationActive == state) {
-        qDebug() << "application state change to active.";
+        qCDebug(logGrandSearch) << "Application state changed to active - Showing main window";
         m_mainWindow->show();
     }
 }
@@ -93,7 +96,9 @@ void HandleVisibility::regionMousePress(const QPoint &p, const int flag)
         }
     }
     // 点击位置在程序窗口之外则退出
-    qDebug() << "click:" << p << "   flag:" << flag << "    and exit.";
+    qCInfo(logGrandSearch) << "Mouse click outside application window - Position:" << p
+                           << "Flag:" << flag
+                           << "Scheduling window close";
     // todo ：后期根据情况，可能需要设置为隐藏，而不能直接退出
     // 延迟退出，便于dock插件响应时能正确获取当前状态
     QTimer::singleShot(500, this, &HandleVisibility::onCloseWindow);

--- a/src/grand-search/gui/mainwindow.cpp
+++ b/src/grand-search/gui/mainwindow.cpp
@@ -22,6 +22,9 @@
 #include <QVBoxLayout>
 #include <QScreen>
 #include <QKeyEvent>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logGrandSearch)
 
 DWIDGET_USE_NAMESPACE
 using namespace GrandSearch;
@@ -187,7 +190,8 @@ void MainWindow::initUI()
         // 在Qt5.11版本、x11环境下，同时设置BypassWindowManagerHint与Tool属性之后，键盘切换大小写将会导致程序的激活状态发生改变。
         setWindowFlags(Qt::BypassWindowManagerHint | Qt::WindowStaysOnTopHint);
     }
-    qDebug() << "current platform name:" << QApplication::platformName() << "   flags:" << this->windowFlags();
+    qCInfo(logGrandSearch) << "Initializing main window - Platform:" << QApplication::platformName() 
+                          << "Window flags:" << this->windowFlags();
 
     // 控制界面大小和位置
     setFixedSize(MainWindowWidth, MainWindowHeight);

--- a/src/grand-search/gui/searchconfig/blacklistwidget.cpp
+++ b/src/grand-search/gui/searchconfig/blacklistwidget.cpp
@@ -16,13 +16,16 @@
 #include <QFileDialog>
 #include <QStandardPaths>
 #include <QItemSelection>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logGrandSearch)
 
 DWIDGET_USE_NAMESPACE
 
 using namespace GrandSearch;
 
 BlackListWidget::BlackListWidget(QWidget *parent)
-    :DWidget(parent)
+    : DWidget(parent)
 {
     m_groupLabel = new QLabel(tr("Excluded path"), this);
     m_groupLabel->adjustSize();
@@ -65,20 +68,20 @@ BlackListWidget::BlackListWidget(QWidget *parent)
 
 BlackListWidget::~BlackListWidget()
 {
-
 }
 
 void BlackListWidget::addButtonClicked()
 {
     QFileDialog fileDialog;
-    auto url = fileDialog.getExistingDirectoryUrl(this, QString("")
-                                                  , QStandardPaths::standardLocations(QStandardPaths::HomeLocation).first());
+    auto url = fileDialog.getExistingDirectoryUrl(this, QString(""), QStandardPaths::standardLocations(QStandardPaths::HomeLocation).first());
     QFileInfo info(url.toLocalFile());
     m_listWrapper->clearSelection();
     if (!url.isEmpty() && !info.isSymLink() && info.exists()) {
         m_listWrapper->addRow(info.absoluteFilePath());
     } else {
-        qInfo() << "add path failed";
+        qCWarning(logGrandSearch) << "Failed to add path to blacklist - Path:" << url.toLocalFile()
+                                  << "Is symlink:" << info.isSymLink()
+                                  << "Exists:" << info.exists();
     }
 }
 

--- a/src/grand-search/gui/searchconfig/llmwidget/embeddingpluginwidget.cpp
+++ b/src/grand-search/gui/searchconfig/llmwidget/embeddingpluginwidget.cpp
@@ -4,22 +4,26 @@
 
 #include "embeddingpluginwidget.h"
 
+#include <DFontSizeManager>
+#include <DGuiApplicationHelper>
+
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QProcess>
 #include <QDBusConnection>
 #include <QDBusMessage>
 #include <QDBusPendingCall>
+#include <QLoggingCategory>
 
-#include <DFontSizeManager>
-#include <DGuiApplicationHelper>
+Q_DECLARE_LOGGING_CATEGORY(logGrandSearch)
 
 DWIDGET_USE_NAMESPACE
 using namespace GrandSearch;
 
 static constexpr char PLUGINSNAME[] = "uos-ai-rag";
 
-EmbeddingPluginWidget::EmbeddingPluginWidget(QWidget *parent) : DWidget(parent)
+EmbeddingPluginWidget::EmbeddingPluginWidget(QWidget *parent)
+    : DWidget(parent)
 {
     initUI();
 }
@@ -122,7 +126,7 @@ void EmbeddingPluginWidget::initUI()
 
 void EmbeddingPluginWidget::openAppStore()
 {
-    qInfo() << "open app store" << PLUGINSNAME;
+    qCInfo(logGrandSearch) << "Opening application store for plugin installation - Plugin:" << PLUGINSNAME;
     QDBusMessage msg = QDBusMessage::createMethodCall("com.home.appstore.client", "/com/home/appstore/client",
                                                       "com.home.appstore.client", "openBusinessUri");
     QVariantList list;

--- a/src/grand-search/main.cpp
+++ b/src/grand-search/main.cpp
@@ -4,6 +4,7 @@
 
 #include "environments.h"
 #include "global/grandsearch_global.h"
+#include "global/framelogmanager.h"
 
 #include "gui/mainwindow.h"
 #include "gui/searchconfig/configwidget.h"
@@ -25,6 +26,8 @@
 
 #include <unistd.h>
 
+Q_LOGGING_CATEGORY(logGrandSearch, "org.deepin.dde.GrandSearch.GrandSearch")
+
 GRANDSEARCH_USE_NAMESPACE
 DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
@@ -44,10 +47,7 @@ int main(int argc, char *argv[])
 #endif
 
     // 设置终端和文件记录日志
-    const QString logFormat = "%{time}{yyyyMMdd.HH:mm:ss.zzz}[%{type:1}][%{function:-35} %{line:-4} %{threadid} ] %{message}\n";
-    DLogManager::setLogFormat(logFormat);
-    DLogManager::registerConsoleAppender();
-    DLogManager::registerFileAppender();
+    dgsLogManager->applySuggestedLogSettings();
 
     QCommandLineParser parser;
 
@@ -55,7 +55,7 @@ int main(int argc, char *argv[])
     QString position;
 
     if (argc > 1) {
-        QCommandLineOption option_setting({"s", "setting"}, "Start grand search config.");
+        QCommandLineOption option_setting({ "s", "setting" }, "Start grand search config.");
         QCommandLineOption option_position("position", "Start grand search config, and scroll to one position.", "value");
 
         parser.addOption(option_setting);
@@ -64,24 +64,28 @@ int main(int argc, char *argv[])
 
         parser.process(app);
         isSetting = parser.isSet(option_setting);
-        position  = parser.value(option_position);
+        position = parser.value(option_position);
     }
     // 根据要求，通过启动参数决定显示界面
-    if (isSetting) { // 设置界面
+    if (isSetting) {   // 设置界面
         // 设置单例运行程序
         if (!app.setSingleInstance("dde-grand-search-config")) {
-            qWarning() << "set single instance failed!I (pid:" << getpid() << ") will exit.";
+            qCWarning(logGrandSearch) << "Failed to set single instance mode - PID:" << getpid()
+                                      << "Application will exit";
             return -1;
         }
 
         // 加载翻译
         app.loadTranslator();
 
-        qDebug() << "starting config:" << app.applicationName() << app.applicationVersion() << getpid();
+        qCInfo(logGrandSearch) << "Starting configuration interface - Application:" << app.applicationName()
+                               << "Version:" << app.applicationVersion()
+                               << "PID:" << getpid();
 
         ConfigWidget w;
         w.show();
         if (position == "aiconfig") {
+            qCDebug(logGrandSearch) << "Scrolling to AI configuration section";
             w.scrollToAiConfig();
         }
         Dtk::Widget::moveToCenter(&w);
@@ -90,17 +94,20 @@ int main(int argc, char *argv[])
         QObject::connect(&app, &DApplication::newInstanceStarted, &w, &ConfigWidget::activateWindow);
 
         return app.exec();
-    } else {    // 搜索界面
+    } else {   // 搜索界面
         // 设置单例运行程序
         if (!app.setSingleInstance("dde-grand-search")) {
-            qWarning() << "set single instance failed!I (pid:" << getpid() << ") will exit.";
+            qCWarning(logGrandSearch) << "Failed to set single instance mode - PID:" << getpid()
+                                      << "Application will exit";
             return -1;
         }
 
         // 加载翻译
         app.loadTranslator();
 
-        qDebug() << "starting search:" << app.applicationName() << app.applicationVersion() << getpid();
+        qCInfo(logGrandSearch) << "Starting search interface - Application:" << app.applicationName()
+                               << "Version:" << app.applicationVersion()
+                               << "PID:" << getpid();
 
         // 解析点选数据
         AccessRecord::instance()->startParseRecord();
@@ -109,7 +116,7 @@ int main(int argc, char *argv[])
         MainWindow mainWindow;
         mainWindow.show();
 
-        QTimer::singleShot(0, &mainWindow, [&mainWindow](){
+        QTimer::singleShot(0, &mainWindow, [&mainWindow]() {
             // 界面初始化完成后，再处理与业务有关的连接
             mainWindow.connectToController();
         });
@@ -117,21 +124,24 @@ int main(int argc, char *argv[])
         // 注册dbus服务
         QDBusConnection conn = QDBusConnection::sessionBus();
         if (!conn.isConnected()) {
-            qWarning() << "QDBusConnection is not connect.";
+            qCCritical(logGrandSearch) << "Failed to connect to D-Bus session bus";
             return -1;
         }
 
         GrandSearchService service(&mainWindow);
         Q_UNUSED(new GrandSearchServiceAdaptor(&service))
         if (!conn.registerService(GrandSearchViewServiceName)) {
-            qWarning() << "registerService Failed:" << conn.lastError();
+            qCCritical(logGrandSearch) << "Failed to register D-Bus service:" << conn.lastError().message();
             return -1;
         }
 
         if (!conn.registerObject(GrandSearchViewServicePath, &service)) {
-            qWarning() << "registerObject Failed:" << conn.lastError();
+            qCCritical(logGrandSearch) << "Failed to register D-Bus object:" << conn.lastError().message();
             return -1;
         }
+
+        qCInfo(logGrandSearch) << "D-Bus service registered successfully - Service:" << GrandSearchViewServiceName
+                               << "Path:" << GrandSearchViewServicePath;
 
         return app.exec();
     }

--- a/src/grand-search/utils/filestatisticsthread.cpp
+++ b/src/grand-search/utils/filestatisticsthread.cpp
@@ -9,6 +9,9 @@
 #include <QFileInfo>
 #include <QDirIterator>
 #include <QTimer>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logGrandSearch)
 
 using namespace GrandSearch;
 
@@ -33,7 +36,7 @@ FileStatisticsThread::~FileStatisticsThread()
 void FileStatisticsThread::start(const QString &sourceFile)
 {
     if (isRunning()) {
-        qWarning() << "current thread is running.";
+        qCWarning(logGrandSearch) << "File statistics thread is already running - Source:" << m_sourceFile;
         return;
     }
 

--- a/src/grand-search/utils/report/committhread.cpp
+++ b/src/grand-search/utils/report/committhread.cpp
@@ -2,6 +2,9 @@
 
 #include <QLibrary>
 #include <QDebug>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logGrandSearch)
 
 using namespace GrandSearch;
 using namespace report;
@@ -20,7 +23,7 @@ void CommitLog::commit(const QString &data)
     if (data.isEmpty())
         return;
 
-    //qDebug() << data.toStdString().c_str();
+    // qCDebug(logGrandSearch) << "Committing event log data - Size:" << data.length();
     m_writeEventLog(data.toStdString());
 }
 
@@ -28,7 +31,7 @@ bool CommitLog::init()
 {
     QLibrary library("deepin-event-log");
     if (!library.load()) {
-        qWarning() << "Load library failed";
+        qCWarning(logGrandSearch) << "Failed to load deepin-event-log library - Error:" << library.errorString();
         return false;
     }
 
@@ -36,12 +39,13 @@ bool CommitLog::init()
     m_writeEventLog = reinterpret_cast<WriteEventLog>(library.resolve("WriteEventLog"));
 
     if (!m_initEventLog || !m_writeEventLog) {
-        qWarning() << "Library init failed";
+        qCWarning(logGrandSearch) << "Failed to resolve library functions - Initialize:" << (m_initEventLog ? "OK" : "Failed")
+                                  << "WriteEventLog:" << (m_writeEventLog ? "OK" : "Failed");
         return false;
     }
 
     if (!m_initEventLog("uos-ai", false)) {
-        qWarning() << "Initialize called failed";
+        qCWarning(logGrandSearch) << "Failed to initialize event log system - Application:uos-ai";
         return false;
     }
 

--- a/src/preview-plugin/audio-preview/audiofileinfo.cpp
+++ b/src/preview-plugin/audio-preview/audiofileinfo.cpp
@@ -9,6 +9,7 @@
 #include <QDebug>
 #include <QTextCodec>
 #include <QLocale>
+#include <QLoggingCategory>
 
 #include <unicode/ucnv.h>
 #include <unicode/ucsdet.h>
@@ -17,6 +18,7 @@
 #include <taglib.h>
 #include <tpropertymap.h>
 
+Q_DECLARE_LOGGING_CATEGORY(logAudioPreview)
 GRANDSEARCH_USE_NAMESPACE
 using namespace GrandSearch::audio_preview;
 
@@ -29,13 +31,13 @@ AudioFileInfo::AudioMetaData AudioFileInfo::openAudioFile(const QString &file)
 {
     TagLib::FileRef f(file.toLocal8Bit());
     if (!f.file()) {
-        qWarning() << "TagLib: open file failed:" << file;
+        qCWarning(logAudioPreview) << "Failed to open audio file - Path:" << file;
         return {};
     }
 
     TagLib::Tag *tag = f.tag();
     if (!tag) {
-        qWarning() << "TagLib: no tag for media file" << file;
+        qCWarning(logAudioPreview) << "No metadata tags found in audio file - Path:" << file;
         return {};
     }
 

--- a/src/preview-plugin/audio-preview/audiopreviewplugin.cpp
+++ b/src/preview-plugin/audio-preview/audiopreviewplugin.cpp
@@ -11,6 +11,7 @@
 #include <QFileInfo>
 #include <QRect>
 #include <QDateTime>
+#include <QLoggingCategory>
 
 extern "C"
 {
@@ -18,6 +19,7 @@ extern "C"
 #include <libavformat/avformat.h>
 }
 
+Q_LOGGING_CATEGORY(logAudioPreview, "org.deepin.dde.grandsearch.plugin.audio")
 GRANDSEARCH_USE_NAMESPACE
 using namespace GrandSearch::audio_preview;
 

--- a/src/preview-plugin/pdf-preview/pdfpreviewplugin.cpp
+++ b/src/preview-plugin/pdf-preview/pdfpreviewplugin.cpp
@@ -7,7 +7,9 @@
 #include "pdfview.h"
 
 #include <QFileInfo>
+#include <QLoggingCategory>
 
+Q_LOGGING_CATEGORY(logPdfPreview, "org.deepin.dde.grandsearch.plugin.pdf")
 GRANDSEARCH_USE_NAMESPACE
 using namespace GrandSearch::pdf_preview;
 

--- a/src/preview-plugin/pdf-preview/pdfview.cpp
+++ b/src/preview-plugin/pdf-preview/pdfview.cpp
@@ -19,6 +19,9 @@
 #include <QScreen>
 #include <QDBusInterface>
 #include <QDBusReply>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logPdfPreview)
 
 GRANDSEARCH_USE_NAMESPACE
 using namespace GrandSearch::pdf_preview;
@@ -55,7 +58,7 @@ void PDFView::initDoc(const QString &file)
 {
     m_doc.reset(new DPdfDoc(file));
     if (!m_doc || m_doc->status() != DPdfDoc::SUCCESS) {
-        qWarning() << "Cannot read this pdf file: " << file;
+        qCWarning(logPdfPreview) << "Failed to load PDF document - Path:" << file << "Status:" << (m_doc ? m_doc->status() : -1);
         m_isBadDoc = true;
     }
 }

--- a/src/preview-plugin/video-preview/videopreviewplugin.cpp
+++ b/src/preview-plugin/video-preview/videopreviewplugin.cpp
@@ -11,6 +11,7 @@
 #include <QDateTime>
 #include <QtConcurrent>
 #include <QPainterPath>
+#include <QLoggingCategory>
 
 #ifdef __cplusplus
 extern "C" {
@@ -19,6 +20,7 @@ extern "C" {
 }
 #endif
 
+Q_LOGGING_CATEGORY(logVideoPreview, "org.deepin.dde.grandsearch.plugin.video")
 GRANDSEARCH_USE_NAMESPACE
 using namespace GrandSearch::video_preview;
 
@@ -267,13 +269,13 @@ QVariantHash DecodeBridge::decode(QSharedPointer<DecodeBridge> self, const QStri
                 info.insert(kLabelDuration, QVariant::fromValue(duration));
                 info.insert(kLabelDimension, QSize(codecpar->width, codecpar->height));
             } else {
-                qWarning() << "VideoPreviewPlugin: find stream error" << videoRet;
+                qCWarning(logVideoPreview) << "Failed to find video stream - Error code:" << videoRet << "File:" << file;
             }
         }
 
         avformat_close_input(&avCtx);
     } else {
-        qWarning() << "VideoPreviewPlugin: could not open video....";
+        qCWarning(logVideoPreview) << "Failed to open video file - Path:" << file;
     }
 
     //检查一次是否停止
@@ -300,7 +302,7 @@ QVariantHash DecodeBridge::decode(QSharedPointer<DecodeBridge> self, const QStri
             info.insert(kKeyThumbnailer, QVariant::fromValue(pixmap));
         } else {
             // 预览失败
-            qWarning() << "thumbnailer create image error";
+            qCWarning(logVideoPreview) << "Failed to generate video thumbnail - File:" << file;
             QImage errorImg(":/icons/image_damaged.svg");
             errorImg = errorImg.scaled(46, 46);
             auto img = CommonTools::creatErrorImage({192, 108}, errorImg);


### PR DESCRIPTION
- 使用journalctl管理全局搜索日志
- 规范全局搜索的日志输出

## Summary by Sourcery

Standardize and centralize logging across the global search daemon by introducing a dedicated logging category and manager, migrating all debug/info/warning/critical statements to use QLoggingCategory (logDaemon), and configuring journalctl and fallback appenders for consistent log output.

Enhancements:
- Introduce FrameLogManager to unify logging setup and support journalctl with fallback to console/file appenders
- Replace raw qDebug/qInfo/qWarning/qCritical calls with qCDebug/qCInfo/qCWarning/qCCritical using the logDaemon category
- Initialize suggested log settings in main.cpp to enable journal logging and consistent formatting
- Apply consistent logging patterns and formatting updates across all components