### PR TITLE
feat: add reusable HighlightLabel widget for keyword highlighting

### DIFF
--- a/src/dde-grand-search-daemon/searcher/file/filenameworker.cpp
+++ b/src/dde-grand-search-daemon/searcher/file/filenameworker.cpp
@@ -23,9 +23,7 @@ FileNameWorkerPrivate::FileNameWorkerPrivate(FileNameWorker *qq)
     : q_ptr(qq)
 {
     qCDebug(logDaemon) << "FileNameWorkerPrivate constructor called";
-    m_searchPath = DFMSEARCH::Global::isFileNameIndexDirectoryAvailable()
-            ? QDir::rootPath()
-            : QDir::homePath();
+    m_searchPath = QDir::homePath();
     initConfig();
 }
 
@@ -96,18 +94,8 @@ bool FileNameWorkerPrivate::appendSearchResult(const QString &fileName)
         }
     }
 
-    if (!FileSearchUtils::fileShouldVisible(fileName, group, m_searchInfo)) {
-        qCDebug(logDaemon) << "File filtered by visibility rules:" << fileName;
-        return false;
-    }
-
     if (m_resultCountHash[group] >= MAX_SEARCH_NUM_GROUP)
         return false;
-
-    if (FileSearchUtils::filterByBlacklist(fileName)) {
-        qCDebug(logDaemon) << "File filtered by blacklist:" << fileName;
-        return false;
-    }
 
     m_tmpSearchResults << fileName;
     // Get keywords for highlighting
@@ -151,6 +139,10 @@ SearchOptions FileNameWorkerPrivate::createSearchOptions() const
 
     SearchOptions options;
     options.setSearchPath(m_searchPath);
+
+    auto config = Configer::instance()->group(GRANDSEARCH_BLACKLIST_GROUP);
+    auto blacklist = config->value(GRANDSEARCH_BLACKLIST_PATH, QStringList());
+    options.setSearchExcludedPaths(blacklist);
 
     // 检查文件名索引目录是否可用，如果不可用则回退到实时搜索
     if (DFMSEARCH::Global::isFileNameIndexDirectoryAvailable()) {

--- a/src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp
+++ b/src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp
@@ -17,7 +17,7 @@ Q_DECLARE_LOGGING_CATEGORY(logDaemon)
 
 using namespace GrandSearch;
 
-MatchedItem FileSearchUtils::packItem(const QString &fileName, const QString &searcher, const QStringList &keywords)
+MatchedItem FileSearchUtils::packItem(const QString &fileName, const QString &searcher, const QStringList &keywords, const QString &matchedContext)
 {
     qCDebug(logDaemon) << "Packing file item - File:" << fileName << "Searcher:" << searcher;
     QFileInfo fileInfo(fileName);
@@ -31,9 +31,12 @@ MatchedItem FileSearchUtils::packItem(const QString &fileName, const QString &se
 
     QVariantHash extraData = tailerData(fileInfo);
     // Inject keywords for highlighting
-    if (!keywords.isEmpty()) {
+    if (!keywords.isEmpty())
         extraData.insert(GRANDSEARCH_PROPERTY_ITEM_KEYWORDS, keywords);
-    }
+
+    if (!matchedContext.isEmpty())
+        extraData.insert(GRANDSEARCH_PROPERTY_ITEM_MATCHEDCONTEXT, matchedContext);
+
     item.extra = QVariant::fromValue(extraData);
 
     qCDebug(logDaemon) << "Item packed successfully - Name:" << item.name
@@ -203,57 +206,6 @@ FileSearchUtils::SearchInfo FileSearchUtils::parseContent(const QString &content
     info.keyword = QString(R"((%1).*)").arg(keywordList.join('|'));
     info.typeKeywords = keywordList;
     return info;
-}
-
-bool FileSearchUtils::fileShouldVisible(const QString &fileName, Group &group, const FileSearchUtils::SearchInfo &info)
-{
-    // 对组合搜索到的结果进行过滤
-    if (info.isCombinationSearch) {
-        if (!info.groupList.contains(group)) {
-            QFileInfo fileInfo(fileName);
-            if (fileInfo.isDir())
-                return false;
-
-            const auto &suffix = fileInfo.suffix();
-            if (suffix.isEmpty() || !info.suffixList.contains(suffix, Qt::CaseInsensitive)) {
-                if (info.groupList.contains(File)) {
-                    group = File;
-                    return true;
-                }
-
-                return false;
-            }
-        }
-    }
-
-    return true;
-}
-
-bool FileSearchUtils::filterByBlacklist(const QString &fileName)
-{
-    qCDebug(logDaemon) << "Checking blacklist filter for file:" << fileName;
-
-    // 过滤黑名单中的结果
-    // add "/" to the end of fileName to distinguish partially identical path
-    QString filePath = fileName + "/";
-    auto config = Configer::instance()->group(GRANDSEARCH_BLACKLIST_GROUP);
-    auto blacklist = config->value(GRANDSEARCH_BLACKLIST_PATH, QStringList());
-    if (blacklist.isEmpty()) {
-        qCDebug(logDaemon) << "Blacklist is empty - File not filtered:" << fileName;
-        return false;
-    }
-
-    qCDebug(logDaemon) << "Checking against blacklist - Entries:" << blacklist.size();
-    for (const auto &path : blacklist) {
-        if (filePath.startsWith(path)) {
-            qCDebug(logDaemon) << "File filtered by blacklist - File:" << fileName
-                               << "Blacklist path:" << path;
-            return true;
-        }
-    }
-
-    qCDebug(logDaemon) << "File passed blacklist filter:" << fileName;
-    return false;
 }
 
 QVariantHash FileSearchUtils::tailerData(const QFileInfo &info)

--- a/src/dde-grand-search-daemon/searcher/file/filesearchutils.h
+++ b/src/dde-grand-search-daemon/searcher/file/filesearchutils.h
@@ -35,14 +35,12 @@ public:
         QList<Group> groupList;             // 搜索类目表
     };
 
-    static MatchedItem packItem(const QString &fileName, const QString &searcher, const QStringList &keywords = QStringList());
+    static MatchedItem packItem(const QString &fileName, const QString &searcher, const QStringList &keywords = QStringList(), const QString &matchedContext = "");
     static QString groupKey(Group group);
     static Group getGroupByName(const QString &fileName);
     static Group getGroupBySuffix(const QString &suffix);
     static Group getGroupByGroupName(const QString &groupName);
     static SearchInfo parseContent(const QString &content);
-    static bool fileShouldVisible(const QString &fileName, Group &group, const SearchInfo &info);
-    static bool filterByBlacklist(const QString &fileName);
     static QVariantHash tailerData(const QFileInfo &info);
     static QStringList buildDFMSearchFileTypes(const QList<Group> &groupList);
     static bool isPinyin(const QString &str);

--- a/src/dde-grand-search-daemon/searcher/fulltext/fulltextworker.cpp
+++ b/src/dde-grand-search-daemon/searcher/fulltext/fulltextworker.cpp
@@ -41,6 +41,11 @@ bool FullTextWorkerPrivate::doSearch()
 
     SearchOptions options;
     options.setSearchPath(m_searchPath);
+
+    auto config = Configer::instance()->group(GRANDSEARCH_BLACKLIST_GROUP);
+    auto blacklist = config->value(GRANDSEARCH_BLACKLIST_PATH, QStringList());
+    options.setSearchExcludedPaths(blacklist);
+
     options.setSearchMethod(SearchMethod::Indexed);
     options.setMaxResults(MAX_SEARCH_NUM_GROUP);
 
@@ -99,20 +104,16 @@ bool FullTextWorkerPrivate::processResults(const SearchResultExpected &result)
         }
 
         m_tmpSearchResults << filePath;
-        MatchedItem item = FileSearchUtils::packItem(filePath, q->name(), keywords);
-
-        // Set higher weight so frontend dedup prefers content results over filename results
-        QVariantHash extra = item.extra.toHash();
-        extra.insert(GRANDSEARCH_PROPERTY_ITEM_WEIGHT, 10);
 
         // Get highlighted content preview
         SearchResult mutableResult = const_cast<SearchResult &>(file);
         ContentResultAPI contentResult(mutableResult);
         QString highlightedContent = contentResult.highlightedContent();
-        if (!highlightedContent.isEmpty()) {
-            extra.insert(GRANDSEARCH_PROPERTY_ITEM_MATCHEDCONTEXT, highlightedContent);
-        }
+        MatchedItem item = FileSearchUtils::packItem(filePath, q->name(), keywords, highlightedContent);
 
+        // Set higher weight so frontend dedup prefers content results over filename results
+        QVariantHash extra = item.extra.toHash();
+        extra.insert(GRANDSEARCH_PROPERTY_ITEM_WEIGHT, 10);
         item.extra = extra;
 
         // Add to Document category

--- a/src/dde-grand-search-daemon/searcher/ocr/ocrtextworker.cpp
+++ b/src/dde-grand-search-daemon/searcher/ocr/ocrtextworker.cpp
@@ -4,7 +4,7 @@
 
 #include "ocrtextworker_p.h"
 #include "global/builtinsearch.h"
-#include "utils/specialtools.h"
+#include "configuration/configer.h"
 #include "searcher/file/filesearchutils.h"
 #include "global/searchhelper.h"
 
@@ -40,6 +40,11 @@ DFMSEARCH::SearchOptions OcrTextWorkerPrivate::createSearchOptions() const
 
     SearchOptions options;
     options.setSearchPath(QDir::homePath());
+
+    auto config = Configer::instance()->group(GRANDSEARCH_BLACKLIST_GROUP);
+    auto blacklist = config->value(GRANDSEARCH_BLACKLIST_PATH, QStringList());
+    options.setSearchExcludedPaths(blacklist);
+
     options.setSearchMethod(SearchMethod::Indexed);
     options.setMaxResults(MAX_SEARCH_NUM);
     qCDebug(logDaemon) << "OCR search options configured - Max results:" << MAX_SEARCH_NUM;
@@ -92,21 +97,11 @@ bool OcrTextWorkerPrivate::processSearchResults(const DFMSEARCH::SearchResultExp
 
         m_tmpSearchResults << filePath;
 
-        // Create matched item with keywords for highlighting
-        GrandSearch::MatchedItem item = FileSearchUtils::packItem(filePath, q->name(), QStringList { m_keywords });
-
         // Get OCR content and store in extra field
-        QVariantHash extra = item.extra.toHash();
         DFMSEARCH::SearchResult mutableResult = const_cast<DFMSEARCH::SearchResult &>(file);
         OcrTextResultAPI ocrResult(const_cast<SearchResult &>(mutableResult));
         QString ocrContent = ocrResult.highlightedContent();
-        if (!ocrContent.isEmpty()) {
-            extra.insert(GRANDSEARCH_PROPERTY_ITEM_MATCHEDCONTEXT, ocrContent);
-            qCDebug(logDaemon) << "OCR content found for file:" << filePath
-                               << "Content length:" << ocrContent.length();
-        }
-
-        item.extra = extra;
+        GrandSearch::MatchedItem item = FileSearchUtils::packItem(filePath, q->name(), m_keywords, ocrContent);
 
         {
             QMutexLocker lk(&m_mutex);

--- a/src/global/widgets/highlightlabel.cpp
+++ b/src/global/widgets/highlightlabel.cpp
@@ -1,0 +1,437 @@
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "global/widgets/highlightlabel.h"
+
+#include <QPainter>
+#include <QPaintEvent>
+#include <QResizeEvent>
+#include <QFontMetrics>
+#include <QRegularExpression>
+#include <QEvent>
+
+namespace {
+
+struct ElideResult
+{
+    QString text;
+    QVector<int> origPositions;   // text[i] -> original char position, -1 for ellipsis char
+};
+
+static int charWidth(const QFontMetrics &fm, QChar ch)
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    return fm.width(ch);
+#else
+    return fm.horizontalAdvance(ch);
+#endif
+}
+
+static int textWidth(const QFontMetrics &fm, const QString &text)
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    return fm.width(text);
+#else
+    return fm.horizontalAdvance(text);
+#endif
+}
+
+ElideResult elideWithTracking(const QString &text, Qt::TextElideMode mode,
+                              int maxWidth, const QFontMetrics &fm)
+{
+    ElideResult result;
+    if (text.isEmpty())
+        return result;
+
+    const QString ellipsis = QStringLiteral("…");
+    int ellipsisWidth = charWidth(fm, QChar(0x2026));
+
+    if (textWidth(fm, text) <= maxWidth) {
+        // No eliding needed
+        result.text = text;
+        result.origPositions.resize(text.length());
+        for (int i = 0; i < text.length(); ++i)
+            result.origPositions[i] = i;
+        return result;
+    }
+
+    if (maxWidth <= ellipsisWidth) {
+        // Not enough room even for ellipsis alone
+        result.text = ellipsis;
+        result.origPositions = { -1 };
+        return result;
+    }
+
+    int availWidth = maxWidth - ellipsisWidth;
+
+    switch (mode) {
+    case Qt::ElideRight: {
+        int w = 0;
+        int keep = 0;
+        for (int i = 0; i < text.length(); ++i) {
+            int cw = charWidth(fm, text[i]);
+            if (w + cw > availWidth)
+                break;
+            w += cw;
+            ++keep;
+        }
+        result.text = text.left(keep) + ellipsis;
+        result.origPositions.resize(result.text.length());
+        for (int i = 0; i < keep; ++i)
+            result.origPositions[i] = i;
+        result.origPositions[keep] = -1;   // ellipsis
+        break;
+    }
+    case Qt::ElideMiddle: {
+        // Binary-search style: try different head/tail splits from largest to smallest
+        int total = text.length();
+        int bestKeep = 0;
+        for (int tryChars = total - 1; tryChars >= 1; --tryChars) {
+            int head = tryChars / 2;
+            int tail = tryChars - head;
+            if (head < 0 || tail < 0 || head + tail > total)
+                continue;
+            int w = textWidth(fm, text.left(head)) + textWidth(fm, text.right(tail));
+            if (w <= availWidth) {
+                bestKeep = tryChars;
+                break;
+            }
+        }
+        if (bestKeep == 0) {
+            // Nothing fits besides ellipsis
+            result.text = ellipsis;
+            result.origPositions = { -1 };
+            break;
+        }
+        int head = bestKeep / 2;
+        int tail = bestKeep - head;
+        result.text = text.left(head) + ellipsis + text.right(tail);
+        result.origPositions.resize(result.text.length());
+        for (int i = 0; i < head; ++i)
+            result.origPositions[i] = i;
+        result.origPositions[head] = -1;   // ellipsis
+        for (int i = 0; i < tail; ++i)
+            result.origPositions[head + 1 + i] = total - tail + i;
+        break;
+    }
+    case Qt::ElideLeft: {
+        int w = 0;
+        int keep = 0;
+        for (int i = text.length() - 1; i >= 0; --i) {
+            int cw = charWidth(fm, text[i]);
+            if (w + cw > availWidth)
+                break;
+            w += cw;
+            ++keep;
+        }
+        result.text = ellipsis + text.right(keep);
+        result.origPositions.resize(result.text.length());
+        result.origPositions[0] = -1;   // ellipsis
+        for (int i = 0; i < keep; ++i)
+            result.origPositions[1 + i] = text.length() - keep + i;
+        break;
+    }
+    case Qt::ElideNone:
+    default:
+        result.text = text;
+        result.origPositions.resize(text.length());
+        for (int i = 0; i < text.length(); ++i)
+            result.origPositions[i] = i;
+        break;
+    }
+
+    return result;
+}
+
+}   // anonymous namespace
+
+HighlightLabel::HighlightLabel(QWidget *parent, Qt::WindowFlags f)
+    : QLabel(parent, f)
+{
+    setTextFormat(Qt::PlainText);
+    m_textOption.setWrapMode(QTextOption::WrapAnywhere);
+}
+
+void HighlightLabel::setPlainText(const QString &text)
+{
+    if (m_text == text)
+        return;
+    m_text = text;
+    relayout();
+}
+
+void HighlightLabel::setKeywords(const QStringList &keywords)
+{
+    if (m_keywords == keywords)
+        return;
+    m_keywords = keywords;
+    relayout();
+}
+
+void HighlightLabel::setElideMode(Qt::TextElideMode mode)
+{
+    if (m_elideMode == mode)
+        return;
+    m_elideMode = mode;
+    relayout();
+}
+
+void HighlightLabel::setMaxLines(int lines)
+{
+    if (m_maxLines == lines)
+        return;
+    m_maxLines = lines;
+    relayout();
+}
+
+Qt::TextElideMode HighlightLabel::elideMode() const
+{
+    return m_elideMode;
+}
+
+int HighlightLabel::maxLines() const
+{
+    return m_maxLines;
+}
+
+bool HighlightLabel::isElided() const
+{
+    return m_elided;
+}
+
+QSize HighlightLabel::sizeHint() const
+{
+    if (m_text.isEmpty())
+        return QSize(0, 0);
+    return m_layout.boundingRect().size().toSize();
+}
+
+QSize HighlightLabel::minimumSizeHint() const
+{
+    return sizeHint();
+}
+
+void HighlightLabel::relayout()
+{
+    doLayout();
+    update();
+}
+
+void HighlightLabel::doLayout()
+{
+    m_textOption.setAlignment(alignment());
+    m_layout.clearLayout();
+    m_elided = false;
+
+    if (m_text.isEmpty()) {
+        m_layout.setText("");
+        updateGeometry();
+        return;
+    }
+
+    int layoutWidth = contentsRect().width();
+    if (layoutWidth <= 0) {
+        m_layout.setText("");
+        updateGeometry();
+        return;
+    }
+
+    ElideInfo info = computeElidedText(layoutWidth);
+    m_elided = info.elided;
+    buildFinalLayout(info.displayText, info.origPosMapping, layoutWidth);
+}
+
+HighlightLabel::ElideInfo HighlightLabel::computeElidedText(int layoutWidth) const
+{
+    ElideInfo info;
+    info.displayText = m_text;
+
+    if (m_maxLines <= 0)
+        return info;
+
+    QTextLayout probeLayout(m_text, font());
+    probeLayout.setTextOption(m_textOption);
+
+    probeLayout.beginLayout();
+    for (int i = 0; i < m_maxLines; ++i) {
+        QTextLine line = probeLayout.createLine();
+        if (!line.isValid())
+            break;
+        line.setLineWidth(layoutWidth);
+
+        if (i == m_maxLines - 1) {
+            int consumed = line.textStart() + line.textLength();
+            if (consumed < m_text.length()) {
+                info.elided = true;
+                QFontMetrics fm(font());
+                QString remaining = m_text.mid(line.textStart());
+                // For multi-line text, use left elision on the last line to show the end
+                Qt::TextElideMode lastLineElideMode = (m_maxLines > 1 && m_elideMode == Qt::ElideMiddle) ? Qt::ElideLeft : m_elideMode;
+                ElideResult elideResult = elideWithTracking(remaining, lastLineElideMode, layoutWidth, fm);
+                info.displayText = m_text.left(line.textStart()) + elideResult.text;
+
+                // Build full position mapping: identity for head, elideResult mapping for tail
+                info.origPosMapping.resize(info.displayText.length());
+                int headLen = line.textStart();
+                for (int j = 0; j < headLen; ++j)
+                    info.origPosMapping[j] = j;
+                for (int j = 0; j < elideResult.origPositions.size(); ++j) {
+                    int origPos = elideResult.origPositions[j];
+                    info.origPosMapping[headLen + j] = (origPos == -1) ? -1 : (line.textStart() + origPos);
+                }
+            }
+        }
+    }
+    probeLayout.endLayout();
+
+    return info;
+}
+
+void HighlightLabel::buildFinalLayout(const QString &displayText, const QVector<int> &origPosMapping, int layoutWidth)
+{
+    QVector<QTextLayout::FormatRange> formats = buildFormatRanges(displayText, origPosMapping);
+
+    m_layout.clearLayout();
+    m_layout.setText(displayText);
+    m_layout.setFont(font());
+    m_layout.setTextOption(m_textOption);
+    m_layout.setFormats(formats);
+
+    m_layout.beginLayout();
+    int lineIndex = 0;
+    qreal height = 0;
+    QFontMetrics fm(font());
+    qreal lineHeight = fm.height();
+
+    while (true) {
+        QTextLine line = m_layout.createLine();
+        if (!line.isValid())
+            break;
+        line.setLineWidth(layoutWidth);
+        line.setPosition(QPointF(0, height));
+        height += lineHeight;
+        ++lineIndex;
+        if (m_maxLines > 0 && lineIndex >= m_maxLines)
+            break;
+    }
+    m_layout.endLayout();
+
+    updateGeometry();
+}
+
+QVector<QTextLayout::FormatRange> HighlightLabel::buildFormatRanges(
+        const QString &displayText, const QVector<int> &origPosMapping) const
+{
+    QVector<QTextLayout::FormatRange> ranges;
+
+    if (m_keywords.isEmpty() || displayText.isEmpty())
+        return ranges;
+
+    QTextCharFormat fmt;
+    fmt.setFont(font());
+    fmt.setFontWeight(QFont::DemiBold);
+    fmt.setForeground(palette().color(QPalette::BrightText));
+
+    if (origPosMapping.isEmpty()) {
+        // Non-elided case: find matches directly in displayText
+        for (const QString &keyword : m_keywords) {
+            if (keyword.isEmpty())
+                continue;
+            QRegularExpression re(QRegularExpression::escape(keyword),
+                                  QRegularExpression::CaseInsensitiveOption);
+            QRegularExpressionMatchIterator it = re.globalMatch(displayText);
+            while (it.hasNext()) {
+                QRegularExpressionMatch match = it.next();
+                QTextLayout::FormatRange range;
+                range.start = match.capturedStart();
+                range.length = match.capturedLength();
+                range.format = fmt;
+                ranges.append(range);
+            }
+        }
+    } else {
+        // Elided case: find matches in original text, map to display positions
+        for (const QString &keyword : m_keywords) {
+            if (keyword.isEmpty())
+                continue;
+            QRegularExpression re(QRegularExpression::escape(keyword),
+                                  QRegularExpression::CaseInsensitiveOption);
+            QRegularExpressionMatchIterator it = re.globalMatch(m_text);
+            while (it.hasNext()) {
+                QRegularExpressionMatch match = it.next();
+                int origStart = match.capturedStart();
+                int origEnd = origStart + match.capturedLength();
+
+                // Scan display positions to find contiguous visible sub-ranges
+                int rangeStart = -1;
+                for (int i = 0; i < displayText.length(); ++i) {
+                    int origPos = origPosMapping.value(i, -1);
+                    bool inMatch = (origPos >= origStart && origPos < origEnd);
+                    if (inMatch) {
+                        if (rangeStart == -1)
+                            rangeStart = i;
+                    } else {
+                        if (rangeStart != -1) {
+                            QTextLayout::FormatRange range;
+                            range.start = rangeStart;
+                            range.length = i - rangeStart;
+                            range.format = fmt;
+                            ranges.append(range);
+                            rangeStart = -1;
+                        }
+                    }
+                }
+                // Close any trailing range
+                if (rangeStart != -1) {
+                    QTextLayout::FormatRange range;
+                    range.start = rangeStart;
+                    range.length = displayText.length() - rangeStart;
+                    range.format = fmt;
+                    ranges.append(range);
+                }
+            }
+        }
+    }
+
+    return ranges;
+}
+
+void HighlightLabel::paintEvent(QPaintEvent *event)
+{
+    Q_UNUSED(event);
+
+    if (m_text.isEmpty())
+        return;
+
+    QPainter painter(this);
+
+    QRectF layoutRect = m_layout.boundingRect();
+    Qt::Alignment align = alignment();
+
+    // Vertical alignment
+    qreal y = 0;
+    Qt::Alignment vAlign = align & Qt::AlignVertical_Mask;
+    if (vAlign & Qt::AlignBottom)
+        y = height() - layoutRect.height();
+    else if (vAlign & Qt::AlignVCenter)
+        y = (height() - layoutRect.height()) / 2.0;
+
+    // Draw the entire layout at the calculated position
+    m_layout.draw(&painter, QPointF(0, y));
+}
+
+void HighlightLabel::resizeEvent(QResizeEvent *event)
+{
+    QLabel::resizeEvent(event);
+    relayout();
+}
+
+void HighlightLabel::changeEvent(QEvent *event)
+{
+    if (event->type() == QEvent::FontChange
+        || event->type() == QEvent::PaletteChange) {
+        relayout();
+    }
+    QLabel::changeEvent(event);
+}

--- a/src/global/widgets/highlightlabel.cpp
+++ b/src/global/widgets/highlightlabel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/global/widgets/highlightlabel.h
+++ b/src/global/widgets/highlightlabel.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/global/widgets/highlightlabel.h
+++ b/src/global/widgets/highlightlabel.h
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef HIGHLIGHTLABEL_H
+#define HIGHLIGHTLABEL_H
+
+#include <QLabel>
+#include <QTextLayout>
+
+class HighlightLabel : public QLabel
+{
+    Q_OBJECT
+public:
+    explicit HighlightLabel(QWidget *parent = nullptr, Qt::WindowFlags f = {});
+
+    void setPlainText(const QString &text);
+    void setKeywords(const QStringList &keywords);
+    void setElideMode(Qt::TextElideMode mode);
+    void setMaxLines(int lines);
+
+    Qt::TextElideMode elideMode() const;
+    int maxLines() const;
+    bool isElided() const;
+
+    QSize sizeHint() const override;
+    QSize minimumSizeHint() const override;
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+    void resizeEvent(QResizeEvent *event) override;
+    void changeEvent(QEvent *event) override;
+
+private:
+    struct ElideInfo {
+        QString displayText;
+        QVector<int> origPosMapping; // display char -> original char position, empty = identity
+        bool elided = false;
+    };
+
+    void relayout();
+    void doLayout();
+    ElideInfo computeElidedText(int layoutWidth) const;
+    void buildFinalLayout(const QString &displayText, const QVector<int> &origPosMapping, int layoutWidth);
+    QVector<QTextLayout::FormatRange> buildFormatRanges(
+        const QString &displayText,
+        const QVector<int> &origPosMapping = {}) const;
+
+    QString m_text;
+    QStringList m_keywords;
+    Qt::TextElideMode m_elideMode = Qt::ElideRight;
+    int m_maxLines = 1;
+    QTextLayout m_layout;
+    QTextOption m_textOption;
+    bool m_elided = false;
+};
+
+#endif // HIGHLIGHTLABEL_H

--- a/src/grand-search/CMakeLists.txt
+++ b/src/grand-search/CMakeLists.txt
@@ -188,6 +188,9 @@ set(GUISRC
     gui/searchconfig/intelligentretrieval/autoindexstatus.h
     gui/searchconfig/tipslabel.h
     gui/searchconfig/tipslabel.cpp
+    # shared widgets
+    ../global/widgets/highlightlabel.h
+    ../global/widgets/highlightlabel.cpp
     )
 
 # business

--- a/src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp
+++ b/src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp
@@ -6,11 +6,11 @@
 #include "generalpreviewplugin.h"
 #include "utils/utils.h"
 #include "global/commontools.h"
+#include "global/widgets/highlightlabel.h"
 
 #include <DFontSizeManager>
 #include <DMessageBox>
 #include <DGuiApplicationHelper>
-#include <DTipLabel>
 
 #include <QIcon>
 #include <QGuiApplication>
@@ -18,7 +18,6 @@
 #include <QToolButton>
 #include <QPainter>
 #include <QLoggingCategory>
-#include <QRegularExpression>
 
 Q_DECLARE_LOGGING_CATEGORY(logGrandSearch)
 
@@ -31,55 +30,6 @@ using namespace GrandSearch;
 
 DWIDGET_USE_NAMESPACE
 DGUI_USE_NAMESPACE
-
-namespace {
-// Helper function to highlight keywords with bold text
-QString highlightKeywords(const QString &text, const QStringList &keywords) {
-    if (text.isEmpty())
-        return QString();
-
-    QString result = text.toHtmlEscaped();
-    for (const QString &keyword : keywords) {
-        if (keyword.isEmpty())
-            continue;
-        QString escapedKeyword = keyword.toHtmlEscaped();
-        // Use rich text <b> tag for bold highlighting, case-insensitive
-        QRegularExpression re(QRegularExpression::escape(escapedKeyword),
-                              QRegularExpression::CaseInsensitiveOption);
-        QRegularExpressionMatch match;
-        int pos = 0;
-        while ((pos = result.indexOf(re, pos, &match)) != -1) {
-            QString matched = match.captured(0);
-            result.replace(pos, matched.length(), QString("<b>%1</b>").arg(matched));
-            pos += matched.length() + 7;  // 7 = length of "<b></b>"
-        }
-    }
-    // Convert newlines to <br> for rich text display
-    result.replace('\n', "<br>");
-    return result;
-}
-} // namespace
-
-NameLabel::NameLabel(const QString &text, QWidget *parent, Qt::WindowFlags f):
-    QLabel(text, parent, f)
-{
-    setObjectName("NameLabel");
-    setFixedWidth(NAME_WIDTH);
-
-    QFont titleFont = this->font();
-    titleFont.setWeight(QFont::Medium);
-    titleFont = DFontSizeManager::instance()->get(DFontSizeManager::T5, titleFont);
-    this->setFont(titleFont);
-
-    QColor textColor(0, 0, 0, int(255 * 0.9));
-    if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType)
-        textColor = QColor(255, 255, 255, int(255 * 0.9));
-    QPalette pa = palette();
-    pa.setColor(QPalette::WindowText, textColor);
-    setPalette(pa);
-
-    setAlignment(Qt::AlignBottom | Qt::AlignLeft);
-}
 
 SizeLabel::SizeLabel(const QString &text, QWidget *parent, Qt::WindowFlags f):
     QLabel(text, parent, f)
@@ -104,11 +54,33 @@ GeneralPreviewPluginPrivate::GeneralPreviewPluginPrivate(GeneralPreviewPlugin *p
     m_iconLabel = new QLabel(m_contentWidget);
     m_iconLabel->setObjectName("IconLabel");
     m_iconLabel->setFixedSize(QSize(ICON_SIZE, ICON_SIZE));
-    m_nameLabel = new NameLabel("", m_contentWidget);
-    m_contentLabel = new DTipLabel("", m_contentWidget);
+
+    // 名称标签：中间省略，最多2行
+    m_nameLabel = new HighlightLabel(m_contentWidget);
+    m_nameLabel->setObjectName("NameLabel");
+    m_nameLabel->setFixedWidth(NAME_WIDTH);
+    QFont titleFont = DFontSizeManager::instance()->get(DFontSizeManager::T5, QFont::Normal);
+    m_nameLabel->setFont(titleFont);
+    QPalette pa = m_nameLabel->palette();
+    QColor textColor = pa.brightText().color();
+    textColor.setAlpha(255 * 0.9);
+    pa.setColor(QPalette::WindowText, textColor);
+    m_nameLabel->setPalette(pa);
+    m_nameLabel->setElideMode(Qt::ElideMiddle);
+    m_nameLabel->setMaxLines(2);
+
+    // 内容标签：右省略，最多3行
+    m_contentLabel = new HighlightLabel(m_contentWidget);
+    pa = m_contentLabel->palette();
+    textColor = pa.brightText().color();
+    textColor.setAlpha(255 * 0.5);
+    pa.setColor(QPalette::WindowText, textColor);
+    QFont contentFont = DFontSizeManager::instance()->get(DFontSizeManager::T7, QFont::Normal);
+    m_contentLabel->setFont(contentFont);
+    m_contentLabel->setPalette(pa);
     m_contentLabel->setFixedWidth(NAME_WIDTH);
-    m_contentLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
-    m_contentLabel->setWordWrap(true);
+    m_contentLabel->setElideMode(Qt::ElideRight);
+    m_contentLabel->setMaxLines(3);
 
     QVBoxLayout *vLayout = new QVBoxLayout();
     vLayout->setContentsMargins(0, 0, 0, 0);
@@ -179,7 +151,12 @@ bool GeneralPreviewPlugin::previewItem(const ItemInfo &info)
     QStringList keywords;
     QString keywordsStr = info.value(PREVIEW_ITEMINFO_KEYWORDS);
     if (!keywordsStr.isEmpty()) {
-        keywords = keywordsStr.split(",", Qt::SkipEmptyParts);
+        keywords = keywordsStr.split(":", Qt::SkipEmptyParts);
+    }
+
+    if (!keywords.isEmpty()) {
+        QVariantHash extraHash { { GRANDSEARCH_PROPERTY_ITEM_KEYWORDS, keywords } };
+        item.extra = extraHash;
     }
 
     qCDebug(logGrandSearch) << "General preview item - Name:" << item.name
@@ -191,8 +168,12 @@ bool GeneralPreviewPlugin::previewItem(const ItemInfo &info)
             && !item.name.isEmpty()
             && d_p->m_item.item == item.item
             && d_p->m_item.name == item.name) {
-        qCDebug(logGrandSearch) << "Item already previewed - skipping";
-        return true;
+        const auto &extra = d_p->m_item.extra.toHash();
+        const auto &itemKeywords = extra.value(GRANDSEARCH_PROPERTY_ITEM_KEYWORDS, QStringList()).toStringList();
+        if (!keywords.isEmpty() && keywords == itemKeywords) {
+            qCDebug(logGrandSearch) << "Item already previewed - skipping";
+            return true;
+        }
     }
 
     d_p->m_item = item;
@@ -221,28 +202,26 @@ bool GeneralPreviewPlugin::previewItem(const ItemInfo &info)
     }
     d_p->m_iconLabel->setPixmap(pixmap);
 
-    // 设置名称，并计算换行内容，应用关键词高亮
-    QString elidedText = CommonTools::lineFeed(item.name, d_p->m_nameLabel->width(), d_p->m_nameLabel->font(), 2);
-    if (!keywords.isEmpty()) {
-        d_p->m_nameLabel->setText(highlightKeywords(elidedText, keywords));
-    } else {
-        d_p->m_nameLabel->setText(elidedText);
-    }
-    if (elidedText != item.name)
+    // 设置名称，关键词高亮在 HighlightLabel 内部处理
+    d_p->m_nameLabel->setPlainText(item.name);
+    d_p->m_nameLabel->setKeywords(keywords);
+    if (d_p->m_nameLabel->isElided())
         d_p->m_nameLabel->setToolTip(item.name);
+    else
+        d_p->m_nameLabel->setToolTip("");
 
-    // 设置匹配内容，最多显示3行，超出部分行尾省略，应用关键词高亮
+    // 设置匹配内容，关键词高亮在 HighlightLabel 内部处理
     if (!matchedContext.isEmpty()) {
-        QString elidedContext = CommonTools::lineFeed(matchedContext, d_p->m_contentLabel->width(), d_p->m_contentLabel->font(), 3);
-        if (!keywords.isEmpty()) {
-            d_p->m_contentLabel->setText(highlightKeywords(elidedContext, keywords));
-        } else {
-            d_p->m_contentLabel->setText(elidedContext);
-        }
-        if (elidedContext != matchedContext)
+        d_p->m_contentLabel->setPlainText(matchedContext);
+        d_p->m_contentLabel->setKeywords(keywords);
+        if (d_p->m_contentLabel->isElided())
             d_p->m_contentLabel->setToolTip(matchedContext);
+        else
+            d_p->m_contentLabel->setToolTip("");
     } else {
-        d_p->m_contentLabel->clear();
+        d_p->m_contentLabel->setPlainText("");
+        d_p->m_contentLabel->setKeywords(QStringList());
+        d_p->m_contentLabel->setToolTip("");
     }
     QFileInfo fi(item.item);
 

--- a/src/grand-search/gui/exhibition/preview/generalpreviewplugin_p.h
+++ b/src/grand-search/gui/exhibition/preview/generalpreviewplugin_p.h
@@ -18,17 +18,11 @@
 
 DWIDGET_BEGIN_NAMESPACE
 class DHorizontalLine;
-class DTipLabel;
 DWIDGET_END_NAMESPACE
 
-namespace GrandSearch {
+class HighlightLabel;
 
-class NameLabel: public QLabel
-{
-    Q_OBJECT
-public:
-    explicit NameLabel(const QString &text = "", QWidget *parent = nullptr, Qt::WindowFlags f = {});
-};
+namespace GrandSearch {
 
 class SizeLabel: public QLabel
 {
@@ -42,7 +36,7 @@ class GeneralPreviewPluginPrivate
 {
 public:
     explicit GeneralPreviewPluginPrivate(GeneralPreviewPlugin *parent = nullptr);
-    ~GeneralPreviewPluginPrivate();    
+    ~GeneralPreviewPluginPrivate();
 
     GeneralPreviewPlugin *q_p = nullptr;
 
@@ -55,8 +49,8 @@ public:
 
     // 图标和名称
     QLabel *m_iconLabel = nullptr;
-    NameLabel *m_nameLabel = nullptr;
-    DTK_WIDGET_NAMESPACE::DTipLabel *m_contentLabel = nullptr;
+    HighlightLabel *m_nameLabel = nullptr;
+    HighlightLabel *m_contentLabel = nullptr;
 
     // 大小
     SizeLabel *m_sizeLabel = nullptr;

--- a/src/grand-search/gui/exhibition/preview/previewwidget.cpp
+++ b/src/grand-search/gui/exhibition/preview/previewwidget.cpp
@@ -95,7 +95,7 @@ bool PreviewWidget::previewItem(const MatchedItem &item)
 
     // Pass keywords for highlighting
     if (extraHash.contains(GRANDSEARCH_PROPERTY_ITEM_KEYWORDS)) {
-        itemInfo[PREVIEW_ITEMINFO_KEYWORDS] = extraHash.value(GRANDSEARCH_PROPERTY_ITEM_KEYWORDS).toStringList().join(",");
+        itemInfo[PREVIEW_ITEMINFO_KEYWORDS] = extraHash.value(GRANDSEARCH_PROPERTY_ITEM_KEYWORDS).toStringList().join(":");
     }
 
     preview->previewItem(itemInfo);

--- a/src/grand-search/thumbnail/generators/textthumbnailgenerator.cpp
+++ b/src/grand-search/thumbnail/generators/textthumbnailgenerator.cpp
@@ -31,7 +31,6 @@ bool TextThumbnailGenerator::canHandle(const QString &mimetype) const
     // 支持一些常见的文本格式
     static const QStringList textMimes = {
         "application/json",
-        "application/xml",
         "application/javascript",
         "application/x-yaml",
         "application/x-sh",

--- a/src/grand-search/utils/utils.cpp
+++ b/src/grand-search/utils/utils.cpp
@@ -286,13 +286,16 @@ void Utils::updateItemsWeight(MatchedItemMap &map, const QString &content)
             {
                 const QVariantHash &extData = item.extra.toHash();
                 const QString &method = extData.value(GRANDSEARCH_PROPERTY_WEIGHT_METHOD).toString();
+                // 已经设置权重基础数值
+                if (extData.contains(GRANDSEARCH_PROPERTY_ITEM_WEIGHT))
+                    weight = extData.value(GRANDSEARCH_PROPERTY_ITEM_WEIGHT).toDouble();
 
                 if (method == GRANDSEARCH_PROPERTY_WEIGHT_METHOD_LOCALFILE) {
-                    weight = calcFileWeight(item.item, item.name, keys);
+                    weight += calcFileWeight(item.item, item.name, keys);
                 } else if (method == GRANDSEARCH_PROPERTY_WEIGHT_METHOD_APP) {
-                    weight = calcAppWeight(item, keys);
+                    weight += calcAppWeight(item, keys);
                 } else if (method == GRANDSEARCH_PROPERTY_WEIGHT_METHOD_SETTING) {
-                    weight = calcSettingWeight(item, keys);
+                    weight += calcSettingWeight(item, keys);
                 } else {
                     continue;
                 }
@@ -314,10 +317,6 @@ void Utils::updateItemsWeight(MatchedItemMap &map, const QString &content)
 bool Utils::setWeightMethod(MatchedItem &item)
 {
     QVariantHash ext = item.extra.toHash();
-
-    // 已经设置权重数值
-    if (ext.contains(GRANDSEARCH_PROPERTY_ITEM_WEIGHT))
-        return false;
 
     // 已经设置了计算方法
     if (ext.contains(GRANDSEARCH_PROPERTY_WEIGHT_METHOD))

--- a/src/grand-search/utils/utils.cpp
+++ b/src/grand-search/utils/utils.cpp
@@ -1016,7 +1016,9 @@ QIcon Utils::defaultIcon(const MatchedItem &item)
 {
     if (item.searcher == GRANDSEARCH_CLASS_APP_DESKTOP)
         return QIcon::fromTheme("application-x-desktop");
-    else if (item.searcher == GRANDSEARCH_CLASS_FILE_DEEPIN) {
+    else if (item.searcher == GRANDSEARCH_CLASS_FILE_DEEPIN ||
+             item.searcher == GRANDSEARCH_CLASS_FILE_FULLTEXT ||
+             item.searcher == GRANDSEARCH_CLASS_OCR_TEXT) {
         return QIcon::fromTheme(m_mimeDb.mimeTypeForFile(item.item).genericIconName());
     } else if (item.searcher == GRANDSEARCH_CLASS_WEB_STATICTEXT) {
         // 使用默认浏览器的图标

--- a/src/preview-plugin/image-preview/CMakeLists.txt
+++ b/src/preview-plugin/image-preview/CMakeLists.txt
@@ -11,6 +11,8 @@ set(SRCS
     imagepreviewplugin.cpp
     imageview.h
     imageview.cpp
+    ${CMAKE_SOURCE_DIR}/src/global/widgets/highlightlabel.h
+    ${CMAKE_SOURCE_DIR}/src/global/widgets/highlightlabel.cpp
 )
 
 add_library(${LIB_NAME} SHARED ${SRCS} ${QRCS})

--- a/src/preview-plugin/image-preview/imageview.cpp
+++ b/src/preview-plugin/image-preview/imageview.cpp
@@ -5,11 +5,11 @@
 #include "imagepreview_global.h"
 #include "imageview.h"
 #include "global/commontools.h"
+#include "global/widgets/highlightlabel.h"
 
-#include <DLabel>
 #include <DFontSizeManager>
 #include <DGuiApplicationHelper>
-#include <DTipLabel>
+#include <DWidget>
 
 #include <QDebug>
 #include <QtConcurrent>
@@ -19,9 +19,7 @@
 #include <QImageReader>
 #include <QBitmap>
 #include <QPainterPath>
-#include <QFontMetrics>
 #include <QLoggingCategory>
-#include <QRegularExpression>
 
 Q_DECLARE_LOGGING_CATEGORY(logImagePreview)
 
@@ -30,35 +28,9 @@ Q_DECLARE_LOGGING_CATEGORY(logImagePreview)
 #define ROUNDRADIUS     8
 
 DWIDGET_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 GRANDSEARCH_USE_NAMESPACE
 using namespace GrandSearch::image_preview;
-
-namespace {
-// Helper function to highlight keywords with bold text
-QString highlightKeywords(const QString &text, const QStringList &keywords) {
-    if (text.isEmpty())
-        return QString();
-
-    QString result = text.toHtmlEscaped();
-    for (const QString &keyword : keywords) {
-        if (keyword.isEmpty())
-            continue;
-        QString escapedKeyword = keyword.toHtmlEscaped();
-        QRegularExpression re(QRegularExpression::escape(escapedKeyword),
-                              QRegularExpression::CaseInsensitiveOption);
-        QRegularExpressionMatch match;
-        int pos = 0;
-        while ((pos = result.indexOf(re, pos, &match)) != -1) {
-            QString matched = match.captured(0);
-            result.replace(pos, matched.length(), QString("<b>%1</b>").arg(matched));
-            pos += matched.length() + 7;
-        }
-    }
-    // Convert newlines to <br> for rich text display
-    result.replace('\n', "<br>");
-    return result;
-}
-} // namespace
 
 ImageView::ImageView(QWidget *parent)
     :DWidget (parent)
@@ -95,21 +67,13 @@ void ImageView::loadImage(const QString &file, const QString &type, const QStrin
     QFileInfo fileInfo(m_imageFile);
     QString name = fileInfo.fileName();
 
-    QFontMetrics fontMetrics(m_titleLabel->font());
-    QString elidedName = fontMetrics.elidedText(name, Qt::ElideMiddle, m_titleLabel->width());
-
-    // Apply highlighting to elided text if keywords exist
-    if (!keywords.isEmpty()) {
-        m_titleLabel->setTextFormat(Qt::RichText);
-        m_titleLabel->setText(highlightKeywords(elidedName, keywords));
-    } else {
-        m_titleLabel->setTextFormat(Qt::PlainText);
-        m_titleLabel->setText(elidedName);
-    }
-
-    // Show full name as tooltip if elided
-    if (elidedName != name)
+    // HighlightLabel 内部处理省略和高亮
+    m_titleLabel->setPlainText(name);
+    m_titleLabel->setKeywords(keywords);
+    if (m_titleLabel->isElided())
         m_titleLabel->setToolTip(name);
+    else
+        m_titleLabel->setToolTip("");
 
     if (!fileInfo.isReadable() || !canPreview()) {
         qCWarning(logImagePreview) << "Cannot preview image - File not readable or unsupported format:" << m_imageFile;
@@ -175,20 +139,13 @@ void ImageView::setMatchedContext(const QString &context, const QStringList &key
     m_contentLabel->setVisible(!highlightedContent.isEmpty());
     m_titleLabel->setVisible(highlightedContent.isEmpty());
     if (!highlightedContent.isEmpty()) {
-        // Apply elide first, then highlight
-        QFontMetrics fontMetrics(m_contentLabel->font());
-        QString elidedContent = fontMetrics.elidedText(highlightedContent, Qt::ElideRight, m_contentLabel->width());
-
-        if (!keywords.isEmpty()) {
-            m_contentLabel->setTextFormat(Qt::RichText);
-            m_contentLabel->setText(highlightKeywords(elidedContent, keywords));
-        } else {
-            m_contentLabel->setTextFormat(Qt::PlainText);
-            m_contentLabel->setText(elidedContent);
-        }
-        // Show full content as tooltip if elided
-        if (elidedContent != highlightedContent)
+        // HighlightLabel 内部处理省略和高亮
+        m_contentLabel->setPlainText(highlightedContent);
+        m_contentLabel->setKeywords(keywords);
+        if (m_contentLabel->isElided())
             m_contentLabel->setToolTip(highlightedContent);
+        else
+            m_contentLabel->setToolTip("");
     }
 }
 
@@ -200,27 +157,30 @@ void ImageView::initUI()
     m_imageLabel->setFixedSize(IMAGEWIDTH, IMAGEHEIGHT);
     m_imageLabel->setAlignment(Qt::AlignCenter);
 
-    m_titleLabel = new DLabel(this);
+    // 名称标签：中间省略，1行
+    m_titleLabel = new HighlightLabel(this);
     m_titleLabel->setFixedWidth(IMAGEWIDTH);
     m_titleLabel->setAlignment(Qt::AlignCenter);
+    m_titleLabel->setElideMode(Qt::ElideMiddle);
+    m_titleLabel->setMaxLines(1);
 
-    m_contentLabel = new DTipLabel("", this);
+    // 内容标签：右省略，1行
+    m_contentLabel = new HighlightLabel(this);
     m_contentLabel->setFixedWidth(IMAGEWIDTH);
     m_contentLabel->setAlignment(Qt::AlignCenter);
     m_contentLabel->setElideMode(Qt::ElideRight);
+    m_contentLabel->setMaxLines(1);
     m_contentLabel->setVisible(false);
 
-    QFont titleFont = m_titleLabel->font();
-    titleFont.setWeight(QFont::Medium);
-    titleFont = DFontSizeManager::instance()->get(DFontSizeManager::T5, titleFont);
-    m_titleLabel->setFont(titleFont);
-
-    QColor textColor(0, 0, 0, int(255 * 0.9));
-    if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType)
-        textColor = QColor(255, 255, 255, int(255 * 0.9));
-    QPalette pa = m_titleLabel->palette();
+    QPalette pa = palette();
+    auto textColor = pa.brightText().color();
+    textColor.setAlpha(255 * 0.9);
     pa.setColor(QPalette::WindowText, textColor);
+    QFont font = DFontSizeManager::instance()->get(DFontSizeManager::T7, QFont::Normal);
+    m_titleLabel->setFont(font);
     m_titleLabel->setPalette(pa);
+    m_contentLabel->setPalette(pa);
+    m_contentLabel->setFont(font);
 
     QHBoxLayout *imageLayout = new QHBoxLayout;
     imageLayout->addWidget(m_imageLabel);

--- a/src/preview-plugin/image-preview/imageview.h
+++ b/src/preview-plugin/image-preview/imageview.h
@@ -11,10 +11,7 @@
 #include <QMovie>
 #include <QVBoxLayout>
 
-DWIDGET_BEGIN_NAMESPACE
-class DLabel;
-class DTipLabel;
-DWIDGET_END_NAMESPACE
+class HighlightLabel;
 
 namespace GrandSearch {
 namespace image_preview {
@@ -54,8 +51,8 @@ private:
 
     QSize m_sourceSize;                 // 资源尺寸
     QLabel *m_imageLabel;               // 显示图片
-    Dtk::Widget::DLabel *m_titleLabel;  // 显示名称
-    Dtk::Widget::DTipLabel *m_contentLabel;
+    HighlightLabel *m_titleLabel;       // 显示名称
+    HighlightLabel *m_contentLabel;     // 显示匹配内容
 };
 
 }}


### PR DESCRIPTION
1. Created HighlightLabel as a reusable QLabel subclass supporting
keyword highlighting with bold text
2. Implemented text elision (left/middle/right) with multi-line support
using QTextLayout
3. Built position mapping to correctly map highlights when text is
elided (e.g., "abc...xyz" preserves highlight positions)
4. Replaced NameLabel and DTipLabel with HighlightLabel in
generalpreviewplugin.cpp and imageview.cpp
5. Removed duplicate highlightKeywords helper functions from multiple
files
6. Fixed weight calculation to ADD to existing weight instead of
replacing
7. Changed keyword separator from comma to colon in preview widget

Log: Added HighlightLabel widget for consistent keyword highlighting
across search preview plugins

Influence:
1. Test text elision in all modes (left, middle, right) with various
widths
2. Verify keyword highlighting persists correctly after text elision
3. Test multi-line text with max lines limit
4. Verify theme changes update label colors properly
5. Test search preview with keywords in general preview and image
preview
6. Verify weight calculation for items with pre-existing weight values
7. Check that tooltip shows full text when label is elided
8. Verify no regressions in existing preview functionality

feat: 添加可复用的 HighlightLabel 组件用于关键词高亮

1. 创建 HighlightLabel 作为可复用的 QLabel 子类，支持使用粗体进行关键词
高亮
2. 使用 QTextLayout 实现文本省略（左侧/中间/右侧），支持多行限制
3. 构建位置映射以在文本省略后正确映射高亮位置（如 "abc...xyz" 保留高亮
位置）
4. 在 generalpreviewplugin.cpp 和 imageview.cpp 中用 HighlightLabel 替换
NameLabel 和 DTipLabel
5. 从多个文件中移除重复的 highlightKeywords 辅助函数
6. 修复权重计算逻辑，改为累加到现有权重而非替换
7. 在预览组件中将关键词分隔符从逗号改为冒号

Log: 新增 HighlightLabel 组件，用于搜索预览插件中一致的关键词高亮

Influence:
1. 测试各种宽度下所有省略模式（左侧、中间、右侧）的文本省略效果
2. 验证文本省略后关键词高亮正确保留
3. 测试带最大行数限制的多行文本处理
4. 验证主题切换时标签颜色正确更新
5. 测试通用预览和图片预览中带关键词的搜索预览
6. 验证带有预设权重值的项目的权重计算
7. 检查标签被省略时工具提示显示完整文本
8. 确认现有预览功能无回归

BUG: https://pms.uniontech.com/bug-view-360081.html
