### PR TITLE
fix: [Icon] The dock plugin icon is empty.

### DIFF
--- a/src/grand-search-dock-plugin/gui/grandsearchwidget.cpp
+++ b/src/grand-search-dock-plugin/gui/grandsearchwidget.cpp
@@ -26,20 +26,9 @@ DWIDGET_USE_NAMESPACE
 
 static QPixmap iconPixmap(const QString &fileName, const QSize &size, qreal ratio)
 {
-    QString iconPath = QString(":/icons/%1.dci").arg(fileName);
-    QPixmap pixmap;
-    DDciIcon dciIcon = DDciIcon::fromTheme(iconPath);
-    if (!dciIcon.isNull()) {
-        auto theme = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType
-                ? DDciIcon::Light
-                : DDciIcon::Dark;
-        pixmap = dciIcon.pixmap(ratio, size.width(), theme);
-    } else {
-        iconPath = QString(":/icons/%1.svg").arg(fileName);
-        pixmap = QIcon::fromTheme(iconPath).pixmap(size);
-    }
+    QString iconPath = QString(":/icons/%1.svg").arg(fileName);
 
-    return pixmap;
+    return QIcon::fromTheme(iconPath).pixmap(size);
 }
 
 GrandSearchWidget::GrandSearchWidget(QWidget *parent)

--- a/src/grand-search/gui/mainwindow.cpp
+++ b/src/grand-search/gui/mainwindow.cpp
@@ -302,7 +302,9 @@ void MainWindow::closeEvent(QCloseEvent *event)
     // 通知查询控制器停止搜索
     emit terminateSearch();
     // FIXME: DBlurEffectWidget close abort on treeland
-    qApp->exit(0);
-    _Exit(0);
+    QTimer::singleShot(1, this, [](){
+        qApp->exit(0);
+        _Exit(0);
+    });
     // return DBlurEffectWidget::closeEvent(event);
 }


### PR DESCRIPTION
Question:
-- The dock plugin icon is empty.
-- Clicked the dock plugin button, not show dde-grand-search main window. Solution：
-- The DCI icon here is used by v25, while v20 does not use the DCI icon for now. -- Terminating the process directly may occasionally fail to send the D-Bus signal
   'GrandSearchService::VisibleChanged(false)'.
   Therefore, a timer is added here to safely exit the process.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-323075.html