### PR TITLE
Revert "build: add libboost-system-dev to build dependencies"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,6 @@ Build-Depends: debhelper (>= 9),
  libjpeg62-turbo-dev,
  liblucene++-dev,
  libboost-dev,
- libboost-system-dev,
  libdeepin-service-framework-dev (>1.0.9),
  libdde-shell-dev | hello,
  deepin-desktop-base

--- a/src/dde-grand-search-daemon/CMakeLists.txt
+++ b/src/dde-grand-search-daemon/CMakeLists.txt
@@ -47,8 +47,6 @@ set(LINK_LIBS
     ${DTK_LIBS}
     ${deepin-qdbus-service_LIBRARIES}
     dfm${DTK_VERSION_MAJOR}-search
-    ${Boost_LIBRARIES}
-    pthread
 )
 
 # 源文件


### PR DESCRIPTION
Reverts linuxdeepin/dde-grand-search#232

## Summary by Sourcery

Build:
- Remove Boost libraries and pthread from the link dependencies in CMakeLists, reverting the addition of libboost-system-dev