### PR TITLE
chore: add `deepin-desktop-base` to control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -27,7 +27,8 @@ Build-Depends: debhelper (>= 9),
  liblucene++-dev,
  libboost-dev,
  libdeepin-service-framework-dev (>1.0.9),
- libdde-shell-dev | hello
+ libdde-shell-dev | hello,
+ deepin-desktop-base
 Standards-Version: 3.9.8
 Homepage: http://www.deepin.org/
 


### PR DESCRIPTION
for CI

Log:

## Summary by Sourcery

Build:
- Include deepin-desktop-base in debian/control dependencies