### PR TITLE
fix: [dock-plugin] Set the tooltip margin

### DIFF
--- a/src/grand-search-dock-plugin/gui/tipswidget.cpp
+++ b/src/grand-search-dock-plugin/gui/tipswidget.cpp
@@ -8,6 +8,8 @@
 #include <QAccessible>
 #include <QTextDocument>
 
+inline constexpr int kMargin { 12 };
+
 using namespace GrandSearch;
 
 TipsWidget::TipsWidget(QWidget *parent)
@@ -34,7 +36,7 @@ void TipsWidget::setText(const QString &text)
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     setFixedSize(fontMetrics().horizontalAdvance(m_text), fontMetrics().boundingRect(m_text).height());
 #else
-    setFixedSize(fontMetrics().width(m_text), fontMetrics().height());
+    setFixedSize(fontMetrics().width(m_text) + 2 * kMargin, fontMetrics().height());
 #endif
 
     update();


### PR DESCRIPTION
-- Set the tooltip margin

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-325759.html

## Summary by Sourcery

Include horizontal margins in tooltip size calculations to prevent text clipping.

Bug Fixes:
- Fix tooltip text clipping by adding a 12px margin on each side.

Enhancements:
- Introduce a kMargin constant to define tooltip margins consistently.