### PR TITLE
chore: bump version to 6.0.11

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-grand-search (6.0.11) unstable; urgency=medium
+
+  * new file-search
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Wed, 21 May 2025 18:11:40 +0800
+
 dde-grand-search (6.0.10) unstable; urgency=medium
 
   * refactor search for filename 


### PR DESCRIPTION
as title

Log:

## Summary by Sourcery

Chores:
- Bump version to 6.0.11 in Debian changelog