### PR TITLE
fix: update translations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-grand-search (6.0.21) unstable; urgency=medium
+
+  * Update version to 6.0.21. 
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Thu, 07 Aug 2025 20:53:41 +0800
+
 dde-grand-search (6.0.20) unstable; urgency=medium
 
   * chore: Update the help manual

--- a/translations/dde-grand-search_lo.ts
+++ b/translations/dde-grand-search_lo.ts
@@ -1,0 +1,789 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lo">
+<context>
+    <name>GrandSearch::AiToolBar</name>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="48"/>
+        <source>Unable to use %1, please go to the App Store to update the UOS AI version first.</source>
+        <translation>ບໍ່ສາມາດໃຊ້ %1 ໄດ້, ກະລຸນາໄປທີ່ App Store ເພື່ອອັບເດດ UOS AI ກ່ອນ.</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="49"/>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="50"/>
+        <source>Open App Stroe</source>
+        <translation>ເປີດ App Store</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::AiToolBarInner</name>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="112"/>
+        <source>Summary</source>
+        <translation>ສະຫຼຸບ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="113"/>
+        <source>Translation</source>
+        <translation>ແປພາສາ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="114"/>
+        <source>Extension</source>
+        <translation>ຂະຫຍາຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="115"/>
+        <source>Add to knowledge base</source>
+        <translation>ເພີ່ມເຂົ້າຖານຂໍ້ມູນຄວາມຮູ້</translation>
+    </message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="126"/>
+        <source>Summarize document content with UOS AI</source>
+        <translation>Resumeเนื้อหาเอกสารด้วย UOS AI</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="127"/>
+        <source>Translate document content with UOS AI</source>
+        <translation>แปลเนื้อหาเอกสารด้วย UOS AI</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="128"/>
+        <source>Extend document content with UOS AI</source>
+        <translation>ขยายเนื้อหาเอกสารด้วย UOS AI</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="129"/>
+        <source>Add document to UOS AI knowledge base</source>
+        <translation>เพิ่มเอกสารไปยังฐานข้อมูลความรู้ของ UOS AI</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="299"/>
+        <source>Summarize this document for me and provide me with a clear result directly, without any unnecessary content.</source>
+        <translation>Resumeเอกสารนี้ให้ฉันโดยตรง โดยให้ผลลัพธ์ที่ชัดเจนโดยไม่มีเนื้อหาที่ไม่จำเป็น</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="315"/>
+        <source>Translate this document for me and provide me with a clear result directly, without any unnecessary content.</source>
+        <translation>แปลเอกสารนี้ให้ฉันโดยตรง โดยให้ผลลัพธ์ที่ชัดเจนโดยไม่มีเนื้อหาที่ไม่จำเป็น</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="331"/>
+        <source>Expand this document for me and provide me with a clear and expanded result directly, without any unnecessary content.</source>
+        <translation>ขยายเอกสารนี้ให้ฉันโดยตรง โดยให้ผลลัพธ์ที่ชัดเจนและขยายได้โดยไม่มีเนื้อหาที่ไม่จำเป็น</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="447"/>
+        <source>DDE Grand Search</source>
+        <translation>การค้นหา DDE ใหญ่</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="450"/>
+        <source>Unable to use %1, please go to the App Store to update the UOS AI version first.</source>
+        <translation>មិនអាចប្រើប្រាស់ %1 ទេ, សូមទៅ App Store ក្នុងទូរស័ព្ភដែលអ្នកមានដើម្បីផ្ទុកទម្រង់ UOS AI ថ្មីជាមុនសិន.</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="451"/>
+        <source>Open App Stroe</source>
+        <translation>បុក App Store</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::BestMatchWidget</name>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/bestmatchwidget.cpp" line="23"/>
+        <source>Best match</source>
+        <translation>การค้นหาที่ดีที่สุด</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::BlackListWidget</name>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/blacklistwidget.cpp" line="30"/>
+        <source>Excluded path</source>
+        <translation>លំដាប់បាញ់ចេញ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/blacklistwidget.cpp" line="41"/>
+        <source>Add paths to the exclusion list to prevent searching in them.</source>
+        <translation>បញ្ចូលលំដាប់ទៅក្នុងបញ្ចុចបាញ់ចេញដើម្បីបញ្ណោចការស្ទាក់ស្រាល់ក្នុងវិសាលភាពទាំងនេះ.</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::CustomWidget</name>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/customwidget.cpp" line="26"/>
+        <source>Custom search</source>
+        <translation>ຄົ້ນຫາກຳນົດເອງ</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::DdeGrandSearchDockPlugin</name>
+    <message>
+        <location filename="../src/grand-search-dock-plugin/ddegrandsearchdockplugin.cpp" line="47"/>
+        <source>Grand Search</source>
+        <translation>ການຄົ້ນຫາທີ່ຍິ່ງໃຫຍ່</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search-dock-plugin/ddegrandsearchdockplugin.cpp" line="166"/>
+        <source>Search settings</source>
+        <translation>ການຕັ້ງຄ່າການຄົ້ນຫາ</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::DeleteDialog</name>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/blacklistview/deletedialog.cpp" line="14"/>
+        <source>Do you want to remove the path from the exclusion list?</source>
+        <translation>តើអ្នកចង់បញ្ចូលលំដាប់នេះចេញពីបញ្ចុចបាញ់ចេញទេ?</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/blacklistview/deletedialog.cpp" line="20"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>បង្ថយ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/blacklistview/deletedialog.cpp" line="28"/>
+        <source>Confirm</source>
+        <comment>button</comment>
+        <translation>បញ្ចាក់</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::EmbeddingPluginWidget</name>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/llmwidget/embeddingpluginwidget.cpp" line="52"/>
+        <source>Installed</source>
+        <translation>ផ្សំឡើង</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/llmwidget/embeddingpluginwidget.cpp" line="52"/>
+        <source>Not Installed</source>
+        <translation>មិនផ្សំឡើង</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/llmwidget/embeddingpluginwidget.cpp" line="105"/>
+        <source>Install</source>
+        <translation>ផ្សំឡើង</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::EntranceWidget</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="234"/>
+        <source>Search</source>
+        <translation>ស្ទាក់ស្រាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="235"/>
+        <source>What would you like to search for?</source>
+        <translation>តើអ្វីដែលអ្នកចង់ស្វែងหา?</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::EntranceWidgetPrivate</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="82"/>
+        <source>Cut</source>
+        <translation>ຕັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="86"/>
+        <source>Copy</source>
+        <translation>ສຳເນົາ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="90"/>
+        <source>Paste</source>
+        <translation>ວາງ</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::GeneralPreviewPlugin</name>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="193"/>
+        <source>Location:</source>
+        <translation>ສະຖານທີ່:</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="204"/>
+        <source>Time modified:</source>
+        <translation>ເວລາທີ່ຖືກແກ້ໄຂ:</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::GeneralToolBar</name>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <source>Open</source>
+        <translation>ເປີດ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <source>Open Path</source>
+        <translation>ເປີດທາງ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <source>Copy Path</source>
+        <translation>ចំនុចសាស្ត្រដែលចាក់ចំណំ</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::GroupWidget</name>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="269"/>
+        <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
+        <translation>សូមទៅ %1 ដើម្បីស្វែងយក ULLM ឡើង, និង %2 ការបង្កើតស្មានស្ទង់ស្ទាត់ជាមិនបានបន្ទាប់គ្នាជាមួយ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="270"/>
+        <source>Search configration</source>
+        <translation>ການຕັ້ງຄ່າການຄົ້ນຫາ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="271"/>
+        <source>turn on</source>
+        <translation>ເປີດ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="274"/>
+        <source>Please %1 Automatic index update.</source>
+        <translation>ກະລຸນາ %1 ການອັບເດດດັດສະນີອັດຕະໂນມັດ.</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="278"/>
+        <source>Please go to %1 to install the ULLM.</source>
+        <translation>សូមទៅ %1 ដើម្បីស្វែងយក ULLM ឡើង</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="330"/>
+        <source>More</source>
+        <translation>ច្រើនជាងគេ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="281"/>
+        <source>No search results</source>
+        <translation>សម្រែកមិនមានលទ្ធភាពទេ</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::IndexWidget</name>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/indexwidget.cpp" line="25"/>
+        <source>Index</source>
+        <translation>សន្ធិច</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::IntelligentRetrievalWidget</name>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="65"/>
+        <source>AI Smart Search</source>
+        <translation>ການຄົ້ນຫາ AI ອັດສະລິຍະ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="78"/>
+        <source>When turned on, you can try to search for local documents using natural language descriptions, such as &quot;last week&apos;s documents&quot;.</source>
+        <translation>ເມື່ອເປີດໃຊ້ງານ, ທ່ານສາມາດຄົ້ນຫາເອກະສານໃນເຄື່ອງໄດ້ໂດຍໃຊ້ຄຳອະທິບາຍພາສາທຳມະຊາດ, ເຊັ່ນ &quot;ເອກະສານອາທິດກ່ອນ&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="99"/>
+        <source>Automatic index update</source>
+        <translation>ການອັບເດດດັດສະນີອັດຕະໂນມັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="118"/>
+        <source>Full Text Search</source>
+        <translation>ການຄົ້ນຫາຂໍ້ຄວາມທັງໝົດ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="135"/>
+        <source>When turned on, full text search can be used in the file manager and grand search.</source>
+        <translation>ເມື່ອເປີດໃຊ້ງານ, ການຄົ້ນຫາຂໍ້ຄວາມທັງໝົດສາມາດໃຊ້ໃນຕົວຈັດການໄຟລ໌ແລະການຄົ້ນຫາຫຼັກໄດ້.</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="153"/>
+        <source>Embedding Plugins</source>
+        <translation>ປລັກອິນຝັງຕົວ</translation>
+    </message>
+        <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="153"/>
+        <source>After installing the model, you can use services such as AI Search and UOS AI Assistant..</source>
+        <translation>បន្ទាប់ពីប្រើប្រាស់ម៉ូដេល, អ្នកអាចប្រើប្រាស់សេវាស្ថានភាពដូចជា AI Search និង UOS AI Assistant..</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="171"/>
+        <source>ULLM</source>
+        <translation>ULLM</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="171"/>
+        <source>After installing the ULLM, you can use the AI intelligent search function without an internet connection.</source>
+        <translation>បន្ទាប់ពីប្រើប្រាស់ULLM, អ្នកអាចប្រើប្រាស់មុខងារស្វែងរកប្រើប្រាស់បញ្ហាសត្វដោយមិនត្រូវមានការចង្អើនទូរសាល់.</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="184"/>
+        <source>Intelligent full text search</source>
+        <translation>ການຄົ້ນຫາຂໍ້ຄວາມທັງໝົດອັດສະລິຍະ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="218"/>
+        <source>When enabled, you can search the text of articles using disjointed and incomplete keywords.</source>
+        <translation>ເມື່ອເປີດໃຊ້ງານ, ທ່ານສາມາດຄົ້ນຫາຂໍ້ຄວາມຂອງບົດຄວາມໄດ້ໂດຍໃຊ້ຄຳສຳຄັນທີ່ບໍ່ຕໍ່ເນື່ອງ ແລະບໍ່ຄົບຖ້ວນ.</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="240"/>
+        <source>Please install %0 in &lt;a href=&quot;%0&quot;&gt;the app store&lt;/a&gt; before turning on this configuration.</source>
+        <translation>ກະລຸນາຕິດຕັ້ງ %0 ຢູ່ &lt;a href=&quot;%0&quot;&gt;ຮ້ານແອັບ&lt;/a&gt; ກ່ອນທີ່ຈະເປີດໃຊ້ການຕັ້ງຄ່ານີ້.</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="280"/>
+        <source>Intelligent search indexing is being updated, which may take up more resources, please keep the power access.</source>
+        <translation>ກຳລັງອັບເດດດັດສະນີການຄົ້ນຫາອັດສະລິຍະ, ອາດຈະໃຊ້ຊັບພະຍາກອນຫຼາຍ, ກະລຸນາເຊື່ອມຕໍ່ໄຟຟ້າໄວ້.</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="284"/>
+        <source>Smart Search indexing update is complete. Last update time: %0</source>
+        <translation>ການອັບເດດດັດສະນີການຄົ້ນຫາອັດສະລິຍະສຳເລັດແລ້ວ. ເວລາອັບເດດຫຼ້າສຸດ: %0</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="287"/>
+        <source>Indexing error!</source>
+        <translation>ข้อผิดพลาดดัชนี!</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="336"/>
+        <source>To use AI Smart Search, you need to install the Embedding Plugins and ULLM first.</source>
+        <translation>เพื่อใช้การค้นหานักปัญญา AI คุณต้องติดตั้ง плагиныฝังและULLMก่อน</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="337"/>
+        <source>OK</source>
+        <translation>ตกลง</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::LLMWidget</name>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="61"/>
+        <source>Not Installed</source>
+        <translation>ไม่ติดตั้ง</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="77"/>
+        <source>Install Model</source>
+        <translation>ติดตั้งแบบจำลอง</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="93"/>
+        <source>Update model</source>
+        <translation>อัปเดตแบบจำลอง</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="94"/>
+        <source>Uninstall model</source>
+        <translation>ถอนติดตั้งแบบจำลอง</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="146"/>
+        <source>Installing</source>
+        <translation>กำลังติดตั้ง</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="212"/>
+        <source>Are you sure you want to delete this model?</source>
+        <translation>คุณแน่ใจจริงที่จะลบแบบจำลองนี้?</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="213"/>
+        <source>After uninstallation, functions such as AI Search and UOS AI Assistant will not work properly.</source>
+        <translation>หลังจากถอนติดตั้ง การค้นหา AI และผู้ช่วย AI UOS จะทำงานได้ไม่ดี</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="214"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ยกเลิก</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="215"/>
+        <source>Confirm</source>
+        <comment>button</comment>
+        <translation>ยืนยัน</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="324"/>
+        <source>Installing </source>
+        <translation>กำลังติดตั้ง </translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="344"/>
+        <source>Installing the ULLM</source>
+        <translation>กำลังติดตั้ง ULLM</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="345"/>
+        <source>Exiting will cause the installation to fail, do you still want to exit?</source>
+        <translation>ການອອກຈາກລະບົບຈະເຮັດໃຫ້ການຕິດຕັ້ງລົ້ມເຫຼວ, ທ່ານຍັງຕ້ອງການອອກບໍ?</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="346"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>ອອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="347"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation>ສືບຕໍ່</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="378"/>
+        <source>UnInstall Model</source>
+        <translation>ຖອນການຕິດຕັ້ງແບບຈຳລອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="379"/>
+        <source>Installed</source>
+        <translation>ຕິດຕັ້ງແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="390"/>
+        <source>Please install the &quot;Embedding Plugins&quot; first before installing this model.</source>
+        <translation>ກະລຸນາຕິດຕັ້ງ "Embedding Plugins" ກ່ອນທີ່ຈະຕິດຕັ້ງແບບຈຳລອງນີ້.</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::MainWindow</name>
+    <message>
+        <location filename="../src/grand-search/gui/mainwindow.cpp" line="213"/>
+        <source>No search results</source>
+        <translation>ບໍ່ມີຜົນການຄົ້ນຫາ</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::MatchWidget</name>
+    <message>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/matchwidget.cpp" line="87"/>
+        <source>Guess you want to search the following</source>
+        <translation>ຄາດວ່າທ່ານຕ້ອງການຄົ້ນຫາສິ່ງຕໍ່ໄປນີ້</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::PlanWidget</name>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/planwidget.cpp" line="27"/>
+        <source>Search experience program</source>
+        <translation>ໂຄງການປະສົບການຄົ້ນຫາ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/planwidget.cpp" line="35"/>
+        <source>Join search experience program</source>
+        <translation>ເຂົ້າຮ່ວມໂຄງການປະສົບການຄົ້ນຫາ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/planwidget.cpp" line="48"/>
+        <source>Joining the search experience program means that you grant and authorize us to collect the information of your device and system, file icons, content and properties, applications and their configurations, the contents you search while using the Application, the time of search, the type of requested large model.If you refuse our collection and use of the aforementioned information, do not join the program.</source>
+        <translation>ການເຂົ້າຮ່ວມໂຄງການປະສົບການຄົ້ນຫາ ໝາຍເຖິງວ່າທ່ານອະນຸຍາດແລະອະນຸຍາດໃຫ້ພວກເຮົາເກັບຂໍ້ມູນກ່ຽວກັບອຸປະກອນແລະລະບົບຂອງທ່ານ, ໄອຄອນໄຟລ໌, ເນື້ອຫາແລະຄຸນສົມບັດ, ແອັບພິເຄຊັນແລະການຕັ້ງຄ່າຂອງພວກມັນ, ເນື້ອຫາທີ່ທ່ານຄົ້ນຫາໃນຂະນະທີ່ໃຊ້ແອັບ, ເວລາຄົ້ນຫາ, ປະເພດຂອງແບບຈຳລອງທີ່ຮ້ອງຂໍ. ຖ້າທ່ານບໍ່ອະນຸຍາດໃຫ້ເຮົາເກັບກໍາແລະນໍາໃຊ້ຂໍ້ມູນດັ່ງກ່າວ, ກະລຸນາຢ່າເຂົ້າຮ່ວມໂຄງການນີ້.</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/planwidget.cpp" line="59"/>
+        <source>To know more about the management of your data, please refer to the UnionTech Software Privacy Policy (</source>
+        <translation>ເພື່ອຮູ້ເພີ່ມເຕີມກ່ຽວກັບການຈັດການຂໍ້ມູນຂອງທ່ານ, ກະລຸນາອ້າງອີງນະໂຍບາຍຄວາມປອດໄພຂອງ UnionTech Software (</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/planwidget.cpp" line="61"/>
+        <source>https://www.uniontech.com/agreement/privacy-en</source>
+        <translation>https://www.uniontech.com/agreement/privacy-en</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/planwidget.cpp" line="62"/>
+        <source>https://www.deepin.org/en/agreement/privacy/</source>
+        <translation>https://www.deepin.org/en/agreement/privacy/</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/planwidget.cpp" line="64"/>
+        <source>).</source>
+        <translation>).</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::ScopeWidget</name>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/scopewidget.cpp" line="28"/>
+        <source>Search contents</source>
+        <translation>ເນື້ອຫາການຄົ້ນຫາ</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::SearchEngineWidget</name>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="37"/>
+        <source>Default search engine</source>
+        <translation>មូលដ្យានរបស់មុខងារស្វែងរក</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="45"/>
+        <source>Search for keywords by the default search engine.</source>
+        <translation>តាមមូលដ្យានរបស់មុខងារស្វែងរកស្វែងរកពាក់ពែងតាមពាក់ពែង</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="57"/>
+        <source>Default search engine is</source>
+        <translation>មូលដ្យានរបស់មុខងារស្វែងរកគឺ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="66"/>
+        <source>Google</source>
+        <translation>Google</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="67"/>
+        <source>Baidu</source>
+        <translation>Baidu</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="68"/>
+        <source>Bing</source>
+        <translation>Bing</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="69"/>
+        <source>Yahoo</source>
+        <translation>Yahoo</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="70"/>
+        <source>360</source>
+        <translation>360</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="71"/>
+        <source>360 AI Search</source>
+        <translation>360 AI Search</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="72"/>
+        <source>Sogou</source>
+        <translation>Sogou</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="73"/>
+        <source>Custom</source>
+        <translation>ກຳນົດເອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="94"/>
+        <source>You need to use &quot;%0&quot; to replace the keyword in the URL</source>
+        <translation>ທ່ານຕ້ອງໃຊ້ &quot;%0&quot; ເພື່ອແທນຄຳສຳຄັນໃນ URL</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="158"/>
+        <source>Invalid URL</source>
+        <translation>URL ບໍ່ຖືກຕ້ອງ</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::StaticTextWorker</name>
+    <message>
+        <location filename="../src/dde-grand-search-daemon/searcher/web/statictextworker.cpp" line="65"/>
+        <source>Search for &quot;%1&quot;</source>
+        <translation>ຄົ້ນຫາ &quot;%1&quot;</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::TailerWidget</name>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/tailerwidget.cpp" line="19"/>
+        <source>Tailer settings</source>
+        <translation>ການຕັ້ງຄ່າ Tailer</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/tailerwidget.cpp" line="29"/>
+        <source>It is displayed at the end of search results for better identification and distinction of items with duplicate names.</source>
+        <translation>ມັນຖື່ງຢື່ນຢົງທີ່ສົ້ງສ້າງໃນຕົ້ນຕອບຄົ໋ການຄີກຖື່ງ, ໂດຍສະເພາະສົ້ງສ້າງໃຫ້ສົ້ງສ້າງທີ່ມີຊື່ອີງກັນ, ເພື່ອການແຈ້ງແຈ່ງແລະການແີ້ແຍ່ງທີ່ດີຂຶ້ນໄປ.</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/tailerwidget.cpp" line="38"/>
+        <source>Parent directory</source>
+        <translation>ໄດເຣກທໍາມະດາ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/searchconfig/tailerwidget.cpp" line="40"/>
+        <source>Time modified</source>
+        <translation>ເວລາທີ່ແກ້ໄຂ</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::audio_preview::AudioPreviewPlugin</name>
+    <message>
+        <location filename="../src/preview-plugin/audio-preview/audiopreviewplugin.cpp" line="59"/>
+        <source>Artist:</source>
+        <translation>ສິນລະປິນ:</translation>
+    </message>
+    <message>
+        <location filename="../src/preview-plugin/audio-preview/audiopreviewplugin.cpp" line="71"/>
+        <source>Album:</source>
+        <translation>ອະລະບັ້ມ:</translation>
+    </message>
+    <message>
+        <location filename="../src/preview-plugin/audio-preview/audiopreviewplugin.cpp" line="96"/>
+        <source>Duration:</source>
+        <translation>ໄລຍະເວລາ:</translation>
+    </message>
+    <message>
+        <location filename="../src/preview-plugin/audio-preview/audiopreviewplugin.cpp" line="111"/>
+        <source>Type:</source>
+        <translation>ປະເພດ:</translation>
+    </message>
+    <message>
+        <location filename="../src/preview-plugin/audio-preview/audiopreviewplugin.cpp" line="123"/>
+        <source>Location:</source>
+        <translation>ສະຖານທີ່:</translation>
+    </message>
+    <message>
+        <location filename="../src/preview-plugin/audio-preview/audiopreviewplugin.cpp" line="137"/>
+        <source>Time modified:</source>
+        <translation>ເວລາທີ່ແກ້ໄຂ</translation>
+    </message>
+</context>
+<context>
+    <name>GrandSearch::image_preview::ImagePreviewPlugin</name>
+    <message>
+        <location filename="../src/preview-plugin/image-preview/imagepreviewplugin.cpp" line="53"/>
+        <source>Dimensions:</source>
+        <translation>ຂະໜາດ:</translation>
+    </message>
+    <message>
+        <location filename="../src/preview-plugin/image-preview/imagepreviewplugin.cpp" line="69"/>
+        <source>Type:</source>
+        <translation>ປະເພດ:</translation>
+    </message>
+    <message>
+        <location filename="../src/preview-plugin/image-preview/imagepreviewplugin.cpp" line="84"/>
+        <source>Size:</source>
+        <translation>ຂະໜາດໄຟລ໌:</translation>
+    </message>
+    <message>
+        <location filename="../src/preview-plugin/image-preview/imagepreviewplugin.cpp" line="96"/>
+        <source>Location:</source>
+        <translation>ສະຖານທີ່:</translation>
+    </message>
+    <message>
+        <location filename="../src/preview-plugin/image-preview/imagepreviewplugin.cpp" line="110"/>
+        <source>Time modified:</source>
+        <translation>ເວລາທີ່ແກ້ໄຂ</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/grand-search/gui/datadefine.h" line="24"/>
+        <source>Best match</source>
+        <translation>ການຄົ້ນຫາທີ່ຕົງກັນທີ່ສຸດ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/datadefine.h" line="25"/>
+        <source>Applications</source>
+        <translation>កម្មវិធីទាំងអស់</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/datadefine.h" line="26"/>
+        <source>Settings</source>
+        <translation>ການຕັ້ງຄ່າ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/datadefine.h" line="27"/>
+        <source>Videos</source>
+        <translation>វិដែអិចស៊ីដេ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/datadefine.h" line="28"/>
+        <source>Music</source>
+        <translation>មូសិក</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/datadefine.h" line="29"/>
+        <source>Pictures</source>
+        <translation>រូបភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/datadefine.h" line="30"/>
+        <source>Documents</source>
+        <translation>ເອກະສານ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/datadefine.h" line="31"/>
+        <source>Folders</source>
+        <translation>ໂຟນເດີ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/datadefine.h" line="32"/>
+        <source>Files</source>
+        <translation>ໄຟລ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/datadefine.h" line="33"/>
+        <source>Web</source>
+        <translation>ເວັບ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/datadefine.h" line="34"/>
+        <source>AI Search</source>
+        <translation>ການຄົ້ນຫາ AI</translation>
+    </message>
+    <message>
+        <location filename="../src/preview-plugin/video-preview/videopreviewplugin.cpp" line="28"/>
+        <source>Dimensions:</source>
+        <translation>ຂະໜາດ:</translation>
+    </message>
+    <message>
+        <location filename="../src/preview-plugin/video-preview/videopreviewplugin.cpp" line="29"/>
+        <source>Type:</source>
+        <translation>ປະເພດ:</translation>
+    </message>
+    <message>
+        <location filename="../src/preview-plugin/video-preview/videopreviewplugin.cpp" line="30"/>
+        <source>Size:</source>
+        <translation>ຂະໜາດ:</translation>
+    </message>
+    <message>
+        <location filename="../src/preview-plugin/video-preview/videopreviewplugin.cpp" line="31"/>
+        <source>Duration:</source>
+        <translation>ໄລຍະເວລາ:</translation>
+    </message>
+    <message>
+        <location filename="../src/preview-plugin/video-preview/videopreviewplugin.cpp" line="32"/>
+        <source>Location:</source>
+        <translation>ສະຖານທີ່:</translation>
+    </message>
+    <message>
+        <location filename="../src/preview-plugin/video-preview/videopreviewplugin.cpp" line="33"/>
+        <source>Time modified:</source>
+        <translation>ເວລາທີ່ແກ້ໄຂ:</translation>
+    </message>
+    <message>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="205"/>
+        <source>modified</source>
+        <translation>ແກ້ໄຂແລ້ວ</translation>
+    </message>
+</context>
+<context>
+    <name>searchitem</name>
+    <message>
+        <location filename="../src/grand-search-shell-plugin/package/searchitem.qml" line="24"/>
+        <source>GrandSearch</source>
+        <translation>ການຄົ້ນຫາຂະໜາດໃຫຍ່</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search-shell-plugin/package/searchitem.qml" line="81"/>
+        <source>SearchConfig</source>
+        <translation>ການຕັ້ງຄ່າການຄົ້ນຫາ</translation>
+    </message>
+</context>
+</TS>

--- a/translations/org.deepin.ds.dock.searchitem_lo.ts
+++ b/translations/org.deepin.ds.dock.searchitem_lo.ts
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>dock::SearchItem</name>
+    <message>
+        <location filename="../searchitem.cpp" line="47"/>
+        <source>GrandSearch</source>
+        <translation>ການຄົ້ນຫາທີ່ຍິ່ງໃຫຍ່</translation>
+    </message>
+</context>
+<context>
+    <name>searchitem</name>
+    <message>
+        <location filename="../package/searchitem.qml" line="24"/>
+        <source>GrandSearch</source>
+        <translation>ການຄົ້ນຫາທີ່ຍິ່ງໃຫຍ່</translation>
+    </message>
+    <message>
+        <location filename="../package/searchitem.qml" line="53"/>
+        <source>SearchConfig</source>
+        <translation>ການຕັ້ງຄ່າການຄົ້ນຫາ</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
log: update

## Summary by Sourcery

Add comprehensive Lao translations for Grand Search and its dock plugin.

Documentation:
- Introduce translations/dde-grand-search_lo.ts with Lao translations for UI strings in the Grand Search application.
- Add translations/org.deepin.ds.dock.searchitem_lo.ts with Lao translations for the dock search item plugin.