### PR TITLE
feat: add libdfm-search dependency to dde-grand-search package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,7 @@ Homepage: http://www.deepin.org/
 Package: dde-grand-search
 Architecture: any
 Replaces: dde-shell (<=1.99.30)
-Depends: ${shlibs:Depends}, ${misc:Depends},
+Depends: ${shlibs:Depends}, ${misc:Depends}, libdfm-search,
 Recommends:
  deepin-desktop-schemas (>=5.8.0.34),
  dde-daemon (>=5.12.0.31),


### PR DESCRIPTION
Add libdfm-search as a runtime dependency for the dde-grand-search package in debian/control. This ensures the search functionality has access to the required file manager search library.

Log: add libdfm-search dependency to dde-grand-search package