### PR TITLE
fix: correct word in dsl parser

### DIFF
--- a/src/dde-grand-search-daemon/searcher/semantic/dslparser/dslparser.cpp
+++ b/src/dde-grand-search-daemon/searcher/semantic/dslparser/dslparser.cpp
@@ -504,7 +504,7 @@ DurationCond::DurationCond(const QString &text, QObject *parent)
         m_compType = "=";
     }
     static QRegularExpression reg("([\\d\\.]+) ?year", QRegularExpression::CaseInsensitiveOption);
-    static QRegularExpression reg1("([\\d\\.]+) ?mouth", QRegularExpression::CaseInsensitiveOption);
+    static QRegularExpression reg1("([\\d\\.]+) ?month", QRegularExpression::CaseInsensitiveOption);
     static QRegularExpression reg2("([\\d\\.]+) ?week", QRegularExpression::CaseInsensitiveOption);
     static QRegularExpression reg3("([\\d\\.]+) ?day", QRegularExpression::CaseInsensitiveOption);
     static QRegularExpression reg4("([\\d\\.]+) ?hour", QRegularExpression::CaseInsensitiveOption);


### PR DESCRIPTION
Description: correct word in dsl parser

Log:

## Summary by Sourcery

Bug Fixes:
- Correct the regular expression to match "month" rather than "mouth" in the DSL parser.