### PR TITLE
Pr0922

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-grand-search (6.0.25) unstable; urgency=medium
+
+  * fix: fix memory leak
+
+ -- wangrong <wangrong@uniontech.com>  Mon, 22 Sep 2025 11:33:34 +0800
+
 dde-grand-search (6.0.24) unstable; urgency=medium
 
   * add pinyin acronym search support

--- a/src/grand-search/utils/utils.cpp
+++ b/src/grand-search/utils/utils.cpp
@@ -701,6 +701,7 @@ QString Utils::getFileMimetypeByGio(const QString &path)
     info = g_file_query_info(file, "standard::content-type", G_FILE_QUERY_INFO_NONE, nullptr, nullptr);
     result = g_file_info_get_content_type(info);
 
+    g_object_unref(info);
     g_object_unref(file);
 
     return result;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Release GFileInfo object by calling g_object_unref(info) after querying content type