### PR TITLE
6.0.13

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-grand-search (6.0.13) unstable; urgency=medium
+
+  * improve search method handling and logging in file search components
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 13 Jun 2025 09:31:45 +0800
+
 dde-grand-search (6.0.12) unstable; urgency=medium
 
   * fix bugs

--- a/src/dde-grand-search-daemon/searcher/file/filenamesearcher.cpp
+++ b/src/dde-grand-search-daemon/searcher/file/filenamesearcher.cpp
@@ -6,8 +6,6 @@
 #include "global/builtinsearch.h"
 #include "filenameworker.h"
 
-#include <dfm-search/dsearch_global.h>
-
 #include <QDBusInterface>
 #include <QDBusReply>
 #include <QDBusConnectionInterface>
@@ -29,7 +27,7 @@ QString FileNameSearcher::name() const
 
 bool FileNameSearcher::isActive() const
 {
-    return DFMSEARCH::Global::isFileNameIndexDirectoryAvailable();
+    return true;
 }
 
 bool FileNameSearcher::activate()
@@ -49,4 +47,3 @@ bool FileNameSearcher::action(const QString &action, const QString &item)
     qCWarning(logDaemon) << "Unsupported action requested - Action:" << action;
     return false;
 }
-

--- a/src/dde-grand-search-daemon/searcher/semantic/database/filenamequery.cpp
+++ b/src/dde-grand-search-daemon/searcher/semantic/database/filenamequery.cpp
@@ -170,9 +170,13 @@ SearchQuery FileNameQueryPrivate::createSearchQuery(const SemanticEntity &entity
 
 SearchOptions FileNameQueryPrivate::createSearchOptions(const SemanticEntity &entity) const
 {
+    auto searchPath = DFMSEARCH::Global::isFileNameIndexDirectoryAvailable()
+            ? QDir::rootPath()
+            : QDir::homePath();
+
     SearchOptions options;
-    options.setSearchPath(QDir::rootPath());
-    
+    options.setSearchPath(searchPath);
+
     // 检查文件名索引目录是否可用，如果不可用则回退到实时搜索
     if (DFMSEARCH::Global::isFileNameIndexDirectoryAvailable()) {
         qCDebug(logDaemon) << "Using indexed search method for semantic query";
@@ -181,7 +185,7 @@ SearchOptions FileNameQueryPrivate::createSearchOptions(const SemanticEntity &en
         qCWarning(logDaemon) << "File name index directory is not available, falling back to realtime search for semantic query";
         options.setSearchMethod(SearchMethod::Realtime);
     }
-    
+
     return options;
 }
 

--- a/src/dde-grand-search-daemon/searcher/semantic/database/filenamequery.cpp
+++ b/src/dde-grand-search-daemon/searcher/semantic/database/filenamequery.cpp
@@ -172,7 +172,16 @@ SearchOptions FileNameQueryPrivate::createSearchOptions(const SemanticEntity &en
 {
     SearchOptions options;
     options.setSearchPath(QDir::rootPath());
-    options.setSearchMethod(SearchMethod::Indexed);
+    
+    // 检查文件名索引目录是否可用，如果不可用则回退到实时搜索
+    if (DFMSEARCH::Global::isFileNameIndexDirectoryAvailable()) {
+        qCDebug(logDaemon) << "Using indexed search method for semantic query";
+        options.setSearchMethod(SearchMethod::Indexed);
+    } else {
+        qCWarning(logDaemon) << "File name index directory is not available, falling back to realtime search for semantic query";
+        options.setSearchMethod(SearchMethod::Realtime);
+    }
+    
     return options;
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Enable realtime search fallback when file name index is unavailable and ensure filename search remains active regardless of indexing

Enhancements:
- Fallback to realtime search with debug/warning logs when file name index directory is unavailable in both file and semantic query modules
- Use home directory as default search path if the index directory is not available
- Remove index availability check from FileNameWorker pre-search validation to permit realtime search
- Always activate FileNameSearcher instead of gating on index directory availability
- Remove unused dsearch_global include from FileNameSearcher