### PR TITLE
chore: bump version to 6.0.14

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-grand-search (6.0.14) unstable; urgency=medium
+
+  * update translations
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Mon, 23 Jun 2025 11:48:11 +0800
+
 dde-grand-search (6.0.13) unstable; urgency=medium
 
   * improve search method handling and logging in file search components


### PR DESCRIPTION
6.0.14

Log:

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect version 6.0.14