### PR TITLE
chore: fix CI faild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ add_definitions(-DPLUGIN_SEARCHER_DIR="${PLUGIN_SEARCHER_DIR}")
 # 获取系统版本
 if (NOT DEFINED BUILD_OS_VERSION OR BUILD_OS_VERSION STREQUAL "")
     # 读取文件并提取Version值
-    file(STRINGS "/etc/deepin-version" FILE_CONTENTS REGEX "^Version=")
+    file(STRINGS "/etc/os-version" FILE_CONTENTS REGEX "^MajorVersion=")
 
     # 遍历文件内容，查找Version行
     foreach(LINE ${FILE_CONTENTS})
@@ -139,7 +139,7 @@ if (NOT DEFINED BUILD_OS_VERSION OR BUILD_OS_VERSION STREQUAL "")
         endif()
     endforeach()
 
-    message("Get BUILD_OS_VERSION from deepin-version ${BUILD_OS_VERSION}")
+    message("Get BUILD_OS_VERSION from os-version ${BUILD_OS_VERSION}")
 else()
     message("catch BUILD_OS_VERSION ${BUILD_OS_VERSION}")
 endif()

--- a/src/preview-plugin/audio-preview/audiofileinfo.cpp
+++ b/src/preview-plugin/audio-preview/audiofileinfo.cpp
@@ -57,9 +57,9 @@ void AudioFileInfo::characterEncodingTransform(AudioFileInfo::AudioMetaData &met
 {
     TagLib::Tag *tag = static_cast<TagLib::Tag *>(obj);
     bool encode = true;
-    encode &= tag->title().isNull() ? true : tag->title().isLatin1();
-    encode &= tag->artist().isNull() ? true : tag->artist().isLatin1();
-    encode &= tag->album().isNull() ? true : tag->album().isLatin1();
+    encode &= tag->title().isEmpty() ? true : tag->title().isLatin1();
+    encode &= tag->artist().isEmpty() ? true : tag->artist().isLatin1();
+    encode &= tag->album().isEmpty() ? true : tag->album().isLatin1();
 
     QByteArray detectByte;
     QByteArray detectCodec;
@@ -72,9 +72,9 @@ void AudioFileInfo::characterEncodingTransform(AudioFileInfo::AudioMetaData &met
             auto localeCode = m_localeCodeMap.value(QLocale::system().name());
 
             auto iter = std::find_if(allDetectCodecs.begin(), allDetectCodecs.end(),
-                                     [localeCode](const QByteArray & curDetext) {
-                return (curDetext == "Big5" || curDetext == localeCode);
-            });
+                                     [localeCode](const QByteArray &curDetext) {
+                                         return (curDetext == "Big5" || curDetext == localeCode);
+                                     });
 
             if (iter != allDetectCodecs.end())
                 detectCodec = *iter;
@@ -88,7 +88,7 @@ void AudioFileInfo::characterEncodingTransform(AudioFileInfo::AudioMetaData &met
             if (curStr.isEmpty())
                 curStr = QString::fromLocal8Bit(tag->album().toCString());
 
-            auto ret = std::any_of(curStr.begin(), curStr.end(), [this](const QChar & ch) {
+            auto ret = std::any_of(curStr.begin(), curStr.end(), [this](const QChar &ch) {
                 return isChinese(ch);
             });
 
@@ -101,7 +101,7 @@ void AudioFileInfo::characterEncodingTransform(AudioFileInfo::AudioMetaData &met
             meta.album = TStringToQString(tag->album());
             meta.artist = TStringToQString(tag->artist());
             meta.title = TStringToQString(tag->title());
-            meta.codec = "UTF-8";  //info codec
+            meta.codec = "UTF-8";   // info codec
         } else {
             QTextCodec *codec = QTextCodec::codecForName(detectCodec);
             if (codec == nullptr) {
@@ -122,7 +122,7 @@ void AudioFileInfo::characterEncodingTransform(AudioFileInfo::AudioMetaData &met
         meta.codec = "UTF-8";
     }
 
-    //empty str
+    // empty str
     meta.album = meta.album.simplified();
     meta.artist = meta.artist.simplified();
     meta.title = meta.title.simplified();


### PR DESCRIPTION
1. Get `BUILD_OS_VERSION` by os-version
 2. Taglib build failed

Log:

## Summary by Sourcery

Fix CI failures by updating system version extraction in CMake and refining metadata string checks in the audio preview plugin

Enhancements:
- Use isEmpty() instead of isNull() for TagLib title, artist, and album checks
- Apply minor formatting cleanups in audiofileinfo.cpp lambdas and comments

Build:
- Extract BUILD_OS_VERSION from /etc/os-version (MajorVersion) instead of /etc/deepin-version