### PR TITLE
fix: handle Qt6 file time logic issues with statx fallback

### DIFF
--- a/src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp
+++ b/src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp
@@ -4,6 +4,7 @@
 
 #include "filesearchutils.h"
 #include "global/builtinsearch.h"
+#include "global/commontools.h"
 #include "utils/specialtools.h"
 #include "global/searchhelper.h"
 #include "global/searchconfigdefine.h"
@@ -229,7 +230,7 @@ QVariantHash FileSearchUtils::tailerData(const QFileInfo &info)
     }
 
     if (config->value(GRANDSEARCH_TAILER_TIMEMODEFIED, false)) {
-        auto timeModified = info.lastModified().toString("yyyy-MM-dd hh:mm ") + QObject::tr("modified");
+        auto timeModified = CommonTools::getFileModifiedTime(info.absoluteFilePath()).toString("yyyy-MM-dd hh:mm ") + QObject::tr("modified");
         datas.append(timeModified);
         qCDebug(logDaemon) << "Added modification time to tailer:" << timeModified;
     }

--- a/src/global/commontools.h
+++ b/src/global/commontools.h
@@ -9,12 +9,18 @@
 #include <QPoint>
 #include <QColor>
 #include <QtDebug>
+#include <QFileInfo>
+#include <QDateTime>
 #include <QImage>
 #include <QPainter>
 #include <QMutex>
 
 #include <fstab.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
+#include <linux/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
 
 namespace GrandSearch {
 
@@ -79,6 +85,40 @@ inline QString formatFileSize(qint64 num, bool withUnitVisible = true, int preci
 inline QString dateTimeFormat()
 {
     return "yyyy/MM/dd HH:mm";
+}
+
+// 在Qt6环境下，当文件时间存在逻辑问题时（如创建时间是今天，修改时间却为昨天等），
+// QFileInfo::lastModified()会返回无效的时间，此时需要使用statx系统调用直接获取文件时间
+inline QDateTime getFileModifiedTime(const QString &filePath)
+{
+    QFileInfo info(filePath);
+    QDateTime time = info.lastModified();
+    if (time.isValid())
+        return time;
+
+    QByteArray path = filePath.toLocal8Bit();
+    struct statx stx;
+    if (syscall(SYS_statx, AT_FDCWD, path.constData(), AT_SYMLINK_NOFOLLOW, STATX_MTIME, &stx) == 0 && (stx.stx_mask & STATX_MTIME))
+        return QDateTime::fromSecsSinceEpoch(static_cast<qint64>(stx.stx_mtime.tv_sec));
+
+    return {};
+}
+
+// 在Qt6环境下，当文件时间存在逻辑问题时（如创建时间是今天，访问时间却为昨天等），
+// QFileInfo::lastRead()会返回无效的时间，此时需要使用statx系统调用直接获取文件时间
+inline QDateTime getFileAccessTime(const QString &filePath)
+{
+    QFileInfo info(filePath);
+    QDateTime time = info.lastRead();
+    if (time.isValid())
+        return time;
+
+    QByteArray path = filePath.toLocal8Bit();
+    struct statx stx;
+    if (syscall(SYS_statx, AT_FDCWD, path.constData(), AT_SYMLINK_NOFOLLOW, STATX_ATIME, &stx) == 0 && (stx.stx_mask & STATX_ATIME))
+        return QDateTime::fromSecsSinceEpoch(static_cast<qint64>(stx.stx_atime.tv_sec));
+
+    return {};
 }
 
 inline QString durationString(qint64 seconds)

--- a/src/grand-search/gui/entrance/entrancewidget.cpp
+++ b/src/grand-search/gui/entrance/entrancewidget.cpp
@@ -208,12 +208,11 @@ void EntranceWidget::initUI()
 
     QPalette palette;
     QColor colorText(0, 0, 0);
-    QColor colorBkg(0, 0, 0, 25);
     if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType) {
         colorText = QColor(255, 255, 255);
-        colorBkg = QColor(255, 255, 255, 25);
+        QColor colorBkg = QColor(255, 255, 255, 25);
+        palette.setColor(QPalette::Button, colorBkg);   // 背景色
     }
-    palette.setColor(QPalette::Button, colorBkg);   // 背景色
     palette.setColor(QPalette::Text, colorText);
     palette.setColor(QPalette::ButtonText, colorText);
 

--- a/src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp
+++ b/src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp
@@ -273,7 +273,7 @@ bool GeneralPreviewPlugin::previewItem(const ItemInfo &info)
     tagInfos.insert(DetailInfoProperty::ElideMode, QVariant::fromValue(Qt::ElideNone));
 
     contentInfos.clear();
-    contentInfos.insert(DetailInfoProperty::Text, QVariant(fi.lastModified().toString(CommonTools::dateTimeFormat())));
+    contentInfos.insert(DetailInfoProperty::Text, QVariant(CommonTools::getFileModifiedTime(item.item).toString(CommonTools::dateTimeFormat())));
     contentInfos.insert(DetailInfoProperty::ElideMode, QVariant::fromValue(Qt::ElideMiddle));
 
     detailInfo = qMakePair(tagInfos, contentInfos);

--- a/src/grand-search/thumbnail/thumbnailcache.cpp
+++ b/src/grand-search/thumbnail/thumbnailcache.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "thumbnailcache.h"
+#include "global/commontools.h"
 
 #include <QCryptographicHash>
 #include <QDir>
@@ -141,8 +142,7 @@ void ThumbnailCache::put(const QString &filePath, const ThumbnailSize &size, con
     QString diskPath = cacheFilePath(filePath, size);
 
     // 获取文件修改时间
-    QFileInfo fileInfo(filePath);
-    qint64 mtime = fileInfo.lastModified().toSecsSinceEpoch();
+    qint64 mtime = CommonTools::getFileModifiedTime(filePath).toSecsSinceEpoch();
 
     // 转换为 QImage 以便添加元数据
     QImage image = thumbnail.toImage();
@@ -196,9 +196,7 @@ bool ThumbnailCache::isCacheExpired(const QString &filePath, const QString &cach
 
 bool ThumbnailCache::isCacheExpired(const QString &filePath, const QString &cachePath, const QImage &cacheImage)
 {
-    QFileInfo sourceFile(filePath);
-
-    if (!sourceFile.exists()) {
+    if (!QFile::exists(filePath)) {
         return true;
     }
 
@@ -211,7 +209,7 @@ bool ThumbnailCache::isCacheExpired(const QString &filePath, const QString &cach
 
     // 使用元数据中的 MTime 进行验证
     qint64 cachedMTime = mtimeStr.toLongLong();
-    qint64 sourceMTime = sourceFile.lastModified().toSecsSinceEpoch();
+    qint64 sourceMTime = CommonTools::getFileModifiedTime(filePath).toSecsSinceEpoch();
 
     // 如果源文件修改时间晚于缓存时间，则缓存过期
     return sourceMTime > cachedMTime;

--- a/src/grand-search/utils/utils.cpp
+++ b/src/grand-search/utils/utils.cpp
@@ -13,6 +13,7 @@ extern "C" {
 
 #include "global/builtinsearch.h"
 #include "global/searchhelper.h"
+#include "global/commontools.h"
 #include "business/config/accessrecord/accessrecord.h"
 
 #include "interfaces/daemongrandsearchinterface.h"
@@ -368,8 +369,8 @@ double Utils::calcFileWeight(const QString &path, const QString &name, const QSt
 #else
     const QDateTime &createDateTime = fileInfo.created();
 #endif
-    const QDateTime &lastModifyTime = fileInfo.lastModified();
-    const QDateTime &lastReadTime = fileInfo.lastRead();
+    const QDateTime &lastModifyTime = CommonTools::getFileModifiedTime(path);
+    const QDateTime &lastReadTime = CommonTools::getFileAccessTime(path);
 
     qint64 createDayDiff = calcDateDiff(createDateTime, currentDateTime);
     qint64 lastModifyDayDiff = calcDateDiff(lastModifyTime, currentDateTime);

--- a/src/preview-plugin/audio-preview/audiopreviewplugin.cpp
+++ b/src/preview-plugin/audio-preview/audiopreviewplugin.cpp
@@ -142,7 +142,7 @@ bool AudioPreviewPlugin::previewItem(const ItemInfo &item)
     m_detailInfos.push_back(detailInfo);
 
     // 修改时间
-    auto time = fileInfo.lastModified();
+    auto time = CommonTools::getFileModifiedTime(path);
 
     tagInfos.clear();
     tagInfos.insert(DetailInfoProperty::Text, QVariant(tr("Time modified:")));

--- a/src/preview-plugin/image-preview/imagepreviewplugin.cpp
+++ b/src/preview-plugin/image-preview/imagepreviewplugin.cpp
@@ -129,7 +129,7 @@ bool ImagePreviewPlugin::previewItem(const ItemInfo &item)
     m_detailInfos.push_back(detailInfo);
 
     // 修改时间
-    auto time = fileInfo.lastModified();
+    auto time = CommonTools::getFileModifiedTime(path);
 
     tagInfos.clear();
     tagInfos.insert(DetailInfoProperty::Text, QVariant(tr("Time modified:")));

--- a/src/preview-plugin/video-preview/videopreviewplugin.cpp
+++ b/src/preview-plugin/video-preview/videopreviewplugin.cpp
@@ -150,7 +150,7 @@ bool VideoPreviewPlugin::previewItem(const ItemInfo &item)
     m_infos.push_back(detailInfo);
 
     // 修改时间
-    auto lt = fileInfo.lastModified().toString(CommonTools::dateTimeFormat());
+    auto lt = CommonTools::getFileModifiedTime(path).toString(CommonTools::dateTimeFormat());
 
     tagInfos.clear();
     tagInfos.insert(DetailInfoProperty::Text, QVariant(kLabelTime));


### PR DESCRIPTION
1. Add getFileModifiedTime() and getFileAccessTime() helper functions
to CommonTools
2. Use statx syscall as fallback when QFileInfo returns invalid
timestamps in Qt6
3. Update all file time retrieval across daemon, GUI, preview plugins
and utils
4. Fix thumbnail cache expiration check to use consistent time source

Qt6 has a known issue where QFileInfo::lastModified() and lastRead()
return invalid QDateTime when file timestamps have logical
inconsistencies (e.g., creation time newer than modification time). This
change adds fallback functions that use the Linux statx syscall directly
to retrieve accurate file timestamps when Qt's methods fail. The fix
ensures reliable file time display in search results, preview panels,
and thumbnail cache validation across the entire application.

Log: Fixed file modification and access time display in search results
and preview panels

Influence:
1. Test file search results showing correct modification times
2. Verify preview panels display accurate file timestamps for documents,
images, audio and video
3. Test thumbnail cache invalidation when source files are modified
4. Check file weight calculation based on access/modify times in search
ranking
5. Verify behavior with files having unusual timestamp combinations
(e.g., mtime before ctime)
6. Test on systems with different filesystems (ext4, btrfs, ntfs via
fuse)
7. Verify fallback works when statx syscall is unavailable

fix: 使用 statx 系统调用处理 Qt6 文件时间逻辑问题

1. 在 CommonTools 中添加 getFileModifiedTime() 和 getFileAccessTime() 辅
助函数
2. 当 QFileInfo 在 Qt6 中返回无效时间戳时，使用 statx 系统调用作为后备
方案
3. 更新守护进程、GUI、预览插件和工具类中的所有文件时间获取逻辑
4. 修复缩略图缓存过期检查，使用一致的时间源

Qt6 存在一个已知问题：当文件时间戳存在逻辑不一致时（例如创建时间比修改时
间新），QFileInfo::lastModified() 和 lastRead() 会返回无效的 QDateTime。
此变更添加了后备函数，直接使用 Linux statx 系统调用获取准确的文件时间
戳。该修复确保整个应用程序中搜索结果、预览面板和缩略图缓存验证的文件时间
显示可靠。

Log: 修复搜索结果和预览面板中文件修改及访问时间的显示问题

Influence:
1. 测试文件搜索结果是否正确显示修改时间
2. 验证预览面板为文档、图片、音频和视频显示准确的文件时间戳
3. 测试源文件修改时缩略图缓存的失效机制
4. 检查基于访问/修改时间的搜索排序文件权重计算
5. 验证具有异常时间戳组合的文件的行为（例如修改时间早于创建时间）
6. 在不同文件系统上测试（ext4、btrfs、通过 fuse 的 ntfs）
7. 验证 statx 系统调用不可用时后备方案是否正常工作

BUG: https://pms.uniontech.com/bug-view-361135.html

## Summary by Sourcery

Ensure reliable file timestamp handling across the application by introducing common helpers with a Linux statx fallback and updating all consumers to use them.

New Features:
- Add CommonTools helper functions for retrieving file modification and access times with a statx-based fallback when Qt6 returns invalid timestamps.

Bug Fixes:
- Fix incorrect or missing file modification and access times in search results, preview panels, and thumbnail metadata under Qt6.
- Correct thumbnail cache expiration logic to use a consistent, reliable file modification time source and handle missing source files safely.

Enhancements:
- Standardize file time retrieval across daemon, GUI, thumbnail cache, and preview plugins through the shared CommonTools helpers.