### PR TITLE
fix: adjust OCR preview length and keyword delimiter

### DIFF
--- a/src/dde-grand-search-daemon/searcher/ocr/ocrtextworker.cpp
+++ b/src/dde-grand-search-daemon/searcher/ocr/ocrtextworker.cpp
@@ -159,7 +159,7 @@ bool OcrTextWorkerPrivate::searchByDFMSearch()
 
     // Configure OCR options
     OcrTextOptionsAPI ocrOptions(options);
-    ocrOptions.setMaxPreviewLength(500);
+    ocrOptions.setMaxPreviewLength(50);
     // Enable filename-OCR content mixed search
     ocrOptions.setFilenameOcrContentMixedAndSearchEnabled(true);
 

--- a/src/preview-plugin/image-preview/imagepreviewplugin.cpp
+++ b/src/preview-plugin/image-preview/imagepreviewplugin.cpp
@@ -48,7 +48,7 @@ bool ImagePreviewPlugin::previewItem(const ItemInfo &item)
     QStringList keywords;
     QString keywordsStr = item.value(PREVIEW_ITEMINFO_KEYWORDS);
     if (!keywordsStr.isEmpty()) {
-        keywords = keywordsStr.split(",", Qt::SkipEmptyParts);
+        keywords = keywordsStr.split(":", Qt::SkipEmptyParts);
     }
 
     qCDebug(logImagePreview) << "Previewing image - Path:" << path << "Type:" << type


### PR DESCRIPTION
1. Reduce OCR max preview length from 500 to 50 characters to optimize
UI display and prevent text overflow in search results
2. Change keyword separator from comma to colon in image preview plugin
to align with the actual keyword format transmitted by the search
framework

Log: Updated OCR preview text limit and fixed keyword separator parsing

Influence:
1. Verify OCR text preview displays correctly with 50-character
truncation limit
2. Test image preview keyword highlighting with colon-separated format
3. Verify search result cards layout with shortened preview text
4. Test keyword extraction and matching functionality with new delimiter
5. Check backward compatibility with existing OCR search results
6. Verify image preview plugin correctly parses and highlights keywords

fix: 调整 OCR 预览长度和关键词分隔符

1. 将 OCR 最大预览长度从 500 减少到 50 个字符，以优化 UI 显示并防止搜索
结果中的文本溢出
2. 在图片预览插件中将关键词分隔符从逗号改为冒号，以与搜索框架传输的实际
关键词格式保持一致

Log: 更新 OCR 预览文本限制并修复关键词分隔符解析

Influence:
1. 验证 OCR 文本预览在 50 字符截断限制下正确显示
2. 测试使用冒号分隔格式的图片预览关键词高亮功能
3. 验证缩短预览文本后的搜索结果卡片布局
4. 测试使用新分隔符的关键词提取和匹配功能
5. 检查与现有 OCR 搜索结果的向后兼容性
6. 验证图片预览插件正确解析和高亮关键词
