### PR TITLE
build: add libboost-system-dev to build dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -26,6 +26,7 @@ Build-Depends: debhelper (>= 9),
  libjpeg62-turbo-dev,
  liblucene++-dev,
  libboost-dev,
+ libboost-system-dev,
  libdeepin-service-framework-dev (>1.0.9),
  libdde-shell-dev | hello,
  deepin-desktop-base

--- a/src/dde-grand-search-daemon/CMakeLists.txt
+++ b/src/dde-grand-search-daemon/CMakeLists.txt
@@ -47,6 +47,8 @@ set(LINK_LIBS
     ${DTK_LIBS}
     ${deepin-qdbus-service_LIBRARIES}
     dfm${DTK_VERSION_MAJOR}-search
+    ${Boost_LIBRARIES}
+    pthread
 )
 
 # 源文件


### PR DESCRIPTION
Add libboost-filesystem-dev to Build-Depends in debian/control to support boost_filesystem library usage in test components.

## Summary by Sourcery

Include Boost development packages in Debian packaging and update CMake configuration to link Boost libraries and pthread for filesystem support

Enhancements:
- Link Boost libraries and pthread in dde-grand-search-daemon CMakeLists for filesystem support

Build:
- Add libboost-filesystem-dev and libboost-system-dev to Debian Build-Depends