### PR TITLE
refactor: extract SearchEdit component from EntranceWidget

### DIFF
--- a/src/grand-search/CMakeLists.txt
+++ b/src/grand-search/CMakeLists.txt
@@ -81,6 +81,9 @@ set(GUISRC
     # 界面相关数据定义
     gui/datadefine.h
     # 入口界面
+    gui/entrance/searchedit_p.h
+    gui/entrance/searchedit.h
+    gui/entrance/searchedit.cpp
     gui/entrance/entrancewidget_p.h
     gui/entrance/entrancewidget.h
     gui/entrance/entrancewidget.cpp

--- a/src/grand-search/gui/entrance/entrancewidget.cpp
+++ b/src/grand-search/gui/entrance/entrancewidget.cpp
@@ -4,136 +4,48 @@
 
 #include "entrancewidget_p.h"
 #include "entrancewidget.h"
-#include "gui/datadefine.h"
+#include "searchedit.h"
 #include "utils/utils.h"
 
-#include <DSearchEdit>
-#include <DStyle>
-#include <DLabel>
-#include <DFontSizeManager>
 #include <DGuiApplicationHelper>
 
 #include <QLineEdit>
-#include <QPushButton>
 #include <QHBoxLayout>
-#include <QWidgetAction>
-#include <QAction>
-#include <QTimer>
-#include <QGuiApplication>
-#include <QKeyEvent>
-#include <QMenu>
-#include <QClipboard>
-#include <QContextMenuEvent>
 #include <QEvent>
-#include <QtGlobal>
-#include <QLoggingCategory>
 
-Q_DECLARE_LOGGING_CATEGORY(logGrandSearch)
-
-DWIDGET_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 using namespace GrandSearch;
 
-static const uint DelayReponseTime = 50;   // 输入延迟搜索时间
-static const uint EntraceWidgetWidth = 740;   // 搜索界面宽度度
-static const uint EntraceWidgetHeight = 48;   // 搜索界面高度
-static const uint WidgetMargins = 10;   // 界面边距
-static const uint SearchMaxLength = 512;   // 输入最大字符限制
-
-static const uint LabelIconSize = 26;   // 标签应用图标显示大小
-static const uint LabelSize = 32;   // 标签大小
+static const uint EntraceWidgetWidth = 740;
+static const uint EntraceWidgetHeight = 48;
+static const uint WidgetMargins = 10;
 
 EntranceWidgetPrivate::EntranceWidgetPrivate(EntranceWidget *parent)
     : q_p(parent)
 {
-    m_delayChangeTimer = new QTimer(this);
-    m_delayChangeTimer->setSingleShot(true);
-    m_delayChangeTimer->setInterval(DelayReponseTime);
-
-    connect(m_delayChangeTimer, &QTimer::timeout, this, &EntranceWidgetPrivate::notifyTextChanged);
-}
-
-void EntranceWidgetPrivate::delayChangeText()
-{
-    Q_ASSERT(m_delayChangeTimer);
-
-    qCDebug(logGrandSearch) << "Search text input changed - Starting delay timer";
-    m_delayChangeTimer->start();
-}
-
-void EntranceWidgetPrivate::notifyTextChanged()
-{
-    Q_ASSERT(m_searchEdit);
-
-    const QString &currentSearchText = m_searchEdit->text().trimmed();
-    qCDebug(logGrandSearch) << "Search text changed - Text:" << currentSearchText
-                            << "Length:" << currentSearchText.length();
-    emit q_p->searchTextChanged(currentSearchText);
-
-    // 搜索内容改变后，清空图标显示
-    MatchedItem item;
-    q_p->onAppIconChanged(QString(), item);
-}
-
-void EntranceWidgetPrivate::showMenu(const QPoint &pos)
-{
-    Q_ASSERT(m_lineEdit);
-
-    qCDebug(logGrandSearch) << "Showing context menu - Position:" << pos;
-    QMenu *menu = new QMenu;
-    QAction *action = nullptr;
-
-    action = menu->addAction(tr("Cut"));
-    action->setEnabled(m_lineEdit->hasSelectedText() && m_lineEdit->echoMode() == QLineEdit::Normal);
-    connect(action, &QAction::triggered, m_lineEdit, &QLineEdit::cut);
-
-    action = menu->addAction(tr("Copy"));
-    action->setEnabled(m_lineEdit->hasSelectedText() && m_lineEdit->echoMode() == QLineEdit::Normal);
-    connect(action, &QAction::triggered, m_lineEdit, &QLineEdit::copy);
-
-    action = menu->addAction(tr("Paste"));
-    action->setEnabled(!QGuiApplication::clipboard()->text().isEmpty());
-    connect(action, &QAction::triggered, m_lineEdit, &QLineEdit::paste);
-
-    menu->exec(pos);
-    delete menu;
 }
 
 EntranceWidget::EntranceWidget(QWidget *parent)
     : QFrame(parent), d_p(new EntranceWidgetPrivate(this))
 {
-    qCDebug(logGrandSearch) << "Creating EntranceWidget";
     initUI();
     initConnections();
-    qCDebug(logGrandSearch) << "EntranceWidget created successfully";
 }
 
-EntranceWidget::~EntranceWidget()
-{
-    qCDebug(logGrandSearch) << "Destroying EntranceWidget";
-}
+EntranceWidget::~EntranceWidget() = default;
 
 void EntranceWidget::showLabelAppIcon(bool visible)
 {
-    Q_ASSERT(d_p->m_lineEdit);
-    Q_ASSERT(d_p->m_appIconLabel);
-    Q_ASSERT(d_p->m_appIconAction);
-    if (visible == d_p->m_appIconLabel->isVisible())
-        return;
-
-    qCDebug(logGrandSearch) << "App icon visibility changed - Visible:" << visible;
-    d_p->m_appIconAction->setVisible(visible);
-    d_p->m_appIconLabel->setVisible(visible);
-    d_p->m_lineEdit->update();
+    Q_ASSERT(d_p->m_searchEdit);
+    d_p->m_searchEdit->setAppIconVisible(visible);
 }
 
 bool EntranceWidget::event(QEvent *event)
 {
     if (event->type() == QEvent::FocusIn) {
-        qCDebug(logGrandSearch) << "Focus in event received";
-        d_p->m_lineEdit->setFocus();
+        d_p->m_searchEdit->setFocus();
         return true;
     }
-
     return QFrame::event(event);
 }
 
@@ -142,113 +54,15 @@ void EntranceWidget::paintEvent(QPaintEvent *event)
     QFrame::paintEvent(event);
 }
 
-bool EntranceWidget::eventFilter(QObject *watched, QEvent *event)
-{
-    if (watched == d_p->m_lineEdit && QEvent::KeyPress == event->type()) {
-        QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
-        if (Q_LIKELY(keyEvent)) {
-            int key = keyEvent->key();
-            qCDebug(logGrandSearch) << "Key press event:" << key;
-            switch (key) {
-            case Qt::Key_Up: {
-                qCDebug(logGrandSearch) << "Navigation key pressed - Selecting previous item";
-                emit sigSelectPreviousItem();
-                return true;
-            }
-            case Qt::Key_Tab:
-            case Qt::Key_Down: {
-                qCDebug(logGrandSearch) << "Navigation key pressed - Selecting next item";
-                emit sigSelectNextItem();
-                return true;
-            }
-            case Qt::Key_Return:
-            case Qt::Key_Enter: {
-                qCDebug(logGrandSearch) << "Enter key pressed - Handling selected item";
-                emit sigHandleItem();
-                return true;
-            }
-            case Qt::Key_Escape: {
-                qCDebug(logGrandSearch) << "Escape key pressed - Closing window";
-                emit sigCloseWindow();
-                return true;
-            }
-            default:
-                break;
-            }
-        }
-    } else if (watched == d_p->m_lineEdit && QEvent::ContextMenu == event->type()) {
-        QContextMenuEvent *contextMenuEvent = static_cast<QContextMenuEvent *>(event);
-        if (Q_LIKELY(contextMenuEvent)) {
-            qCDebug(logGrandSearch) << "Context menu event received";
-            d_p->showMenu(contextMenuEvent->globalPos());
-            return true;
-        }
-    } else if (watched == d_p->m_searchEdit && QEvent::FocusIn == event->type()) {
-        if (Q_LIKELY(d_p->m_lineEdit)) {
-            qCDebug(logGrandSearch) << "Search edit focus in event";
-            d_p->m_lineEdit->setFocus();
-            return true;
-        }
-    }
-    return QFrame::eventFilter(watched, event);
-}
-
 void EntranceWidget::initUI()
 {
-    d_p->m_searchEdit = new DSearchEdit(this);
-    d_p->m_searchEdit->installEventFilter(this);
-
-    d_p->m_lineEdit = d_p->m_searchEdit->lineEdit();
-    d_p->m_lineEdit->setMaxLength(SearchMaxLength);
-    d_p->m_lineEdit->installEventFilter(this);
-
-    QFont lineFont = d_p->m_lineEdit->font();
-    lineFont = DFontSizeManager::instance()->get(DFontSizeManager::T4, lineFont);
-    d_p->m_lineEdit->setFont(lineFont);
-
-    QPalette palette;
-    QColor colorText(0, 0, 0);
-    if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType) {
-        colorText = QColor(255, 255, 255);
-        QColor colorBkg = QColor(255, 255, 255, 25);
-        palette.setColor(QPalette::Button, colorBkg);   // 背景色
-    }
-    palette.setColor(QPalette::Text, colorText);
-    palette.setColor(QPalette::ButtonText, colorText);
-
-    d_p->m_lineEdit->setPalette(palette);
-    DStyle::setFocusRectVisible(d_p->m_lineEdit, false);
-
-    d_p->m_appIconLabel = new DLabel(d_p->m_searchEdit);
-    d_p->m_appIconLabel->setFixedSize(LabelSize, LabelSize);
-
-    d_p->m_appIconAction = new QAction(this);
-    d_p->m_lineEdit->addAction(d_p->m_appIconAction, QLineEdit::TrailingPosition);
-    d_p->m_searchEdit->setRightWidgets(QList<QWidget *>() << d_p->m_appIconLabel);
-
-    // 搜索框界面布局设置
-    // 必须对搜索框控件的边距和间隔设置为0,否则其内含的LineEdit不满足大小显示要求
-    {
-        auto slayout = d_p->m_searchEdit->layout();
-        slayout->setSpacing(0);
-        slayout->setContentsMargins(0, 0, 0, 0);
-
-        // 增加默认应用图标的右边距
-        auto conMar = slayout->contentsMargins();
-        conMar.setRight(2);
-        slayout->setContentsMargins(conMar);
-
-        d_p->m_lineEdit->setFixedSize(EntraceWidgetWidth, EntraceWidgetHeight);
-    }
-
-    // 搜索框提示信息设置
+    d_p->m_searchEdit = new SearchEdit(this);
+    d_p->m_searchEdit->lineEdit()->setFixedSize(EntraceWidgetWidth, EntraceWidgetHeight);
     d_p->m_searchEdit->setPlaceHolder(tr("Search"));
     d_p->m_searchEdit->setPlaceholderText(tr("What would you like to search for?"));
 
-    // 搜索界面布局设置
     d_p->m_mainLayout = new QHBoxLayout(this);
     d_p->m_mainLayout->addWidget(d_p->m_searchEdit);
-    // 根据设计图要求，设置边距和间隔
     d_p->m_mainLayout->setSpacing(0);
     d_p->m_mainLayout->setContentsMargins(WidgetMargins, WidgetMargins, WidgetMargins, WidgetMargins);
 
@@ -258,13 +72,19 @@ void EntranceWidget::initUI()
 void EntranceWidget::initConnections()
 {
     Q_ASSERT(d_p->m_searchEdit);
-    Q_ASSERT(d_p->m_lineEdit);
 
-    // 输入改变时重置定时器，避免短时间内发起大量无效调用
-    connect(d_p->m_searchEdit, &DSearchEdit::textChanged, d_p.data(), &EntranceWidgetPrivate::delayChangeText);
+    connect(d_p->m_searchEdit, &SearchEdit::debouncedTextChanged, this, &EntranceWidget::searchTextChanged);
+    connect(d_p->m_searchEdit, &SearchEdit::debouncedTextChanged, this, [this](const QString &) {
+        MatchedItem item;
+        onAppIconChanged(QString(), item);
+    });
 
-    // 终止搜索时，强制设置焦点
-    connect(d_p->m_searchEdit, &DSearchEdit::searchAborted, d_p->m_lineEdit, qOverload<>(&QLineEdit::setFocus));
+    connect(d_p->m_searchEdit, &SearchEdit::selectNextItem, this, &EntranceWidget::sigSelectNextItem);
+    connect(d_p->m_searchEdit, &SearchEdit::selectPreviousItem, this, &EntranceWidget::sigSelectPreviousItem);
+    connect(d_p->m_searchEdit, &SearchEdit::handleItem, this, &EntranceWidget::sigHandleItem);
+    connect(d_p->m_searchEdit, &SearchEdit::closeWindow, this, &EntranceWidget::sigCloseWindow);
+
+    connect(d_p->m_searchEdit, &SearchEdit::searchAborted, d_p->m_searchEdit->lineEdit(), qOverload<>(&QLineEdit::setFocus));
 }
 
 void EntranceWidget::onAppIconChanged(const QString &searchGroupName, const MatchedItem &item)
@@ -272,10 +92,8 @@ void EntranceWidget::onAppIconChanged(const QString &searchGroupName, const Matc
     Q_UNUSED(searchGroupName)
 
     const QString appIconName = Utils::appIconName(item);
-    // app图标名称为空，隐藏appIcon显示
     if (appIconName.isEmpty()) {
-        qCDebug(logGrandSearch) << "Hiding app icon - Empty name";
-        showLabelAppIcon(false);
+        d_p->m_searchEdit->setAppIconVisible(false);
         d_p->m_appIconName.clear();
         return;
     }
@@ -284,15 +102,6 @@ void EntranceWidget::onAppIconChanged(const QString &searchGroupName, const Matc
         return;
 
     d_p->m_appIconName = appIconName;
-
-    qCDebug(logGrandSearch) << "Updating app icon:" << appIconName;
-
-    // 更新应用图标
-    const int size = LabelIconSize;
-    auto pixmap = QIcon::fromTheme(appIconName).pixmap(size);
-    pixmap.setDevicePixelRatio(qApp->devicePixelRatio());
-    d_p->m_appIconLabel->setPixmap(pixmap);
-
-    // 图标更新完成后再刷新显示
-    showLabelAppIcon(true);
+    d_p->m_searchEdit->setAppIconVisible(true);
+    d_p->m_searchEdit->setAppIcon(appIconName);
 }

--- a/src/grand-search/gui/entrance/entrancewidget.h
+++ b/src/grand-search/gui/entrance/entrancewidget.h
@@ -21,17 +21,16 @@ public:
     ~EntranceWidget() override;
 
     void showLabelAppIcon(bool visible);
+
 protected:
     bool event(QEvent *event) Q_DECL_OVERRIDE;
     void paintEvent(QPaintEvent *event) Q_DECL_OVERRIDE;
-    bool eventFilter(QObject *watched, QEvent *event) Q_DECL_OVERRIDE;
 
 private:
     void initUI();
     void initConnections();
 
 public slots:
-    // 切换选择搜索结果时，应用图标发生改变
     void onAppIconChanged(const QString &searchGroupName, const MatchedItem &item);
 
 signals:

--- a/src/grand-search/gui/entrance/entrancewidget_p.h
+++ b/src/grand-search/gui/entrance/entrancewidget_p.h
@@ -7,44 +7,24 @@
 
 #include "entrancewidget.h"
 
-#include <DWidget>
-
 #include "QObject"
 
-DWIDGET_BEGIN_NAMESPACE
-class DSearchEdit;
-class DLabel;
-DWIDGET_END_NAMESPACE
-
 class QHBoxLayout;
-class QTimer;
-class QLineEdit;
-class QAction;
-class QPushButton;
 
 namespace GrandSearch {
 
+class SearchEdit;
+
 class EntranceWidgetPrivate : public QObject
 {
-    Q_OBJECT
 public:
     explicit EntranceWidgetPrivate(EntranceWidget *parent = nullptr);
 
-    void delayChangeText();
-    void notifyTextChanged();
-
-    void showMenu(const QPoint& pos);
-
     EntranceWidget *q_p = nullptr;
-    Dtk::Widget::DSearchEdit *m_searchEdit = nullptr;   // 搜索输入框控件
-    QLineEdit *m_lineEdit = nullptr;                    // 输入控件
-    Dtk::Widget::DLabel *m_appIconLabel = nullptr;      // 应用图标显示label
-    QAction *m_appIconAction = nullptr;                 // 应用图标显示区域占位action
+    SearchEdit *m_searchEdit = nullptr;
     QHBoxLayout *m_mainLayout = nullptr;
 
-    QTimer *m_delayChangeTimer = nullptr;               // 延迟发出搜索文本改变
-
-    QString m_appIconName;                              // 当前搜索框显示的默认打开应用图标名称
+    QString m_appIconName;
 };
 
 }

--- a/src/grand-search/gui/entrance/searchedit.cpp
+++ b/src/grand-search/gui/entrance/searchedit.cpp
@@ -1,0 +1,465 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "searchedit_p.h"
+#include "searchedit.h"
+
+#include <DStyle>
+#include <DIconButton>
+#include <DIconTheme>
+#include <DFontSizeManager>
+#include <DGuiApplicationHelper>
+
+#include <QLineEdit>
+#include <QHBoxLayout>
+#include <QAction>
+#include <QTimer>
+#include <QMenu>
+#include <QGuiApplication>
+#include <QClipboard>
+#include <QKeyEvent>
+#include <QStyleOption>
+#include <QToolButton>
+#include <QProxyStyle>
+
+DWIDGET_USE_NAMESPACE
+using namespace GrandSearch;
+
+static constexpr int DelayResponseTime = 50;
+static constexpr int AppIconSize = 32;
+static constexpr int SearchIconSize = 20;
+
+class SearchLineEditStyle : public QProxyStyle
+{
+public:
+    using QProxyStyle::QProxyStyle;
+
+    int pixelMetric(PixelMetric metric, const QStyleOption *option = nullptr,
+                    const QWidget *widget = nullptr) const override
+    {
+        if (metric == QStyle::PM_TextCursorWidth)
+            return 0;
+        return QProxyStyle::pixelMetric(metric, option, widget);
+    }
+};
+
+SearchLineEdit::SearchLineEdit(QWidget *parent)
+    : QLineEdit(parent),
+      m_proxyStyle(new SearchLineEditStyle),
+      m_cursorBlinkTimer(new QTimer(this)),
+      m_cursorVisible(true)
+{
+    setStyle(m_proxyStyle);
+
+    // 调色板（暗色/亮色主题）
+    QPalette pa = palette();
+    QColor colorText(0, 0, 0);
+    QColor colorBkg(0, 0, 0, 25);
+    if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType) {
+        colorText = QColor(255, 255, 255);
+        colorBkg = QColor(255, 255, 255, 25);
+    }
+    pa.setColor(QPalette::Button, colorBkg);
+    pa.setColor(QPalette::Text, colorText);
+    pa.setColor(QPalette::ButtonText, colorText);
+    setPalette(pa);
+    DStyle::setFocusRectVisible(this, false);
+
+    m_cursorBlinkTimer->setInterval(500);
+    connect(m_cursorBlinkTimer, &QTimer::timeout, this, [this]() {
+        m_cursorVisible = !m_cursorVisible;
+        update();
+    });
+}
+
+SearchLineEdit::~SearchLineEdit()
+{
+    delete m_proxyStyle;
+}
+
+void SearchLineEdit::paintEvent(QPaintEvent *event)
+{
+    // 自绘光标
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing);
+
+    if (m_cursorVisible && hasFocus()) {
+        QColor cursorColor(0, 0, 0);
+        if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType)
+            cursorColor = QColor(255, 255, 255);
+        QRect cursorRect = this->cursorRect();
+        cursorRect.setX(cursorRect.x() + 5);
+        cursorRect.setWidth(1);
+        cursorRect.setHeight(cursorRect.height() - 1);
+        painter.fillRect(cursorRect, cursorColor);
+    }
+
+    QLineEdit::paintEvent(event);
+}
+
+void SearchLineEdit::focusInEvent(QFocusEvent *event)
+{
+    QLineEdit::focusInEvent(event);
+    m_cursorVisible = true;
+    if (m_cursorBlinkTimer->interval() > 0)
+        m_cursorBlinkTimer->start();
+}
+
+void SearchLineEdit::focusOutEvent(QFocusEvent *event)
+{
+    m_cursorBlinkTimer->stop();
+    QLineEdit::focusOutEvent(event);
+}
+
+SearchEditPrivate::SearchEditPrivate(SearchEdit *qq)
+    : q(qq)
+{
+}
+
+void SearchEditPrivate::init()
+{
+    m_delayTimer = new QTimer(q);
+    m_delayTimer->setSingleShot(true);
+    m_delayTimer->setInterval(DelayResponseTime);
+    QObject::connect(m_delayTimer, &QTimer::timeout, q, [this]() { notifyTextChanged(); });
+
+    // 内部 QLineEdit
+    m_lineEdit = new SearchLineEdit(q);
+    m_lineEdit->installEventFilter(q);
+    m_lineEdit->setMaxLength(512);
+    m_lineEdit->setContextMenuPolicy(Qt::NoContextMenu);
+    m_lineEdit->setClearButtonEnabled(false);
+
+    // 字体
+    QFont lineFont = m_lineEdit->font();
+    lineFont = DFontSizeManager::instance()->get(DFontSizeManager::T4, lineFont);
+    m_lineEdit->setFont(lineFont);
+
+    // 居中的搜索图标 + 占位文本容器
+    m_iconWidget = new QWidget;
+    m_iconWidget->setObjectName("iconWidget");
+    m_iconWidget->installEventFilter(q);
+    QHBoxLayout *centerLayout = new QHBoxLayout(m_iconWidget);
+    centerLayout->setContentsMargins(0, 0, 0, 0);
+    centerLayout->setSpacing(6);
+
+    auto *searchIcon = new DIconButton(DStyle::SP_IndicatorSearch);
+    searchIcon->setFlat(true);
+    searchIcon->setFocusPolicy(Qt::NoFocus);
+    searchIcon->setAttribute(Qt::WA_TransparentForMouseEvents);
+    searchIcon->setIconSize(QSize(SearchIconSize, SearchIconSize));
+
+    m_placeholderLabel = new QLabel(q);
+    DPalette pe;
+    QStyleOption opt;
+    QColor color = DStyleHelper(q->style()).getColor(&opt, pe, DPalette::TextTips);
+    pe.setColor(DPalette::TextTips, color);
+    m_placeholderLabel->setPalette(pe);
+    m_placeholderLabel->setObjectName("SearchEditPlaceHolderLabel");
+
+    m_placeHolder = SearchEdit::tr("Search");
+    m_placeholderLabel->setText(m_placeHolder);
+
+    centerLayout->addWidget(searchIcon, 0, Qt::AlignVCenter);
+    centerLayout->addWidget(m_placeholderLabel, 0, Qt::AlignCenter);
+    centerLayout->addSpacing(12 / qApp->devicePixelRatio());
+
+    // QLineEdit 内部布局：左侧放 iconWidget（居中），聚焦后隐藏
+    m_lineEditLayout = new QHBoxLayout(m_lineEdit);
+    m_lineEditLayout->setContentsMargins(0, 0, 0, 0);
+    m_lineEditLayout->setSpacing(0);
+    m_lineEditLayout->addWidget(m_iconWidget, 0, Qt::AlignCenter);
+
+    // 左侧搜索图标 action（聚焦后显示）
+    m_searchAction = new QAction(q);
+    m_searchAction->setObjectName("_d_search_leftAction");
+    m_searchAction->setIcon(DStyle::standardIcon(q->style(), DStyle::SP_IndicatorSearch));
+    m_lineEdit->addAction(m_searchAction, QLineEdit::LeadingPosition);
+    m_searchAction->setVisible(false);
+
+    // 应用图标（右侧）
+    m_appIconLabel = new QLabel;
+    m_appIconLabel->setFixedSize(AppIconSize, AppIconSize);
+    m_appIconLabel->setVisible(false);
+
+    m_appIconAction = new QAction(q);
+    m_appIconAction->setVisible(false);
+    m_lineEdit->addAction(m_appIconAction, QLineEdit::TrailingPosition);
+
+    // 清除按钮（QLineEdit 外部）
+    m_clearButton = new DIconButton(DStyle::SP_LineEditClearButton);
+    m_clearButton->setIconSize({ 18, 18 });
+    m_clearButton->setFlat(true);
+    m_clearButton->setFocusPolicy(Qt::NoFocus);
+    m_clearButton->setVisible(false);
+
+    // 清除按钮占位 action
+    m_clearAction = new QAction(q);
+    m_clearAction->setVisible(false);
+    m_lineEdit->addAction(m_clearAction, QLineEdit::TrailingPosition);
+
+    // 主布局
+    QHBoxLayout *mainLayout = new QHBoxLayout(q);
+    mainLayout->setSpacing(8);
+    mainLayout->setContentsMargins(0, 0, 10, 0);
+    mainLayout->addWidget(m_lineEdit);
+    mainLayout->addWidget(m_clearButton);
+    mainLayout->addWidget(m_appIconLabel);
+
+    QList<QToolButton *> list = q->lineEdit()->findChildren<QToolButton *>();
+    for (int i = 0; i < list.count(); i++) {
+        if (list.at(i)->defaultAction() == m_searchAction) {
+            QToolButton *searchBtn = list.at(i);
+            searchBtn->setIconSize({ 16, 16 });
+            searchBtn->setFixedWidth(40);
+            break;
+        }
+    }
+
+    // 聚焦切换 + 文本变化触发防抖
+    QObject::connect(m_lineEdit, &QLineEdit::textChanged, q, [this](const QString &text) {
+        toEditMode(false);
+        bool hasText = !text.isEmpty();
+        m_clearButton->setVisible(hasText);
+        m_clearAction->setVisible(hasText);
+        if (hasText)
+            delayTextChanged();
+        else
+            Q_EMIT q->debouncedTextChanged(QString());
+    });
+
+    QObject::connect(m_clearButton, &DIconButton::clicked, q, [this]() {
+        q->clearEdit();
+        Q_EMIT q->searchAborted();
+    });
+}
+
+void SearchEditPrivate::toEditMode(bool focus)
+{
+    if (focus || m_lineEdit->hasFocus() || !m_lineEdit->text().isEmpty()) {
+        m_searchAction->setVisible(true);
+        m_iconWidget->setVisible(false);
+        m_lineEdit->setPlaceholderText(m_placeholderText);
+    } else {
+        m_searchAction->setVisible(false);
+        m_iconWidget->setVisible(true);
+        m_lineEdit->setPlaceholderText(QString());
+    }
+}
+
+void SearchEditPrivate::showContextMenu(const QPoint &pos)
+{
+    QMenu *menu = new QMenu;
+    QAction *action = nullptr;
+
+    action = menu->addAction(SearchEdit::tr("Cut"));
+    action->setEnabled(m_lineEdit->hasSelectedText() && m_lineEdit->echoMode() == QLineEdit::Normal);
+    QObject::connect(action, &QAction::triggered, m_lineEdit, &QLineEdit::cut);
+
+    action = menu->addAction(SearchEdit::tr("Copy"));
+    action->setEnabled(m_lineEdit->hasSelectedText() && m_lineEdit->echoMode() == QLineEdit::Normal);
+    QObject::connect(action, &QAction::triggered, m_lineEdit, &QLineEdit::copy);
+
+    action = menu->addAction(SearchEdit::tr("Paste"));
+    action->setEnabled(!QGuiApplication::clipboard()->text().isEmpty());
+    QObject::connect(action, &QAction::triggered, m_lineEdit, &QLineEdit::paste);
+
+    menu->exec(pos);
+    delete menu;
+}
+
+void SearchEditPrivate::delayTextChanged()
+{
+    Q_ASSERT(m_delayTimer);
+    m_delayTimer->start();
+}
+
+void SearchEditPrivate::notifyTextChanged()
+{
+    const QString &text = m_lineEdit->text().trimmed();
+    Q_EMIT q->debouncedTextChanged(text);
+}
+
+SearchEdit::SearchEdit(QWidget *parent)
+    : QWidget(parent), d(new SearchEditPrivate(this))
+{
+    d->init();
+}
+
+SearchEdit::~SearchEdit() = default;
+
+QLineEdit *SearchEdit::lineEdit() const
+{
+    return d->m_lineEdit;
+}
+
+void SearchEdit::setPlaceHolder(const QString &text)
+{
+    if (d->m_placeHolder == text)
+        return;
+    d->m_placeHolder = text;
+    d->m_placeholderLabel->setText(text);
+}
+
+QString SearchEdit::placeHolder() const
+{
+    return d->m_placeHolder;
+}
+
+void SearchEdit::setPlaceholderText(const QString &text)
+{
+    d->m_placeholderText = text;
+    if (d->m_lineEdit->hasFocus())
+        d->m_lineEdit->setPlaceholderText(text);
+}
+
+QString SearchEdit::placeholderText() const
+{
+    return d->m_placeholderText;
+}
+
+void SearchEdit::setText(const QString &text)
+{
+    d->m_lineEdit->setText(text);
+}
+
+QString SearchEdit::text() const
+{
+    return d->m_lineEdit->text();
+}
+
+void SearchEdit::setClearButtonEnabled(bool enable)
+{
+    d->m_lineEdit->setClearButtonEnabled(enable);
+}
+
+void SearchEdit::setAppIcon(const QString &iconName)
+{
+    if (iconName.isEmpty()) {
+        d->m_appIconName.clear();
+        setAppIconVisible(false);
+        return;
+    }
+
+    if (iconName == d->m_appIconName)
+        return;
+
+    d->m_appIconName = iconName;
+    auto pixmap = QIcon::fromTheme(iconName).pixmap(AppIconSize);
+    pixmap.setDevicePixelRatio(qApp->devicePixelRatio());
+    d->m_appIconLabel->setPixmap(pixmap);
+    setAppIconVisible(true);
+}
+
+void SearchEdit::setAppIcon(const QIcon &icon)
+{
+    if (icon.isNull()) {
+        d->m_appIconName.clear();
+        setAppIconVisible(false);
+        return;
+    }
+
+    auto pixmap = icon.pixmap(AppIconSize);
+    pixmap.setDevicePixelRatio(qApp->devicePixelRatio());
+    d->m_appIconLabel->setPixmap(pixmap);
+    setAppIconVisible(true);
+}
+
+void SearchEdit::setAppIconVisible(bool visible)
+{
+    if (visible == d->m_appIconLabel->isVisible())
+        return;
+    d->m_appIconAction->setVisible(visible);
+    d->m_appIconLabel->setVisible(visible);
+    d->m_lineEdit->update();
+}
+
+bool SearchEdit::isAppIconVisible() const
+{
+    return d->m_appIconLabel->isVisible();
+}
+
+void SearchEdit::clear()
+{
+    d->m_lineEdit->clear();
+}
+
+void SearchEdit::clearEdit()
+{
+    d->m_lineEdit->clear();
+    d->m_clearButton->setVisible(false);
+    d->m_clearAction->setVisible(false);
+    d->toEditMode(false);
+    if (d->m_lineEdit->hasFocus())
+        d->m_lineEdit->clearFocus();
+}
+
+void SearchEdit::setFocus()
+{
+    d->m_lineEdit->setFocus();
+}
+
+bool SearchEdit::eventFilter(QObject *watched, QEvent *event)
+{
+    if (watched == d->m_iconWidget && event->type() == QEvent::MouseButtonPress) {
+        d->m_lineEdit->setFocus();
+        return true;
+    }
+
+    if (watched == d->m_lineEdit) {
+        switch (event->type()) {
+        case QEvent::FocusIn:
+            d->toEditMode(true);
+            break;
+        case QEvent::FocusOut:
+            d->toEditMode(false);
+            break;
+        case QEvent::KeyPress: {
+            auto *keyEvent = static_cast<QKeyEvent *>(event);
+            if (Q_LIKELY(keyEvent)) {
+                switch (keyEvent->key()) {
+                case Qt::Key_Up:
+                    Q_EMIT selectPreviousItem();
+                    return true;
+                case Qt::Key_Tab:
+                case Qt::Key_Down:
+                    Q_EMIT selectNextItem();
+                    return true;
+                case Qt::Key_Return:
+                case Qt::Key_Enter:
+                    Q_EMIT handleItem();
+                    return true;
+                case Qt::Key_Escape:
+                    Q_EMIT closeWindow();
+                    return true;
+                default:
+                    break;
+                }
+            }
+            break;
+        }
+        case QEvent::ContextMenu: {
+            auto *ctxEvent = static_cast<QContextMenuEvent *>(event);
+            if (Q_LIKELY(ctxEvent)) {
+                d->showContextMenu(ctxEvent->globalPos());
+                return true;
+            }
+            break;
+        }
+        default:
+            break;
+        }
+    }
+    return QWidget::eventFilter(watched, event);
+}
+
+bool SearchEdit::event(QEvent *event)
+{
+    if (event->type() == QEvent::FocusIn) {
+        d->m_lineEdit->setFocus();
+        return true;
+    }
+
+    return QWidget::event(event);
+}

--- a/src/grand-search/gui/entrance/searchedit.h
+++ b/src/grand-search/gui/entrance/searchedit.h
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SEARCHEDIT_H
+#define SEARCHEDIT_H
+
+#include <QLineEdit>
+#include <QScopedPointer>
+
+class QLineEdit;
+class QIcon;
+
+namespace GrandSearch {
+
+class SearchLineEdit : public QLineEdit
+{
+    Q_OBJECT
+public:
+    explicit SearchLineEdit(QWidget *parent = nullptr);
+    ~SearchLineEdit() override;
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+    void focusInEvent(QFocusEvent *event) override;
+    void focusOutEvent(QFocusEvent *event) override;
+
+private:
+    QStyle *m_proxyStyle = nullptr;
+    QTimer *m_cursorBlinkTimer = nullptr;
+    bool m_cursorVisible = true;
+};
+
+class SearchEditPrivate;
+class SearchEdit : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit SearchEdit(QWidget *parent = nullptr);
+    ~SearchEdit() override;
+
+    QLineEdit *lineEdit() const;
+
+    void setPlaceHolder(const QString &text);
+    QString placeHolder() const;
+
+    void setPlaceholderText(const QString &text);
+    QString placeholderText() const;
+
+    void setText(const QString &text);
+    QString text() const;
+
+    void setClearButtonEnabled(bool enable);
+
+    void setAppIcon(const QString &iconName);
+    void setAppIcon(const QIcon &icon);
+    void setAppIconVisible(bool visible);
+    bool isAppIconVisible() const;
+
+    void clear();
+    void clearEdit();
+
+    void setFocus();
+
+signals:
+    void debouncedTextChanged(const QString &text);
+
+    void selectPreviousItem();
+    void selectNextItem();
+    void handleItem();
+    void closeWindow();
+    void searchAborted();
+
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+    bool event(QEvent *event) override;
+
+private:
+    QScopedPointer<SearchEditPrivate> d;
+};
+
+}
+
+#endif // SEARCHEDIT_H

--- a/src/grand-search/gui/entrance/searchedit_p.h
+++ b/src/grand-search/gui/entrance/searchedit_p.h
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SEARCHEDIT_P_H
+#define SEARCHEDIT_P_H
+
+#include "searchedit.h"
+
+#include <DIconButton>
+
+#include <QLabel>
+#include <QHBoxLayout>
+#include <QTimer>
+#include <QAction>
+
+namespace GrandSearch {
+
+class SearchLineEdit;
+
+class SearchEditPrivate
+{
+    SearchEditPrivate(SearchEdit *qq);
+
+    void init();
+    void toEditMode(bool focus);
+    void showContextMenu(const QPoint &pos);
+    void delayTextChanged();
+    void notifyTextChanged();
+
+    SearchEdit *q = nullptr;
+
+    SearchLineEdit *m_lineEdit = nullptr;
+    QWidget *m_iconWidget = nullptr;
+    QLabel *m_placeholderLabel = nullptr;
+    QLabel *m_appIconLabel = nullptr;
+    DTK_WIDGET_NAMESPACE::DIconButton *m_clearButton = nullptr;
+    QAction *m_searchAction = nullptr;
+    QAction *m_clearAction = nullptr;
+    QAction *m_appIconAction = nullptr;
+
+    QHBoxLayout *m_lineEditLayout = nullptr;
+
+    QTimer *m_delayTimer = nullptr;
+
+    QString m_placeHolder;
+    QString m_placeholderText;
+    QString m_appIconName;
+
+    friend class SearchEdit;
+};
+
+}
+
+#endif // SEARCHEDIT_P_H


### PR DESCRIPTION
Extract search input functionality into dedicated SearchEdit class
to improve code modularity and maintainability. The new component
encapsulates all search-related UI elements including the search icon,
placeholder text, clear button, application icon display, and debounced
text change handling. EntranceWidget is simplified to delegate all
search input operations to this new component.

Key changes:
1. Create new SearchEdit class with custom SearchLineEdit supporting
theme-aware cursor rendering
2. Move debounced text change timer, context menu, key event handling,
and focus management from EntranceWidget
3. Implement dual-mode UI: centered placeholder with search icon when
unfocused/empty, left-aligned edit mode when focused or containing text
4. Add external clear button with proper visibility management
5. Preserve existing behavior: 50ms debounce delay, navigation keys (Up/
Down/Tab/Enter/Escape), application icon display

Log: Redesigned search input field with centered placeholder and
improved visual feedback

Influence:
1. Verify search input field displays centered placeholder with search
icon when empty and unfocused
2. Test transition to edit mode when clicking placeholder or gaining
focus
3. Confirm left search icon appears in edit mode with proper placeholder
text
4. Test text input with debounced change notification (50ms delay)
5. Verify clear button appears when text is entered and functions
correctly
6. Test keyboard navigation: Up/Down/Tab for item selection, Enter for
activation, Escape for closing
7. Verify context menu functionality (Cut/Copy/Paste) on right-click
8. Test application icon display when selecting search results with
associated applications
9. Confirm theme switching between light and dark modes updates colors
appropriately
10. Verify cursor visibility and blinking behavior in different focus
states

refactor: 从 EntranceWidget 中提取 SearchEdit 组件

将搜索输入功能提取到独立的 SearchEdit 类中，以提高代码模块化和可维护性。
新组件封装了所有搜索相关的 UI 元素，包括搜索图标、占位文本、清除按钮、应
用图标显示和防抖文本变更处理。EntranceWidget 被简化为将所有搜索输入操作
委托给这个新组件。

主要变更：
1. 创建新的 SearchEdit 类，包含支持主题感知光标渲染的自定义
SearchLineEdit
2. 从 EntranceWidget 移动防抖文本变更定时器、上下文菜单、键盘事件处理和
焦点管理
3. 实现双模式 UI：未聚焦/为空时显示居中的占位符和搜索图标，聚焦或包含文
本时切换到左对齐编辑模式
4. 添加外部清除按钮并完善可见性管理
5. 保留现有行为：50ms 防抖延迟、导航键（上/下/Tab/回车/Escape）、应用图
标显示

Log: 重新设计搜索输入框，支持居中占位符和增强的视觉反馈

Influence:
1. 验证搜索输入框在为空且未聚焦时显示居中的占位符和搜索图标
2. 测试点击占位符或获得焦点时切换到编辑模式的过渡效果
3. 确认编辑模式下左侧搜索图标出现并显示正确的占位文本
4. 测试文本输入及防抖变更通知（50ms 延迟）
5. 验证输入文本时清除按钮出现且功能正常
6. 测试键盘导航：上/下/Tab 选择项目，回车激活，Escape 关闭窗口
7. 验证右键点击的上下文菜单功能（剪切/复制/粘贴）
8. 测试选择带有关联应用的搜索结果时应用图标的显示
9. 确认浅色和深色主题切换时颜色更新正确
10. 验证不同焦点状态下的光标可见性和闪烁行为

BUG: https://pms.uniontech.com/bug-view-361033.html
