### PR TITLE
fix: add fallback icon for null pixmap cases

### DIFF
--- a/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistview.cpp
+++ b/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistview.cpp
@@ -271,6 +271,8 @@ void GrandSearchListView::setData(const QModelIndex &index, const MatchedItem &i
         }
     }
 
+    if (itemIcon.isNull())
+        itemIcon = QIcon::fromTheme("unknown");
     m_model->setData(index, itemIcon, Qt::DecorationRole);
 
     // 异步请求缩略图

--- a/src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp
+++ b/src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp
@@ -195,6 +195,9 @@ bool GeneralPreviewPlugin::previewItem(const ItemInfo &info)
     } else {
         pixmap = Utils::defaultIcon(item).pixmap(iconSize);
     }
+
+    if (pixmap.isNull())
+        pixmap = QIcon::fromTheme("unknown").pixmap(iconSize);
     d_p->m_iconLabel->setPixmap(pixmap);
 
     // 设置名称，关键词高亮在 HighlightLabel 内部处理


### PR DESCRIPTION
1. Add null check for itemIcon in GrandSearchListView::setData()
2. Add null check for pixmap in GeneralPreviewPlugin::previewItem()
3. Use QIcon::fromTheme("unknown") as fallback when icon/pixmap is null
4. Prevent UI display issues caused by null icons in search results and
preview panel

Influence:
1. Test search results with various file types including those without
associated icons
2. Verify preview panel displays correctly for items with missing or
null icons
3. Check that the fallback "unknown" icon appears when no specific icon
is available
4. Test edge cases like corrupted files or unsupported formats
5. Verify no visual glitches or empty spaces in list view and preview

fix: 为空图标情况添加默认回退图标

1. 在 GrandSearchListView::setData() 中添加 itemIcon 空值检查
2. 在 GeneralPreviewPlugin::previewItem() 中添加 pixmap 空值检查
3. 当图标或 pixmap 为空时使用 QIcon::fromTheme("unknown") 作为回退
4. 防止搜索结果和预览面板中因空图标导致的 UI 显示问题

Influence:
1. 测试各种文件类型的搜索结果，包括没有关联图标的文件
2. 验证预览面板在图标缺失或为空时能正确显示
3. 检查无特定图标时是否显示回退的 "unknown" 图标
4. 测试损坏文件或不支持格式等边界情况
5. 确认列表视图和预览中无视觉异常或空白区域

BUG: https://pms.uniontech.com/bug-view-360169.html

## Summary by Sourcery

Add fallback handling for null icons in search results and preview to avoid UI issues.

Bug Fixes:
- Ensure list view items use a fallback 'unknown' icon when the computed item icon is null.
- Ensure the general preview plugin uses a fallback 'unknown' icon when the generated pixmap is null.