### PR TITLE
refactor: extract full-text search into separate searcher

### DIFF
--- a/src/dde-grand-search-daemon/CMakeLists.txt
+++ b/src/dde-grand-search-daemon/CMakeLists.txt
@@ -106,6 +106,11 @@ set(SEARCHER
     searcher/ocr/ocrtextworker.h
     searcher/ocr/ocrtextworker.cpp
     searcher/ocr/ocrtextworker_p.h
+    searcher/fulltext/fulltextsearcher.h
+    searcher/fulltext/fulltextsearcher.cpp
+    searcher/fulltext/fulltextworker.h
+    searcher/fulltext/fulltextworker.cpp
+    searcher/fulltext/fulltextworker_p.h
 )
 
 if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64" AND OPT_ENABLE_AI_SEARCH)

--- a/src/dde-grand-search-daemon/configuration/configer.cpp
+++ b/src/dde-grand-search-daemon/configuration/configer.cpp
@@ -39,6 +39,7 @@ UserPreferencePointer ConfigerPrivate::defaultSearcher()
                         {GRANDSEARCH_CLASS_SETTING_CONTROLCENTER, true},
                         {GRANDSEARCH_CLASS_WEB_STATICTEXT, true},
                         {GRANDSEARCH_CLASS_GENERALFILE_SEMANTIC, true},
+                        {GRANDSEARCH_CLASS_FILE_FULLTEXT, true},
                         {GRANDSEARCH_CLASS_OCR_TEXT, true}
                         };
 

--- a/src/dde-grand-search-daemon/maincontroller/maincontroller.cpp
+++ b/src/dde-grand-search-daemon/maincontroller/maincontroller.cpp
@@ -146,8 +146,9 @@ QStringList MainControllerPrivate::checkSearcher(const QStringList &groupList, c
         // 说明分隔符前后的字段既不是后缀也不是类目
         if (groupList.isEmpty() && !keywordList.isEmpty()) {
             data.append(GRANDSEARCH_CLASS_FILE_DEEPIN);
+            data.append(GRANDSEARCH_CLASS_FILE_FULLTEXT);
             data.append(GRANDSEARCH_CLASS_APP_DESKTOP);
-            qCDebug(logDaemon) << "Added default searchers (file and app) for general keyword search";
+            qCDebug(logDaemon) << "Added default searchers (file, full-text and app) for general keyword search";
         }
     }
 

--- a/src/dde-grand-search-daemon/searcher/file/filenameworker.cpp
+++ b/src/dde-grand-search-daemon/searcher/file/filenameworker.cpp
@@ -7,8 +7,6 @@
 #include "utils/specialtools.h"
 #include "configuration/configer.h"
 
-#include <DConfig>
-
 #include <QStandardPaths>
 #include <QLoggingCategory>
 
@@ -16,7 +14,6 @@ Q_DECLARE_LOGGING_CATEGORY(logDaemon)
 
 using namespace GrandSearch;
 DFM_SEARCH_USE_NS
-DCORE_USE_NAMESPACE
 
 #define MAX_SEARCH_NUM_GROUP 100
 #define MAX_SEARCH_NUM_TOTAL 10000
@@ -115,19 +112,12 @@ bool FileNameWorkerPrivate::appendSearchResult(const QString &fileName)
     m_tmpSearchResults << fileName;
     // Get keywords for highlighting
     QStringList keywords { m_searchInfo.keyword };
-    if (m_searchInfo.isCombinationSearch) {
-        keywords = m_searchInfo.typeKeywords;
-    } else if (!m_searchInfo.boolKeywords.isEmpty()) {
+    if (!m_searchInfo.boolKeywords.isEmpty()) {
         keywords = m_searchInfo.boolKeywords;
+    } else if (!m_searchInfo.typeKeywords.isEmpty()) {
+        keywords = m_searchInfo.typeKeywords;
     }
     const auto &item = FileSearchUtils::packItem(fileName, q->name(), keywords);
-
-    // Cache Document category results if full-text search is enabled
-    if (m_documentPushDeferred && group == FileSearchUtils::Document) {
-        cacheDocumentResult(fileName, item);
-        qCDebug(logDaemon) << "Document result cached for deduplication:" << fileName;
-        return true;
-    }
 
     QMutexLocker lk(&m_mutex);
     m_items[group].append(item);
@@ -339,222 +329,12 @@ bool FileNameWorkerPrivate::isResultLimit()
     bool limited = false;
     auto it = m_resultCountHash.cbegin();
     for (; it != m_resultCountHash.cend(); ++it) {
-        if (m_documentPushDeferred && it.key() == FileSearchUtils::Document)
-            limited = m_documentPathCache.size() >= MAX_SEARCH_NUM_GROUP;
-        else
-            limited = it.value() >= MAX_SEARCH_NUM_GROUP;
-
+        limited = it.value() >= MAX_SEARCH_NUM_GROUP;
         if (limited)
             break;
     }
 
     return limited;
-}
-
-bool FileNameWorkerPrivate::checkFullTextSearchEnabled() const
-{
-    // Check if this is a combined search - not supported for full-text
-    if (m_searchInfo.isCombinationSearch) {
-        qCDebug(logDaemon) << "Full-text search disabled: combined search mode";
-        return false;
-    }
-
-    // Check if Document category is enabled
-    if (!m_resultCountHash.contains(FileSearchUtils::Document)) {
-        qCDebug(logDaemon) << "Full-text search disabled: Document category not enabled";
-        return false;
-    }
-
-    // Check DConfig for enableFullTextSearch
-    DConfig *dcfg = DConfig::create("org.deepin.dde.file-manager",
-                                    "org.deepin.dde.file-manager.search");
-    if (!dcfg) {
-        qCWarning(logDaemon) << "Failed to create DConfig for full-text search check";
-        return false;
-    }
-
-    bool enabled = dcfg->value("enableFullTextSearch", false).toBool();
-    delete dcfg;
-
-    if (!enabled) {
-        qCDebug(logDaemon) << "Full-text search disabled by DConfig";
-        return false;
-    }
-
-    // Check if content index is available
-    if (!DFMSEARCH::Global::isContentIndexAvailable()) {
-        qCDebug(logDaemon) << "Full-text search disabled: content index not available";
-        return false;
-    }
-
-    qCDebug(logDaemon) << "Full-text search enabled: all conditions met";
-    return true;
-}
-
-bool FileNameWorkerPrivate::executeContentSearch()
-{
-    qCDebug(logDaemon) << "Starting content search with keyword:" << m_searchInfo.keyword;
-
-    QObject holder;
-    SearchEngine *engine = SearchFactory::createEngine(SearchType::Content, &holder);
-    if (!engine) {
-        qCWarning(logDaemon) << "Failed to create content search engine";
-        return false;
-    }
-
-    // Create search options
-    SearchOptions options;
-    options.setSearchPath(m_searchPath);
-    options.setSearchMethod(SearchMethod::Indexed);
-    options.setMaxResults(MAX_SEARCH_NUM_GROUP);
-
-    // Configure content search options
-    ContentOptionsAPI contentOptions(options);
-    contentOptions.setMaxPreviewLength(50);
-    contentOptions.setFilenameContentMixedAndSearchEnabled(true);
-
-    engine->setSearchOptions(options);
-    qCDebug(logDaemon) << "Content search options configured";
-
-    // Create search query
-    SearchQuery query;
-    if (!m_searchInfo.boolKeywords.isEmpty()) {
-        query = SearchFactory::createQuery(m_searchInfo.keyword, SearchQuery::Type::Boolean);
-        query.setBooleanOperator(SearchQuery::BooleanOperator::AND);
-    } else {
-        query = SearchFactory::createQuery(m_searchInfo.keyword, SearchQuery::Type::Simple);
-    }
-
-    qCDebug(logDaemon) << "Executing content search";
-    const SearchResultExpected &result = engine->searchSync(query);
-    return processContentSearchResults(result);
-}
-
-bool FileNameWorkerPrivate::processContentSearchResults(const SearchResultExpected &result)
-{
-    Q_Q(FileNameWorker);
-
-    qCDebug(logDaemon) << "Processing content search results";
-
-    if (!result.hasValue()) {
-        qCWarning(logDaemon) << "Content search failed - Error:" << result.error().message();
-        return false;
-    }
-
-    int contentCount = 0;
-    for (const auto &file : result.value()) {
-        if (m_status.loadAcquire() != ProxyWorker::Runing)
-            return false;
-
-        const QString &filePath = file.path();
-        int currentDocCount = m_resultCountHash.value(FileSearchUtils::Document, 0);
-        if (currentDocCount >= MAX_SEARCH_NUM_GROUP) {
-            qCDebug(logDaemon) << "Document category limit reached";
-            break;
-        }
-
-        // Skip if already in results from content search
-        if (m_tmpSearchResults.contains(filePath)) {
-            // Remove from document cache if it was a filename result (deduplication)
-            if (m_documentPathCache.remove(filePath)) {
-                m_documentItems.remove(filePath);
-                qCDebug(logDaemon) << "Deduplicated: replaced filename result with content result:" << filePath;
-            } else {
-                qCDebug(logDaemon) << "Duplicate content result ignored:" << filePath;
-                continue;
-            }
-        }
-
-        m_tmpSearchResults << filePath;
-
-        // Create matched item with highlighted content
-        QStringList keywords = !m_searchInfo.boolKeywords.isEmpty()
-                ? m_searchInfo.boolKeywords
-                : QStringList { m_searchInfo.keyword };
-        MatchedItem item = FileSearchUtils::packItem(filePath, q->name(), keywords);
-
-        // Get highlighted content
-        QVariantHash extra = item.extra.toHash();
-        SearchResult mutableResult = const_cast<SearchResult &>(file);
-        ContentResultAPI contentResult(mutableResult);
-        QString highlightedContent = contentResult.highlightedContent();
-        if (!highlightedContent.isEmpty()) {
-            extra.insert(GRANDSEARCH_PROPERTY_ITEM_MATCHEDCONTEXT, highlightedContent);
-        }
-
-        item.extra = extra;
-
-        // Add to Document category
-        {
-            QMutexLocker lk(&m_mutex);
-            m_items[FileSearchUtils::Document].append(item);
-            m_resultCountHash[FileSearchUtils::Document]++;
-        }
-
-        contentCount++;
-        qCDebug(logDaemon) << "Content search result added - File:" << filePath
-                           << "Total doc count:" << m_resultCountHash[FileSearchUtils::Document];
-
-        // Also add to File category if enabled
-        if (m_resultCountHash.contains(FileSearchUtils::File)
-            && m_resultCountHash[FileSearchUtils::File] < MAX_SEARCH_NUM_GROUP) {
-            QMutexLocker lk(&m_mutex);
-            m_items[FileSearchUtils::File].append(item);
-            m_resultCountHash[FileSearchUtils::File]++;
-        }
-
-        tryNotify();
-    }
-
-    qCInfo(logDaemon) << "Content search completed - Added:" << contentCount
-                      << "Time elapsed:" << m_time.elapsed() << "ms";
-
-    return true;
-}
-
-void FileNameWorkerPrivate::cacheDocumentResult(const QString &path, const MatchedItem &item)
-{
-    m_documentPathCache.insert(path);
-    m_documentItems.insert(path, item);
-}
-
-void FileNameWorkerPrivate::pushDocumentResults()
-{
-    if (!m_documentPushDeferred) {
-        return;
-    }
-
-    qCDebug(logDaemon) << "Pushing deferred document results - Cached count:"
-                       << m_documentPathCache.size();
-
-    // Add cached document results to main items
-    int addedCount = 0;
-    for (auto it = m_documentItems.begin(); it != m_documentItems.end(); ++it) {
-        // Check limit
-        if (m_resultCountHash[FileSearchUtils::Document] >= MAX_SEARCH_NUM_GROUP) {
-            qCDebug(logDaemon) << "Document category limit reached during push";
-            break;
-        }
-
-        QMutexLocker lk(&m_mutex);
-        m_items[FileSearchUtils::Document].append(it.value());
-        m_resultCountHash[FileSearchUtils::Document]++;
-        addedCount++;
-
-        // Also add to File category if enabled
-        if (m_resultCountHash.contains(FileSearchUtils::File)
-            && m_resultCountHash[FileSearchUtils::File] < MAX_SEARCH_NUM_GROUP) {
-            m_items[FileSearchUtils::File].append(it.value());
-            m_resultCountHash[FileSearchUtils::File]++;
-        }
-    }
-
-    qCDebug(logDaemon) << "Pushed" << addedCount << "document results from cache";
-
-    // Clear caches
-    m_documentPathCache.clear();
-    m_documentItems.clear();
-    m_documentPushDeferred = false;
 }
 
 FileNameWorker::FileNameWorker(const QString &name, QObject *parent)
@@ -607,29 +387,9 @@ bool FileNameWorker::working(void *context)
     qCDebug(logDaemon) << "Starting file name search with keyword:" << d->m_searchInfo.keyword;
     d->m_time.start();
 
-    // Check if full-text search should be enabled
-    d->m_fullTextSearchEnabled = d->checkFullTextSearchEnabled();
-    d->m_documentPushDeferred = d->m_fullTextSearchEnabled;
-    qCDebug(logDaemon) << "Full-text search enabled:" << d->m_fullTextSearchEnabled
-                       << "Document push deferred:" << d->m_documentPushDeferred;
-
     if (!d->searchByDFMSearch()) {
         qCWarning(logDaemon) << "Search operation failed";
         return false;
-    }
-
-    // Execute content search if enabled
-    if (d->m_fullTextSearchEnabled && d->m_status.loadAcquire() == Runing) {
-        if (hasItem()) {
-            emit unearthed(this);
-        }
-
-        qCDebug(logDaemon) << "Starting content search after filename search";
-        if (!d->executeContentSearch()) {
-            qCWarning(logDaemon) << "Content search operation failed";
-        }
-        // Push deferred document results after content search
-        d->pushDocumentResults();
     }
 
     // 检查是否还有数据

--- a/src/dde-grand-search-daemon/searcher/file/filenameworker_p.h
+++ b/src/dde-grand-search-daemon/searcher/file/filenameworker_p.h
@@ -10,11 +10,6 @@
 
 #include <dfm-search/searchfactory.h>
 #include <dfm-search/filenamesearchapi.h>
-#include <dfm-search/contentsearchapi.h>
-
-#include <DConfig>
-
-DCORE_USE_NAMESPACE
 
 namespace GrandSearch {
 
@@ -35,13 +30,6 @@ public:
     int itemCount() const;
     bool isResultLimit();
 
-    // Full-text search methods
-    bool checkFullTextSearchEnabled() const;
-    bool executeContentSearch();
-    bool processContentSearchResults(const DFMSEARCH::SearchResultExpected &result);
-    void cacheDocumentResult(const QString &path, const MatchedItem &item);
-    void pushDocumentResults();
-
 public:
     FileNameWorker *q_ptr = nullptr;
     QAtomicInt m_status = ProxyWorker::Ready;
@@ -52,14 +40,6 @@ public:
     mutable QMutex m_mutex;
     MatchedItems m_items[FileSearchUtils::GroupCount];
     QSet<QString> m_tmpSearchResults;
-
-    // Document category caching for full-text search deduplication
-    QSet<QString> m_documentPathCache;
-    QHash<QString, MatchedItem> m_documentItems;
-
-    // Full-text search state
-    bool m_fullTextSearchEnabled = false;
-    bool m_documentPushDeferred = false;
 
     // 计时
     QElapsedTimer m_time;

--- a/src/dde-grand-search-daemon/searcher/fulltext/fulltextsearcher.cpp
+++ b/src/dde-grand-search-daemon/searcher/fulltext/fulltextsearcher.cpp
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "fulltextsearcher.h"
+#include "fulltextworker.h"
+#include "global/builtinsearch.h"
+#include "configuration/configer.h"
+
+#include <dfm-search/dsearch_global.h>
+
+#include <DConfig>
+
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logDaemon)
+
+DCORE_USE_NAMESPACE
+
+using namespace GrandSearch;
+
+FullTextSearcher::FullTextSearcher(QObject *parent)
+    : Searcher(parent)
+{
+    qCDebug(logDaemon) << "FullTextSearcher constructor";
+}
+
+QString FullTextSearcher::name() const
+{
+    return GRANDSEARCH_CLASS_FILE_FULLTEXT;
+}
+
+bool FullTextSearcher::isActive() const
+{
+    // Combination search is not supported for full-text search
+    // (check from context - if typeKeywords exist, it's combination)
+    DConfig *dcfg = DConfig::create("org.deepin.dde.file-manager",
+                                    "org.deepin.dde.file-manager.search");
+    if (!dcfg)
+        return false;
+
+    bool enabled = dcfg->value("enableFullTextSearch", false).toBool();
+    delete dcfg;
+
+    if (!enabled) {
+        qCDebug(logDaemon) << "FullTextSearcher inactive: full-text search disabled by DConfig";
+        return false;
+    }
+
+    if (!DFMSEARCH::Global::isContentIndexAvailable()) {
+        qCDebug(logDaemon) << "FullTextSearcher inactive: content index not available";
+        return false;
+    }
+
+    // Check if Document category is enabled
+    auto config = ConfigerIns->group(GRANDSEARCH_CLASS_FILE_DEEPIN);
+    if (!config->value(GRANDSEARCH_GROUP_FILE_DOCUMNET, false)) {
+        qCDebug(logDaemon) << "FullTextSearcher inactive: Document category not enabled";
+        return false;
+    }
+
+    qCDebug(logDaemon) << "FullTextSearcher active";
+    return true;
+}
+
+bool FullTextSearcher::activate()
+{
+    qCDebug(logDaemon) << "FullTextSearcher activate called";
+    return isActive();
+}
+
+ProxyWorker *FullTextSearcher::createWorker() const
+{
+    qCDebug(logDaemon) << "Creating FullTextWorker";
+    auto worker = new FullTextWorker(name());
+    return worker;
+}
+
+bool FullTextSearcher::action(const QString &action, const QString &item)
+{
+    Q_UNUSED(item)
+    qCWarning(logDaemon) << "Unsupported action requested - Action:" << action;
+    return false;
+}

--- a/src/dde-grand-search-daemon/searcher/fulltext/fulltextsearcher.h
+++ b/src/dde-grand-search-daemon/searcher/fulltext/fulltextsearcher.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef FULLTEXTSEARCHER_H
+#define FULLTEXTSEARCHER_H
+
+#include "searcher/searcher.h"
+
+namespace GrandSearch {
+
+class FullTextSearcher : public Searcher
+{
+    Q_OBJECT
+public:
+    explicit FullTextSearcher(QObject *parent = nullptr);
+    QString name() const Q_DECL_OVERRIDE;
+    bool isActive() const Q_DECL_OVERRIDE;
+    bool activate() Q_DECL_OVERRIDE;
+    ProxyWorker *createWorker() const Q_DECL_OVERRIDE;
+    bool action(const QString &action, const QString &item) Q_DECL_OVERRIDE;
+};
+
+}
+
+#endif   // FULLTEXTSEARCHER_H

--- a/src/dde-grand-search-daemon/searcher/fulltext/fulltextworker.cpp
+++ b/src/dde-grand-search-daemon/searcher/fulltext/fulltextworker.cpp
@@ -1,0 +1,280 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "fulltextworker_p.h"
+#include "global/builtinsearch.h"
+#include "configuration/configer.h"
+
+#include <QStandardPaths>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logDaemon)
+
+using namespace GrandSearch;
+DFM_SEARCH_USE_NS
+
+#define MAX_SEARCH_NUM_GROUP 100
+#define EMIT_INTERVAL 50
+
+FullTextWorkerPrivate::FullTextWorkerPrivate(FullTextWorker *qq)
+    : q_ptr(qq)
+{
+    qCDebug(logDaemon) << "FullTextWorkerPrivate constructor called";
+    m_searchPath = QDir::homePath();
+
+    auto config = ConfigerIns->group(GRANDSEARCH_CLASS_FILE_DEEPIN);
+    m_fileGroupEnabled = config->value(GRANDSEARCH_GROUP_FILE, false);
+    qCDebug(logDaemon) << "FullText file group enabled:" << m_fileGroupEnabled;
+}
+
+bool FullTextWorkerPrivate::doSearch()
+{
+    qCDebug(logDaemon) << "Starting content search with keyword:" << m_searchInfo.keyword;
+
+    QObject holder;
+    SearchEngine *engine = SearchFactory::createEngine(SearchType::Content, &holder);
+    if (!engine) {
+        qCWarning(logDaemon) << "Failed to create content search engine";
+        return false;
+    }
+
+    SearchOptions options;
+    options.setSearchPath(m_searchPath);
+    options.setSearchMethod(SearchMethod::Indexed);
+    options.setMaxResults(MAX_SEARCH_NUM_GROUP);
+
+    ContentOptionsAPI contentOptions(options);
+    contentOptions.setMaxPreviewLength(50);
+    contentOptions.setFilenameContentMixedAndSearchEnabled(true);
+
+    engine->setSearchOptions(options);
+    qCDebug(logDaemon) << "Content search options configured";
+
+    SearchQuery query;
+    if (!m_searchInfo.boolKeywords.isEmpty()) {
+        query = SearchFactory::createQuery(m_searchInfo.boolKeywords, SearchQuery::Type::Boolean);
+        query.setBooleanOperator(SearchQuery::BooleanOperator::AND);
+    } else if (!m_searchInfo.typeKeywords.isEmpty()) {
+        query = SearchFactory::createQuery(m_searchInfo.typeKeywords, SearchQuery::Type::Boolean);
+        query.setBooleanOperator(SearchQuery::BooleanOperator::OR);
+    } else {
+        query = SearchFactory::createQuery(m_searchInfo.keyword, SearchQuery::Type::Simple);
+    }
+
+    qCDebug(logDaemon) << "Executing content search";
+    const SearchResultExpected &result = engine->searchSync(query);
+    return processResults(result);
+}
+
+bool FullTextWorkerPrivate::processResults(const SearchResultExpected &result)
+{
+    Q_Q(FullTextWorker);
+
+    qCDebug(logDaemon) << "Processing content search results";
+
+    if (!result.hasValue()) {
+        qCWarning(logDaemon) << "Content search failed - Error:" << result.error().message();
+        return false;
+    }
+
+    int contentCount = 0;
+    // Get keywords for highlighting
+    QStringList keywords { m_searchInfo.keyword };
+    if (!m_searchInfo.boolKeywords.isEmpty()) {
+        keywords = m_searchInfo.boolKeywords;
+    } else if (!m_searchInfo.typeKeywords.isEmpty()) {
+        keywords = m_searchInfo.typeKeywords;
+    }
+
+    for (const auto &file : result.value()) {
+        if (m_status.loadAcquire() != ProxyWorker::Runing)
+            return false;
+
+        const QString &filePath = file.path();
+
+        if (m_tmpSearchResults.contains(filePath)) {
+            qCDebug(logDaemon) << "Duplicate content result ignored:" << filePath;
+            continue;
+        }
+
+        m_tmpSearchResults << filePath;
+        MatchedItem item = FileSearchUtils::packItem(filePath, q->name(), keywords);
+
+        // Set higher weight so frontend dedup prefers content results over filename results
+        QVariantHash extra = item.extra.toHash();
+        extra.insert(GRANDSEARCH_PROPERTY_ITEM_WEIGHT, 10);
+
+        // Get highlighted content preview
+        SearchResult mutableResult = const_cast<SearchResult &>(file);
+        ContentResultAPI contentResult(mutableResult);
+        QString highlightedContent = contentResult.highlightedContent();
+        if (!highlightedContent.isEmpty()) {
+            extra.insert(GRANDSEARCH_PROPERTY_ITEM_MATCHEDCONTEXT, highlightedContent);
+        }
+
+        item.extra = extra;
+
+        // Add to Document category
+        {
+            QMutexLocker lk(&m_mutex);
+            m_items[FileSearchUtils::Document].append(item);
+
+            // Also add to File group if enabled
+            if (m_fileGroupEnabled) {
+                m_items[FileSearchUtils::File].append(item);
+            }
+        }
+
+        contentCount++;
+        qCDebug(logDaemon) << "Content search result added - File:" << filePath
+                           << "Total doc count:" << contentCount;
+
+        tryNotify();
+    }
+
+    qCInfo(logDaemon) << "Content search completed - Added:" << contentCount
+                      << "Time elapsed:" << m_time.elapsed() << "ms";
+
+    return true;
+}
+
+void FullTextWorkerPrivate::tryNotify()
+{
+    Q_Q(FullTextWorker);
+    int cur = m_time.elapsed();
+    if (q->hasItem() && (cur - m_lastEmit) > EMIT_INTERVAL) {
+        m_lastEmit = cur;
+        qCDebug(logDaemon) << "Emitting new results - Time elapsed:" << cur << "ms";
+        emit q->unearthed(q);
+    }
+}
+
+int FullTextWorkerPrivate::itemCount() const
+{
+    QMutexLocker lk(&m_mutex);
+
+    int count = 0;
+    for (int i = FileSearchUtils::GroupBegin; i < FileSearchUtils::GroupCount; ++i)
+        count += m_items[i].size();
+
+    return count;
+}
+
+FullTextWorker::FullTextWorker(const QString &name, QObject *parent)
+    : ProxyWorker(name, parent),
+      d_ptr(new FullTextWorkerPrivate(this))
+{
+    qCDebug(logDaemon) << "FullTextWorker constructor - Name:" << name;
+}
+
+FullTextWorker::~FullTextWorker()
+{
+    qCDebug(logDaemon) << "FullTextWorker destructor called";
+    delete d_ptr;
+    d_ptr = nullptr;
+}
+
+void FullTextWorker::setContext(const QString &context)
+{
+    Q_D(FullTextWorker);
+
+    if (context.isEmpty())
+        qCWarning(logDaemon) << "Search key is empty";
+    d->m_searchInfo = FileSearchUtils::parseContent(context);
+    qCDebug(logDaemon) << "Parsed search keyword:" << d->m_searchInfo.keyword;
+}
+
+bool FullTextWorker::isAsync() const
+{
+    return false;
+}
+
+bool FullTextWorker::working(void *context)
+{
+    Q_D(FullTextWorker);
+    Q_UNUSED(context)
+
+    qCDebug(logDaemon) << "FullTextWorker starting work";
+
+    if (!d->m_status.testAndSetRelease(Ready, Runing)) {
+        qCWarning(logDaemon) << "Failed to start worker - Invalid state transition";
+        return false;
+    }
+
+    if (d->m_searchInfo.keyword.isEmpty() || d->m_searchPath.isEmpty()) {
+        qCWarning(logDaemon) << "Search prerequisites not met - Empty keyword or path";
+        d->m_status.storeRelease(Completed);
+        return false;
+    }
+
+    // Skip combination search (handled by FullTextSearcher::isActive, double-check here)
+    if (d->m_searchInfo.isCombinationSearch) {
+        qCDebug(logDaemon) << "Skipping content search in combination search mode";
+        d->m_status.storeRelease(Completed);
+        return false;
+    }
+
+    qCDebug(logDaemon) << "Starting full-text content search with keyword:" << d->m_searchInfo.keyword;
+    d->m_time.start();
+
+    if (!d->doSearch()) {
+        qCWarning(logDaemon) << "Content search operation failed";
+        return false;
+    }
+
+    if (d->m_status.testAndSetRelease(Runing, Completed)) {
+        if (hasItem()) {
+            qCDebug(logDaemon) << "Content search completed - Emitting final results";
+            emit unearthed(this);
+        }
+    }
+    return true;
+}
+
+void FullTextWorker::terminate()
+{
+    Q_D(FullTextWorker);
+    qCDebug(logDaemon) << "Terminating full-text worker";
+    d->m_status.storeRelease(Terminated);
+}
+
+ProxyWorker::Status FullTextWorker::status()
+{
+    Q_D(FullTextWorker);
+
+    return static_cast<ProxyWorker::Status>(d->m_status.loadAcquire());
+}
+
+bool FullTextWorker::hasItem() const
+{
+    Q_D(const FullTextWorker);
+
+    QMutexLocker lk(&d->m_mutex);
+    for (int i = FileSearchUtils::GroupBegin; i < FileSearchUtils::GroupCount; ++i)
+        if (!d->m_items[i].isEmpty())
+            return true;
+
+    return false;
+}
+
+MatchedItemMap FullTextWorker::takeAll()
+{
+    Q_D(FullTextWorker);
+
+    qCDebug(logDaemon) << "Taking all content search results";
+
+    MatchedItemMap ret;
+
+    QMutexLocker lk(&d->m_mutex);
+    for (int i = FileSearchUtils::GroupBegin; i < FileSearchUtils::GroupCount; ++i) {
+        if (!d->m_items[i].isEmpty()) {
+            MatchedItems items = std::move(d->m_items[i]);
+            Q_ASSERT(d->m_items[i].isEmpty());
+            ret.insert(FileSearchUtils::groupKey(static_cast<FileSearchUtils::Group>(i)), items);
+        }
+    }
+    lk.unlock();
+
+    return ret;
+}

--- a/src/dde-grand-search-daemon/searcher/fulltext/fulltextworker.h
+++ b/src/dde-grand-search-daemon/searcher/fulltext/fulltextworker.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef FULLTEXTWORKER_H
+#define FULLTEXTWORKER_H
+
+#include "searcher/proxyworker.h"
+
+namespace GrandSearch {
+
+class FullTextWorkerPrivate;
+class FullTextWorker : public ProxyWorker
+{
+    Q_OBJECT
+public:
+    explicit FullTextWorker(const QString &name, QObject *parent = nullptr);
+    ~FullTextWorker();
+    void setContext(const QString &context) Q_DECL_OVERRIDE;
+    bool isAsync() const Q_DECL_OVERRIDE;
+    bool working(void *context) Q_DECL_OVERRIDE;
+    void terminate() Q_DECL_OVERRIDE;
+    Status status() Q_DECL_OVERRIDE;
+    bool hasItem() const Q_DECL_OVERRIDE;
+    MatchedItemMap takeAll() Q_DECL_OVERRIDE;
+
+private:
+    FullTextWorkerPrivate *d_ptr;
+    Q_DECLARE_PRIVATE(FullTextWorker)
+};
+
+}
+
+#endif   // FULLTEXTWORKER_H

--- a/src/dde-grand-search-daemon/searcher/fulltext/fulltextworker_p.h
+++ b/src/dde-grand-search-daemon/searcher/fulltext/fulltextworker_p.h
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef FULLTEXTWORKER_P_H
+#define FULLTEXTWORKER_P_H
+
+#include "fulltextworker.h"
+#include "searcher/file/filesearchutils.h"
+
+#include <dfm-search/searchfactory.h>
+#include <dfm-search/contentsearchapi.h>
+
+namespace GrandSearch {
+
+class FullTextWorkerPrivate
+{
+public:
+    explicit FullTextWorkerPrivate(FullTextWorker *qq);
+    bool doSearch();
+    bool processResults(const DFMSEARCH::SearchResultExpected &result);
+
+    void tryNotify();
+    int itemCount() const;
+
+public:
+    FullTextWorker *q_ptr = nullptr;
+    QAtomicInt m_status = ProxyWorker::Ready;
+    QString m_searchPath;
+    FileSearchUtils::SearchInfo m_searchInfo;
+
+    mutable QMutex m_mutex;
+    MatchedItems m_items[FileSearchUtils::GroupCount];
+    QSet<QString> m_tmpSearchResults;
+    bool m_fileGroupEnabled = false;
+
+    QElapsedTimer m_time;
+    int m_lastEmit = 0;
+
+    Q_DECLARE_PUBLIC(FullTextWorker)
+};
+
+}
+
+#endif   // FULLTEXTWORKER_P_H

--- a/src/dde-grand-search-daemon/searcher/searchergroup.cpp
+++ b/src/dde-grand-search-daemon/searcher/searchergroup.cpp
@@ -5,6 +5,7 @@
 #include "searchergroup.h"
 #include "searchergroup_p.h"
 #include "ocr/ocrtextsearcher.h"
+#include "fulltext/fulltextsearcher.h"
 
 #include <QDebug>
 #include <QLoggingCategory>
@@ -45,6 +46,10 @@ void SearcherGroupPrivate::initBuiltin()
     qCInfo(logDaemon) << "Initializing OcrTextSearcher";
     auto ocrSearcher = new OcrTextSearcher(this);
     m_builtin << ocrSearcher;
+
+    qCInfo(logDaemon) << "Initializing FullTextSearcher";
+    auto fullTextSearcher = new FullTextSearcher(this);
+    m_builtin << fullTextSearcher;
 }
 
 bool SearcherGroupPrivate::addExtendSearcher(const SearchPluginInfo &pluginInfo)

--- a/src/global/builtinsearch.h
+++ b/src/global/builtinsearch.h
@@ -12,6 +12,7 @@
 #define GRANDSEARCH_CLASS_WEB_STATICTEXT "com.deepin.dde-grand-search.web-statictext"
 #define GRANDSEARCH_CLASS_GENERALFILE_SEMANTIC "com.deepin.dde-grand-search.generalfile-semantic"
 #define GRANDSEARCH_CLASS_OCR_TEXT "com.deepin.dde-grand-search.ocr-text"
+#define GRANDSEARCH_CLASS_FILE_FULLTEXT "com.deepin.dde-grand-search.file-fulltext"
 
 // AI搜索子项
 #define GRANDSEARCH_CLASS_GENERALFILE_SEMANTIC_ANALYSIS GRANDSEARCH_CLASS_GENERALFILE_SEMANTIC".analysis"

--- a/src/grand-search/gui/exhibition/matchresult/groupwidget.cpp
+++ b/src/grand-search/gui/exhibition/matchresult/groupwidget.cpp
@@ -14,12 +14,12 @@
 #include <DPushButton>
 #include <DHorizontalLine>
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-#include <DGuiApplicationHelper>
+#    include <DGuiApplicationHelper>
 #else
-#include <DApplicationHelper>
+#    include <DApplicationHelper>
 #endif
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-#include <DPaletteHelper>
+#    include <DPaletteHelper>
 #endif
 #include <DSpinner>
 
@@ -79,16 +79,22 @@ void GroupWidget::appendMatchedItems(const MatchedItems &newItems, const QString
     if (newItems.isEmpty())
         return;
 
+    // Deduplicate: remove/replace items with same file path, preferring higher weight
+    MatchedItems dedupedItems = newItems;
+    deduplicateByPath(dedupedItems);
+    if (dedupedItems.isEmpty())
+        return;
+
     // 结果列表未展开
     if (!m_bListExpanded) {
         // 当前组没有数据，则需要判断本次数据是否包含权重
         if (0 == m_listView->rowCount()) {
-            const MatchedItem &item = newItems.first();
+            const MatchedItem &item = dedupedItems.first();
             if (!item.extra.isNull()
                 && item.extra.type() == QVariant::Hash
                 && item.extra.toHash().keys().contains(GRANDSEARCH_PROPERTY_ITEM_WEIGHT)) {
                 // 已经排序过，直接显示
-                m_cacheWeightItems << newItems;
+                m_cacheWeightItems << dedupedItems;
                 updateShowItems(m_cacheWeightItems);
 
                 return;
@@ -96,12 +102,12 @@ void GroupWidget::appendMatchedItems(const MatchedItems &newItems, const QString
         }
 
         // 对未展开的数据排序
-        m_cacheItems << newItems;
+        m_cacheItems << dedupedItems;
         Utils::sortByWeight(m_cacheItems);
         updateShowItems(m_cacheItems);
     } else {
         // 结果列表已展开，已经显示的数据保持不变，仅对新增数据排序，然后追加到列表末尾
-        MatchedItems &tempNewItems = const_cast<MatchedItems &>(newItems);
+        MatchedItems &tempNewItems = const_cast<MatchedItems &>(dedupedItems);
         Utils::sortByWeight(tempNewItems);
         m_listView->addRows(tempNewItems);
     }
@@ -421,6 +427,41 @@ void GroupWidget::initConnect()
     connect(m_resultLabel, &DLabel::linkActivated, this, &GroupWidget::onOpenConfig);
 }
 
+void GroupWidget::deduplicateByPath(MatchedItems &newItems)
+{
+    MatchedItems filtered;
+    QSet<QString> seenInBatch;
+
+    auto weightOf = [](const MatchedItem &item) {
+        return item.extra.toHash()
+                     .value(GRANDSEARCH_PROPERTY_ITEM_WEIGHT, 0)
+                     .toDouble();
+    };
+
+    for (const auto &newItem : newItems) {
+        const QString &path = newItem.item;
+        if (path.isEmpty())
+            continue;
+
+        if (seenInBatch.contains(path))
+            continue;
+        seenInBatch.insert(path);
+
+        const double newWeight = weightOf(newItem);
+
+        MatchedItem existing = findItemByPath(path);
+        if (!existing.item.isEmpty()) {
+            if (newWeight <= weightOf(existing))
+                continue;
+            updateItemByPath(path, newItem);
+        } else {
+            filtered << newItem;
+        }
+    }
+
+    newItems = filtered;
+}
+
 void GroupWidget::updateShowItems(MatchedItems &items)
 {
     // 显示不足5个，补足显示
@@ -485,4 +526,56 @@ void GroupWidget::onOpenConfig(const QString &link)
     } else if (link == "config") {
         QProcess::startDetached("dde-grand-search", args);
     }
+}
+
+MatchedItem GroupWidget::findItemByPath(const QString &path) const
+{
+    auto findIn = [&](const MatchedItems &items) -> MatchedItem {
+        for (const auto &item : items) {
+            if (item.item == path)
+                return item;
+        }
+        return {};
+    };
+
+    MatchedItem found = findIn(m_firstFiveItems);
+    if (!found.item.isEmpty()) return found;
+
+    found = findIn(m_restShowItems);
+    if (!found.item.isEmpty()) return found;
+
+    found = findIn(m_cacheItems);
+    if (!found.item.isEmpty()) return found;
+
+    return findIn(m_cacheWeightItems);
+}
+
+bool GroupWidget::updateItemByPath(const QString &path, const MatchedItem &newItem)
+{
+    auto doUpdate = [&](MatchedItems &items) -> bool {
+        for (int i = 0; i < items.size(); ++i) {
+            if (items[i].item == path) {
+                items[i] = newItem;
+                return true;
+            }
+        }
+        return false;
+    };
+
+    bool updated = false;
+    updated |= doUpdate(m_firstFiveItems);
+    updated |= doUpdate(m_restShowItems);
+    updated |= doUpdate(m_cacheItems);
+    updated |= doUpdate(m_cacheWeightItems);
+
+    if (updated) {
+        if (m_bListExpanded) {
+            MatchedItems all = m_firstFiveItems + m_restShowItems;
+            m_listView->setMatchedItems(all);
+        } else {
+            m_listView->setMatchedItems(m_firstFiveItems);
+        }
+    }
+
+    return updated;
 }

--- a/src/grand-search/gui/exhibition/matchresult/groupwidget.h
+++ b/src/grand-search/gui/exhibition/matchresult/groupwidget.h
@@ -56,6 +56,9 @@ public:
 
     static QString convertDisplayName(const QString &searchGroupName);
 
+    MatchedItem findItemByPath(const QString &path) const;
+    bool updateItemByPath(const QString &path, const MatchedItem &newItem);
+
 public slots:
     virtual void onMoreBtnClicked();
 
@@ -66,6 +69,7 @@ private:
     void initUi();
     void initConnect();
     void updateShowItems(MatchedItems &items);
+    void deduplicateByPath(MatchedItems &newItems);
     void onOpenConfig(const QString& link);
 
 signals:

--- a/src/grand-search/gui/exhibition/matchresult/matchwidget.cpp
+++ b/src/grand-search/gui/exhibition/matchresult/matchwidget.cpp
@@ -91,14 +91,17 @@ void MatchWidget::appendMatchedData(const MatchedItemMap &matchedData)
         }
 
         // 追加匹配数据到类目列表中
-        groupWidget->appendMatchedItems(itData.value(), itData.key());
+        MatchedItems filteredItems = itData.value();
+        if (groupWidget->searchGroupName() != GRANDSEARCH_GROUP_BEST)
+            filteredItems = deduplicateAgainstBestMatch(filteredItems, itData.key());
+        groupWidget->appendMatchedItems(filteredItems, itData.key());
 
         // 列表中没有数据，显示等待效果
         groupWidget->setVisible(true);
         groupWidget->showSpinner(groupWidget->itemCount() < 1);
 
         // 有新增匹配结果，需要调整重新布局
-        if (!bNeedRelayout && itData.value().size() > 0)
+        if (!bNeedRelayout && filteredItems.size() > 0)
             bNeedRelayout = true;
 
         itData++;
@@ -671,4 +674,39 @@ void MatchWidget::resizeEvent(QResizeEvent *event)
     }
 
     DWidget::resizeEvent(event);
+}
+
+MatchedItems MatchWidget::deduplicateAgainstBestMatch(const MatchedItems &items, const QString &groupName)
+{
+    // Groups in blackGroup always display their items regardless of Best Match
+    static const QSet<QString> blackGroup = {
+        GRANDSEARCH_GROUP_FILE_VIDEO,
+        GRANDSEARCH_GROUP_FILE_AUDIO,
+        GRANDSEARCH_GROUP_FILE_PICTURE,
+        GRANDSEARCH_GROUP_FILE_DOCUMNET,
+        GRANDSEARCH_GROUP_FOLDER
+    };
+    if (blackGroup.contains(groupName))
+        return items;
+
+    GroupWidget *bestMatchWidget = m_groupWidgetMap.value(GRANDSEARCH_GROUP_BEST);
+    if (!bestMatchWidget || bestMatchWidget->itemCount() == 0)
+        return items;
+
+    MatchedItems filtered;
+    for (const auto &item : items) {
+        MatchedItem existing = bestMatchWidget->findItemByPath(item.item);
+        if (!existing.item.isEmpty()) {
+            // Already in Best Match — update if new item has higher weight
+            double newWeight = item.extra.toHash().value(GRANDSEARCH_PROPERTY_ITEM_WEIGHT, 0).toDouble();
+            double existingWeight = existing.extra.toHash().value(GRANDSEARCH_PROPERTY_ITEM_WEIGHT, 0).toDouble();
+            if (newWeight > existingWeight) {
+                bestMatchWidget->updateItemByPath(item.item, item);
+            }
+            // Don't add to current group — item belongs to Best Match
+            continue;
+        }
+        filtered << item;
+    }
+    return filtered;
 }

--- a/src/grand-search/gui/exhibition/matchresult/matchwidget.h
+++ b/src/grand-search/gui/exhibition/matchresult/matchwidget.h
@@ -74,6 +74,8 @@ protected:
     // 对要显示的类目列表进行排序
     void sortVislibleGroupList();
 
+    MatchedItems deduplicateAgainstBestMatch(const MatchedItems &items, const QString &groupName);
+
     void paintEvent(QPaintEvent *event) override;
     void resizeEvent(QResizeEvent* event) override;
 

--- a/src/grand-search/utils/utils.cpp
+++ b/src/grand-search/utils/utils.cpp
@@ -324,7 +324,8 @@ bool Utils::setWeightMethod(MatchedItem &item)
         return true;
 
     const QString &search = item.searcher;
-    if (search == GRANDSEARCH_CLASS_FILE_DEEPIN || search == GRANDSEARCH_CLASS_OCR_TEXT) {
+    if (search == GRANDSEARCH_CLASS_FILE_DEEPIN || search == GRANDSEARCH_CLASS_OCR_TEXT
+        || search == GRANDSEARCH_CLASS_FILE_FULLTEXT) {
         ext.insert(GRANDSEARCH_PROPERTY_WEIGHT_METHOD,
                    GRANDSEARCH_PROPERTY_WEIGHT_METHOD_LOCALFILE);
     } else if (search == GRANDSEARCH_CLASS_APP_DESKTOP) {
@@ -493,6 +494,7 @@ void Utils::packageBestMatch(MatchedItemMap &map, int maxQuantity)
 
     static const QMap<QString, bool> supprotedSeracher = {
         { GRANDSEARCH_CLASS_FILE_DEEPIN, true },
+        { GRANDSEARCH_CLASS_FILE_FULLTEXT, true },
         { GRANDSEARCH_CLASS_APP_DESKTOP, true },
         { GRANDSEARCH_CLASS_SETTING_CONTROLCENTER, true },
         { GRANDSEARCH_CLASS_OCR_TEXT, true },


### PR DESCRIPTION
1. Extract embedded full-text search logic from FileNameWorker into new
standalone FullTextSearcher module with dedicated worker classes
2. Create FullTextSearcher, FullTextWorker and FullTextWorkerPrivate
classes to handle content search independently from filename search
3. Remove full-text search methods (checkFullTextSearchEnabled,
executeContentSearch, processContentSearchResults, cacheDocumentResult,
pushDocumentResults) and related state variables from FileNameWorker
4. Add GRANDSEARCH_CLASS_FILE_FULLTEXT to built-in searcher definitions
and default user preferences configuration
5. Register FullTextSearcher in SearcherGroup initialization alongside
other built-in searchers
6. Implement path-based deduplication with weight priority in
GroupWidget to handle duplicate items between filename and full-text
results
7. Add cross-group deduplication logic in MatchWidget to prevent
duplicates between Best Match group and other category groups while
respecting blacklist exceptions
8. Update Utils to recognize full-text searcher for weight method
assignment and best match packaging

Log: Full-text search now runs as independent searcher with improved
result deduplication and weight-based prioritization

Influence:
1. Test general keyword search without type prefix triggers both file
and full-text searchers
2. Verify full-text search results appear in Document and File groups
with highlighted content preview
3. Test deduplication when same file appears in both filename and full-
text results (higher weight 10 should replace lower weight)
4. Verify Best Match group properly deduplicates against other groups
while blacklist groups (video/audio/picture/document/folder) still show
their items
5. Test DConfig enableFullTextSearch setting properly activates/
deactivates the searcher
6. Verify combination search mode (with type keywords) excludes full-
text search automatically
7. Test content index availability detection (isContentIndexAvailable)
disables searcher when index missing
8. Check that disabling Document category in settings deactivates full-
text searcher
9. Verify full-text searcher respects MAX_SEARCH_NUM_GROUP limit (100
items)

refactor: 将全文搜索提取为独立搜索器

1. 将嵌入在 FileNameWorker 中的全文搜索逻辑提取到新的独立
FullTextSearcher 模块，包含专用工作类
2. 创建 FullTextSearcher、FullTextWorker 和 FullTextWorkerPrivate 类，独
立于文件名搜索处理内容搜索
3. 从 FileNameWorker 中移除全文搜索方法（checkFullTextSearchEnabled、
executeContentSearch、processContentSearchResults、cacheDocumentResult、
pushDocumentResults）和相关状态变量
4. 将 GRANDSEARCH_CLASS_FILE_FULLTEXT 添加到内置搜索器定义和默认用户偏好
配置中
5. 在 SearcherGroup 初始化中注册 FullTextSearcher，与其他内置搜索器并列
6. 在 GroupWidget 中实现基于路径的重复数据删除和权重优先级处理，处理文件
名和全文结果之间的重复项
7. 在 MatchWidget 中添加跨组重复数据删除逻辑，防止最佳匹配组与其他类别组
之间的重复，同时尊重黑名单例外
8. 更新 Utils 以识别全文搜索器，用于权重方法分配和最佳匹配打包

Log: 全文搜索现在作为独立搜索器运行，具有改进的结果去重和基于权重的优先
级排序功能

Influence:
1. 测试不带类型前缀的常规关键字搜索是否同时触发文件搜索和全文搜索
2. 验证全文搜索结果是否以高亮内容预览形式显示在文档和文件组中
3. 测试当同一文件同时出现在文件名和全文搜索结果中时进行去重（权重值10应
替换较低权重）
4. 验证最佳匹配组是否正确与其他组进行去重处理，同时黑名单组（视频/音频/
图片/文档/文件夹）仍应显示其项目
5. 测试 DConfig 的 enableFullTextSearch 设置是否正确激活/停用搜索器
6. 验证组合搜索模式（含类型关键字）是否自动排除全文搜索
7. 测试内容索引可用性检测（isContentIndexAvailable）在索引缺失时是否禁用
搜索器
8. 检查在设置中禁用文档类别是否会停用全文搜索器
9. 验证全文搜索器遵守 MAX_SEARCH_NUM_GROUP 限制（100个项目）

## Summary by Sourcery

Extract embedded full-text search from the filename searcher into a dedicated FullTextSearcher/FullTextWorker pipeline and integrate it into the searcher group and default configuration, while updating the UI and utilities to deduplicate results and respect weight-based prioritization between full-text, filename, and Best Match groups.

New Features:
- Introduce a standalone FullTextSearcher and FullTextWorker to handle indexed content search independently of filename search.
- Enable full-text search as a first-class built-in searcher, participating in general keyword searches and best-match packaging.
- Expose full-text search results with highlighted content previews in document and file groups.

Enhancements:
- Simplify FileNameWorker by removing embedded full-text search logic and related state.
- Add path-based, weight-aware deduplication in GroupWidget so higher-weight items replace lower-weight duplicates across file and document results.
- Add cross-group deduplication in MatchWidget so Best Match items take precedence over other groups except for whitelisted media and folder groups.
- Update Utils weighting logic to treat the full-text searcher as a local file source for ranking and best-match aggregation.

Build:
- Register the new full-text searcher and worker sources in the daemon CMake configuration.