### PR TITLE
chore: remove unused Qt Multimedia dependency

### DIFF
--- a/src/grand-search/CMakeLists.txt
+++ b/src/grand-search/CMakeLists.txt
@@ -27,7 +27,6 @@ find_package(${QT_NS} COMPONENTS
     Concurrent
     DBus
     Network
-    Multimedia
 REQUIRED)
 
 set(DBUSSRC
@@ -46,7 +45,6 @@ set(Qt_LIBS
     ${QT_NS}::DBus
     ${QT_NS}::Concurrent
     ${QT_NS}::Network
-    ${QT_NS}::Multimedia
 )
 set(DTK_LIBS
     ${DTK_NS}::Core


### PR DESCRIPTION
1. Remove Qt Multimedia from find_package COMPONENTS list
2. Remove ${QT_NS}::Multimedia from Qt_LIBS linking list
3. The Multimedia module was not actually used in the codebase
4. Reduces build dependencies and improves compilation time
5. Follows clean code practices by eliminating dead dependencies

Influence:
1. Verify project builds successfully without Qt Multimedia
2. Check that no runtime functionality is affected
3. Test search functionality remains working normally
4. Confirm reduced package dependencies in build environment
5. Verify no linker errors related to Multimedia removal

chore: 移除未使用的 Qt Multimedia 依赖

1. 从 find_package COMPONENTS 列表中移除 Qt Multimedia
2. 从 Qt_LIBS 链接列表中移除 ${QT_NS}::Multimedia
3. Multimedia 模块在代码库中实际未被使用
4. 减少构建依赖并提升编译时间
5. 遵循代码整洁原则，消除无用依赖

Influence:
1. 验证项目在无 Qt Multimedia 情况下成功构建
2. 检查运行时功能未受影响
3. 测试搜索功能正常工作
4. 确认构建环境中包依赖减少
5. 验证无 Multimedia 移除相关的链接器错误

## Summary by Sourcery

Remove the unused Qt Multimedia module from the grand-search build configuration to simplify dependencies.

Build:
- Drop Qt Multimedia from the Qt COMPONENTS requested by find_package in the grand-search CMake configuration.
- Remove the Qt Multimedia target from the Qt_LIBS link list in the grand-search CMake configuration.