### PR TITLE
fix: fix vertical line visibility in exhibition widget

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-grand-search (6.0.34) unstable; urgency=medium
+
+  * refactor: extract SearchEdit component from EntranceWidget
+  * fix: fix vertical line visibility in exhibition widget
+  * chore: update translations
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Wed, 20 May 2026 09:12:20 +0800
+
 dde-grand-search (6.0.33) unstable; urgency=medium
 
   * feat: enable OCR text search and fix keyword parsing

--- a/src/grand-search/gui/entrance/searchedit.cpp
+++ b/src/grand-search/gui/entrance/searchedit.cpp
@@ -139,7 +139,6 @@ void SearchEditPrivate::init()
     // 居中的搜索图标 + 占位文本容器
     m_iconWidget = new QWidget;
     m_iconWidget->setObjectName("iconWidget");
-    m_iconWidget->installEventFilter(q);
     QHBoxLayout *centerLayout = new QHBoxLayout(m_iconWidget);
     centerLayout->setContentsMargins(0, 0, 0, 0);
     centerLayout->setSpacing(6);
@@ -161,15 +160,16 @@ void SearchEditPrivate::init()
     m_placeHolder = SearchEdit::tr("Search");
     m_placeholderLabel->setText(m_placeHolder);
 
-    centerLayout->addWidget(searchIcon, 0, Qt::AlignVCenter);
+    centerLayout->addStretch(1);
+    centerLayout->addWidget(searchIcon, 0, Qt::AlignCenter);
     centerLayout->addWidget(m_placeholderLabel, 0, Qt::AlignCenter);
-    centerLayout->addSpacing(12 / qApp->devicePixelRatio());
+    centerLayout->addStretch(1);
 
     // QLineEdit 内部布局：左侧放 iconWidget（居中），聚焦后隐藏
     m_lineEditLayout = new QHBoxLayout(m_lineEdit);
     m_lineEditLayout->setContentsMargins(0, 0, 0, 0);
     m_lineEditLayout->setSpacing(0);
-    m_lineEditLayout->addWidget(m_iconWidget, 0, Qt::AlignCenter);
+    m_lineEditLayout->addWidget(m_iconWidget);
 
     // 左侧搜索图标 action（聚焦后显示）
     m_searchAction = new QAction(q);
@@ -402,11 +402,6 @@ void SearchEdit::setFocus()
 
 bool SearchEdit::eventFilter(QObject *watched, QEvent *event)
 {
-    if (watched == d->m_iconWidget && event->type() == QEvent::MouseButtonPress) {
-        d->m_lineEdit->setFocus();
-        return true;
-    }
-
     if (watched == d->m_lineEdit) {
         switch (event->type()) {
         case QEvent::FocusIn:
@@ -441,7 +436,7 @@ bool SearchEdit::eventFilter(QObject *watched, QEvent *event)
         }
         case QEvent::ContextMenu: {
             auto *ctxEvent = static_cast<QContextMenuEvent *>(event);
-            if (Q_LIKELY(ctxEvent)) {
+            if (Q_LIKELY(ctxEvent) && !d->m_iconWidget->isVisible()) {
                 d->showContextMenu(ctxEvent->globalPos());
                 return true;
             }

--- a/src/grand-search/gui/exhibition/exhibitionwidget.cpp
+++ b/src/grand-search/gui/exhibition/exhibitionwidget.cpp
@@ -51,6 +51,7 @@ void ExhibitionWidget::clearData()
     qCDebug(logGrandSearch) << "Clearing exhibition data";
     m_matchWidget->clearMatchedData();
     m_previewWidget->hide();
+    m_vLine->hide();
 }
 
 void ExhibitionWidget::onSelectNextItem()
@@ -110,6 +111,7 @@ void ExhibitionWidget::previewItem(const QString &searchGroupName, const Matched
     if (!Utils::canPreview(searchGroupName) || item.name.isEmpty()) {
         qCDebug(logGrandSearch) << "Hiding preview - Group:" << searchGroupName;
         m_previewWidget->hide();
+        m_vLine->hide();
 
         // 不显示预览界面，右侧空隙需为0, 用来贴着主界面右侧显示滚动条区域
         m_hLayout->setContentsMargins(MARGIN_SIZE, 0, 0, MARGIN_SIZE);
@@ -127,6 +129,7 @@ void ExhibitionWidget::previewItem(const QString &searchGroupName, const Matched
 
     // 预览界面预览选择的匹配结果项
     m_previewWidget->previewItem(item);
+    m_vLine->show();
 
     emit sigPreviewStateChanged(true);
 }
@@ -142,8 +145,8 @@ void ExhibitionWidget::initUi()
     m_matchWidget->setFocusPolicy(Qt::NoFocus);
     m_hLayout->addWidget(m_matchWidget);
 
-    DVerticalLine* vLine = new DVerticalLine(this);
-    m_hLayout->addWidget(vLine);
+    m_vLine = new DVerticalLine(this);
+    m_hLayout->addWidget(m_vLine);
 
     m_previewWidget = new PreviewWidget(this);
     m_hLayout->addWidget(m_previewWidget);

--- a/src/grand-search/gui/exhibition/exhibitionwidget.h
+++ b/src/grand-search/gui/exhibition/exhibitionwidget.h
@@ -8,6 +8,7 @@
 #include "global/matcheditem.h"
 
 #include <DWidget>
+#include <DVerticalLine>
 
 #include <QScopedPointer>
 
@@ -61,6 +62,7 @@ private:
     QPushButton *m_btnClear = nullptr;
     MatchWidget *m_matchWidget = nullptr;
     PreviewWidget *m_previewWidget = nullptr;
+    Dtk::Widget::DVerticalLine *m_vLine = nullptr;
 };
 
 }

--- a/translations/dde-grand-search.ts
+++ b/translations/dde-grand-search.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Search</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>What would you like to search for?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Cut</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Copy</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Paste</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Location:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Size:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Time modified:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Open Path</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Copy Path</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>More</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Search</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Cut</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Copy</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Paste</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Time modified:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>modified</translation>
     </message>

--- a/translations/dde-grand-search_af.ts
+++ b/translations/dde-grand-search_af.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Soek</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Wat wil jy soek?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Knip</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Kopie</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Plak</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Lokasie:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Grootte:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Tyd aangepas:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Oopmaak</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Pad oopmaak</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Pad kopie</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Gaan asseblief na %1 om die ULLM te installeer, en %2 Automatiese indeksupdate.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>skakel aan</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Asseblief %1 Automatiese indeksupdate.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Gaan asseblief na %1 om die ULLM te installeer.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Meer</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Soek</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Knip</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Kopie</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Plak</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Laatste aangepas:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>aangepas</translation>
     </message>

--- a/translations/dde-grand-search_am_ET.ts
+++ b/translations/dde-grand-search_am_ET.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>ማሽከርከር</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>ምን ይፈለጋል ማሽከርከር?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>አስር</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>ኮፔ</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>ፕ erotisk</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>위치:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>የተለbbe ጊዜ:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>ክፈል</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>ክፈል በደረጃ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>ክፈል በደረጃ</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>ULLM-ን %1 ውስጥ ይመሩ እና %2 የአውtomated የኢንድክስ የአዘጋጅ ይፈጸማሉ.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>ይፈጸማል</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>እባክ ልክ %1 የአውtomated የኢንድክስ የአዘጋጅ ይፈጸማል.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>ULLM-ን %1 ውስጥ ይመሩ.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>በጣም</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">ማሽከርከር</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">አስር</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">ኮፔ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">ፕ erotisk</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>የተገ_MODIFIED ቦታ:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>ተገ_MODIFIED</translation>
     </message>

--- a/translations/dde-grand-search_ar.ts
+++ b/translations/dde-grand-search_ar.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>بحث</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>ماذا ترغب في البحث عنه؟</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>قص</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>نسخ</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>لصق</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>الموقع:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">الحجم:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>وقت التعديل:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>فتح المسار</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>نسخ المسار</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>يرجى الانتقال إلى %1 لتنزيل ULLM، و%2 تحديث الفهرس تلقائيًا.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>تمكين</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>يرجى %1 تحديث الفهرس تلقائيًا.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>يرجى الانتقال إلى %1 لتنزيل ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>المزيد</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">بحث</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">قص</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">لصق</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>وقت التعديل:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>مُعدّل</translation>
     </message>

--- a/translations/dde-grand-search_az.ts
+++ b/translations/dde-grand-search_az.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Axtar</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Nə axtarmaq istərdiniz?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Kəsin</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Kopyala</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Yerləşdirin</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Məkan:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Ölçü:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Dəyişdirilmə vaxtı:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Aç</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Yolu açın</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Yolu kopyalayın</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>İlk öncə %1-dən ULLM-ni yükləyin və %2 Avtomatik indeks yeniləməsini et.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>daxil edin</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Lütfən %1 Avtomatik indeks yeniləməsini et.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>İlk öncə %1-dən ULLM-ni yükləyin.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Daha çox</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">Heç nə tapılmadı</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Axtar</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Kəsin</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Kopyala</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Yerləşdirin</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Dəyişdirilmə vaxtı:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>dəyişdirilib</translation>
     </message>

--- a/translations/dde-grand-search_bg.ts
+++ b/translations/dde-grand-search_bg.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Търсене</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Какво искате да търсите?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Изрежи</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Копирай</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Постави</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Локация:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Размер:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Време на промяна:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Отвори</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Отвори път</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Копирай път</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Моля, отидете на %1 за инсталиране на ULLM, и %2 Автоматично актулиране на индекса.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>включете</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Моля, %1 Автоматично актулиране на индекса.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Моля, отидете на %1 за инсталиране на ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Повече</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Търсене</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Изрежи</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Копирай</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Постави</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Време на промяна:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>променен</translation>
     </message>

--- a/translations/dde-grand-search_bn.ts
+++ b/translations/dde-grand-search_bn.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>অনুসন্ধান</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>আপনি কি অনুসন্ধান করতে চান?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>কাট</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>কপি</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>পেস্ট</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>স্থান:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">আকার:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>সময় পরিবর্তন হয়েছে:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>প্রস্তুত</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>পথ খুলুন</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>পথ কপি</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>ফাইল ম্যানেজার এবং গ্রান্ড সার্চে আপনি স্বয়ংক্রিয় ইনডেক্স আপডেট ব্যবহার করতে পারবেন, তবে আপনি প্রথমে %1 এ উলম ইনস্টল করতে হবে।</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>টার্ন অন</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>আপনি প্রথমে %1 স্বয়ংক্রিয় ইনডেক্স আপডেট ব্যবহার করতে পারবেন।</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>আপনি প্রথমে %1 এ উলম ইনস্টল করতে হবে।</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>আরও</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">অনুসন্ধান</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">কাট</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">কপি</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">পেস্ট</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>সময় পরিবর্তন হয়েছে:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>পরিবর্তন হয়েছে</translation>
     </message>

--- a/translations/dde-grand-search_bo.ts
+++ b/translations/dde-grand-search_bo.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation type="unfinished">བཤེར་འཚོལ།</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation type="unfinished">འཚོལ་འདོད་པའི་ནང་དོན་བཤེར་འཚོལ།</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation type="unfinished">དྲས་གཏུབ།</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation type="unfinished">པར་སློག </translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation type="unfinished">སྦྱར་བ།</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation type="unfinished">གནས་ས།</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">ཆེ་ཆུང་། </translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation type="unfinished">བཟོ་བའི་དུས་ཚོད།</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation type="unfinished">ཁ་ཕྱེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation type="unfinished">འབྱེད་ལམ།</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation type="unfinished">པར་སློག་བྱེད་ལམ།</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>please %1 Automatic index update.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>please go to %1 to install the ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation type="unfinished">དེ་བས་མང་བར་ལྟ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">བཙལ་འབྲས་མེད།</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">བཤེར་འཚོལ།</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">དྲས་གཏུབ།</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">པར་སློག </translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">སྦྱར་བ།</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>བཟོ་བའི་དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/dde-grand-search_br.ts
+++ b/translations/dde-grand-search_br.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>بحث</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>ما الذي ترغب في البحث عنه؟</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>قص</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>نسخ</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>لصق</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>الموقع:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">الحجم:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>وقت التعديل:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>فتح المسار</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>نسخ المسار</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>يرجى الانتقال إلى %1 لتنزيل ULLM، و%2 تحديث التفهرس تلقائيًا.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>تفعيل</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>يرجى %1 تحديث التفهرس تلقائيًا.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>يرجى الانتقال إلى %1 لتنزيل ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>أكثر</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">بحث</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">قص</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">لصق</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>وقت التعديل:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>مُعدّل</translation>
     </message>

--- a/translations/dde-grand-search_ca.ts
+++ b/translations/dde-grand-search_ca.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Cerca</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Què voleu cercar?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Retalla</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Copia</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Enganxa</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Ubicació:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Mida:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Hora de modificació:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Obre</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Obre&apos;n el camí</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Copia&apos;n el camí</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Si us plau, aneu a %1 per instal·lar el ULLM, i %2 Actualització automàtica de l&apos;índex.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>activar</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Si us plau, %1 Actualització automàtica de l&apos;índex.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Si us plau, aneu a %1 per instal·lar el ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Més</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No hi ha resultats de la cerca.</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Cerca</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Retalla</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Copia</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Enganxa</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Hora de modificació:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>modificat</translation>
     </message>

--- a/translations/dde-grand-search_cs.ts
+++ b/translations/dde-grand-search_cs.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Hledat</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Co chcete hledat?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Vyjmout</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Zkopírovat</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Vložit</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Umístění:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Velikost:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Okamžik změny:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Otevřít</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Otevřít popis umístění</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Zkopírovat popis umístění</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Prosím, pojďte do %1 a nainstalujte ULLM, a %2 Automatické aktualizace indexu.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>zapnout</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Prosím, %1 Automatické aktualizace indexu.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Prosím, pojďte do %1 a nainstalujte ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Více</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">Nic nenalezeno</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Hledat</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Vyjmout</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Zkopírovat</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Vložit</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Okamžik změny:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>změněno</translation>
     </message>

--- a/translations/dde-grand-search_da.ts
+++ b/translations/dde-grand-search_da.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Søg</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Hvad vil du søge efter?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Klip</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Kopiér</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Indsæt</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Sted:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Størrelse:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Sidst ændret:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Åbn</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Åbn sti</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Kopiér sti</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Vennligst gå til %1 for at installere ULLM og %2 Automatisk indexopdatering.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>tænd</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Vennligst %1 Automatisk indexopdatering.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Vennligst gå til %1 for at installere ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Mere</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Søg</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Klip</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Kopiér</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Indsæt</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Tid ændret:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>ændret</translation>
     </message>

--- a/translations/dde-grand-search_de.ts
+++ b/translations/dde-grand-search_de.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Suche</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Wonach möchten Sie suchen?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Ausschneiden</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Kopieren</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Einfügen</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Ort:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Größe:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Änderungszeit:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Pfad öffnen</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Pfad kopieren</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Mehr</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">Keine Suchergebnisse</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Suche</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Ausschneiden</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Kopieren</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Einfügen</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Änderungszeit:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>geändert</translation>
     </message>

--- a/translations/dde-grand-search_el.ts
+++ b/translations/dde-grand-search_el.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Αναζήτηση</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Τι θέλετε να αναζητήσετε;</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Κοπή</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Αντιγραφή</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Επικόλληση</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Τοποθεσία:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Ώρα τροποποίησης:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Άνοιγμα Σύντομης Διαδρομής</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Αντιγραφή Σύντομης Διαδρομής</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Παρακαλώ πάρτε το %1 για να εγκαταστήσετε το ULLM και την %2 αυτόματη ενημέρωση ευρετηρίου.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>ενεργοποιήστε</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Παρακαλώ ενεργοποιήστε την αυτόματη ενημέρωση ευρετηρίου.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Παρακαλώ πάρτε το %1 για να εγκαταστήσετε το ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Περισσότερα</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Αναζήτηση</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Κοπή</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Αντιγραφή</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Επικόλληση</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Ώρα τροποποίησης:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>τροποποιημένο</translation>
     </message>

--- a/translations/dde-grand-search_en_US.ts
+++ b/translations/dde-grand-search_en_US.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Search</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>What would you like to search for?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Cut</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Copy</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Paste</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Location:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Size:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Time modified:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Open Path</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Copy Path</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Please go to %1 to install the ULLM, and %2 Automatic index update.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>turn on</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Please %1 Automatic index update.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Please go to %1 to install the ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>More</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation>No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Search</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Cut</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Copy</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Paste</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Time modified:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>modified</translation>
     </message>

--- a/translations/dde-grand-search_eo.ts
+++ b/translations/dde-grand-search_eo.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Serĉi</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Kion vi volas serĉi?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Klipo</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Kopii</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Malki</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Loko:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Dimensio:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Tempo modifika:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Malfermi</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Malfermi la vojon</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Kopii la vojon</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Bonvolu irivi al %1 por instaligi la ULLM, kaj %2 Aŭtomata indekso-aktualigo.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>ŝalti</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Bonvolu %1 Aŭtomata indekso-aktualigo.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Bonvolu irivi al %1 por instaligi la ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Plu</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Serĉi</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Klipo</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Kopii</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Malki</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Tempo de modifado:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>modifita</translation>
     </message>

--- a/translations/dde-grand-search_es.ts
+++ b/translations/dde-grand-search_es.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>GrandSearch::AiToolBar</name>
     <message>
@@ -179,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>¿Qué desea buscar?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Cortar</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Copiar</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Pegar</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Ubicación:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation>Tamaño:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Hora modificada:</translation>
     </message>
@@ -229,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Ruta libre</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Copiar ruta</translation>
     </message>
@@ -247,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Por favor, vaya a %1 para instalar ULLM y a %2 para la actualización automática del índice.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation>Ajustes de búsqueda</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>Activar</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>%1 Actualización automática del índice.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Por favor, diríjase a %1 para instalar ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Más</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation>Sin resultados</translation>
     </message>
@@ -540,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Buscar</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Cortar</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Copiar</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Pegar</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -792,7 +799,7 @@
         <translation>Hora de la modificación</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>Modificado</translation>
     </message>

--- a/translations/dde-grand-search_et.ts
+++ b/translations/dde-grand-search_et.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Otsing</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Mis soovitakse otsida?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Kinni</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Kopeerida</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Kleebida</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Asukoht:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Suurus:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Muutus aeg:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Avada</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Avada tee</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Kopeeri tee</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Palun mine %1 juurde ULLM installimiseks, ja %2 Automaatne indeks päivitys.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>sõitma</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Palun %1 Automaatne indeks päivitys.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Palun mine %1 juurde ULLM installimiseks.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Rohkem</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Otsing</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Kinni</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Kopeerida</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Kleebida</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Muutusaja:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>muudatud</translation>
     </message>

--- a/translations/dde-grand-search_eu.ts
+++ b/translations/dde-grand-search_eu.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Bilatu</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Zein bilatu nahi duzu?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Kopiatu</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Kopia</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Itsatsi</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Koordenatua:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Data aldatua:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Ireki</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Ireki bidea</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Kopia bidea</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Mesedez joan %1 %2 automatikoa indeksua eguneratzea instalatzeko.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>gaitu</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Mesedez %1 automatikoa indeksua eguneratzea.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Mesedez joan %1 %2 automatikoa instalatzeko.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Garrantzitsuagoa</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Bilatu</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Kopiatu</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Kopia</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Itsatsi</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Aldatze-data:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>aldatua</translation>
     </message>

--- a/translations/dde-grand-search_fa.ts
+++ b/translations/dde-grand-search_fa.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>جستجو</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>چه چیزی را می‌خواهید جستجو کنید؟</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>برید</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>کپی کن</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>چسبان</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>مکان:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">اندازه:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>زمان ویرایش:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>باز کن</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>مسیر را باز کن</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>مسیر را کپی کن</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>لطفا به %1 بروید تا ULLM را نصب کنید و %2 به‌روزرسانی خودکار اندیکس را فعال کنید.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>فعال کن</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>لطفا %1 به‌روزرسانی خودکار اندیکس را فعال کنید.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>لطفا به %1 بروید تا ULLM را نصب کنید.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>بیشتر</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">جستجو</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">برید</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">کپی کن</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">چسبان</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>زمان ویرایش:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>ویرایش شده</translation>
     </message>

--- a/translations/dde-grand-search_fi.ts
+++ b/translations/dde-grand-search_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>GrandSearch::AiToolBar</name>
     <message>
@@ -179,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Etsi</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Mitä haluaisit etsiä?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Leikkaa</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Kopioi</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Liitä</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Sijainti:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation>Koko:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Muutosaika:</translation>
     </message>
@@ -229,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Avaa</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Avaa polku</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Kopioi polku</translation>
     </message>
@@ -247,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Siirry %1 -osoitteeseen asentaaaksesi ULLM -ohjelman, ja %2 Automaattinen indeksin päivitys.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation>Hakuasetukset</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>Päälle</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Käytä %1 Automaattinen indeksin päivitys.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Siirry %1 -osoitteeseen asentaaaksesi ULLM -ohjelman.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Lisää</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation>Ei hakutuloksia</translation>
     </message>
@@ -540,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Etsi</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Leikkaa</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Kopioi</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Liitä</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -792,7 +799,7 @@
         <translation>Muutosaika:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>muokattu</translation>
     </message>

--- a/translations/dde-grand-search_fil.ts
+++ b/translations/dde-grand-search_fil.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Paghahanap</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Ano ang nais mong hanapin?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Ibigay</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Kopyahin</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Ilipat</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Lokasyon:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Oras ng pagbabago:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Bumukas</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Bumukas ng landas</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Kopyahin ang landas</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Please pumunta sa %1 para i-install ang ULLM, at %2 Ang automaikong index update.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>paganahin</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Please %1 Ang automaikong index update.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Please pumunta sa %1 para i-install ang ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Mas</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Paghahanap</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Ibigay</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Kopyahin</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Ilipat</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Oras na binago:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>binago</translation>
     </message>

--- a/translations/dde-grand-search_fr.ts
+++ b/translations/dde-grand-search_fr.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Rechercher</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Qu&apos;aimeriez-vous rechercher&#xa0;?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Couper</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Copier</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Coller</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Emplacement :</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Taille :</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Heure modifiée :</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Ouvrir</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Ouvrir le chemin</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Copier le chemin</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>من فضلك انتقل إلى %1 لتثبيت ULLM، و%2 تحديث المؤشر تلقائيًا.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>تمكين</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>من فضلك %1 تحديث المؤشر تلقائيًا.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>من فضلك انتقل إلى %1 لتثبيت ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Autres</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">Aucun résultat trouvé</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Rechercher</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Couper</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Copier</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Coller</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Heure modifiée :</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>modifié</translation>
     </message>

--- a/translations/dde-grand-search_gl_ES.ts
+++ b/translations/dde-grand-search_gl_ES.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>بحث</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>ما الذي ترغب في البحث عنه؟</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>القص</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>النسخ</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>اللصق</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>الموقع:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>وقت التعديل:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>فتح المسار</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>نسخ المسار</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>الرجاء الانتقال إلى %1 لتنزيل ULLM، و%2 تحديث المؤشر تلقائيًا.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>تفعيل</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>الرجاء %1 تحديث المؤشر تلقائيًا.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>الرجاء الانتقال إلى %1 لتنزيل ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>أكثر</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">بحث</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">القص</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">النسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">اللصق</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>وقت التعديل:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>مُعدّل</translation>
     </message>

--- a/translations/dde-grand-search_he.ts
+++ b/translations/dde-grand-search_he.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>חפש</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>מה תרצה ללחפש?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>לצמצם</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>לעתק</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>לבסס</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation> الموقع:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>זמן שינוי</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>לפתוח</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>לפתוח את المسار</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>לעתק المسار</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>אנא היכן %1 להתקנת ULLM, ו-%2 עדכון אינדקס אוטומטי.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>לتشغيل</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>אנא %1 עדכון אינדקס אוטומטי.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>אנא לעבור ל-%1 להתקנת ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>עוד</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">חפש</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">לצמצם</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">לעתק</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">לבסס</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>وقت التعديل:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>مُعدّل</translation>
     </message>

--- a/translations/dde-grand-search_hi_IN.ts
+++ b/translations/dde-grand-search_hi_IN.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>सर्च</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>आप क्या सर्च करना चाहते हैं?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>काट</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>कॉपी</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>पेस्ट</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>स्थान:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>समय संशोधित किया गया:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>पथ खोलें</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>पथ कॉपी करें</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>कृपया %1 में ULLM इंस्टॉल करें, और %2 स्वचालित सूची अपडेट करें।</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>सुलभ करें</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>कृपया %1 स्वचालित सूची अपडेट करें।</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>कृपया %1 में ULLM इंस्टॉल करें।</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>अधिक</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">सर्च</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">काट</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">कॉपी</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">पेस्ट</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>अद्यतन समय:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>अद्यतन</translation>
     </message>

--- a/translations/dde-grand-search_hr.ts
+++ b/translations/dde-grand-search_hr.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Traži</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Što biste htjeli tražiti?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Izmaglica</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Kopiraj</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Zalijepi</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Lokacija:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Veličina:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Vrijeme izmjene:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Otvori</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Otvori putanju</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Kopiraj putanju</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Molimo vas idite na %1 za instalaciju ULLM-a, i %2 Automatsko ažuriranje indeksa.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>uključi</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Molimo vas %1 Automatsko ažuriranje indeksa.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Molimo vas idite na %1 za instalaciju ULLM-a.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Više</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Traži</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Izmaglica</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Kopiraj</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Zalijepi</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Vrijeme izmjene:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>izmjenjen</translation>
     </message>

--- a/translations/dde-grand-search_hu.ts
+++ b/translations/dde-grand-search_hu.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Keresés</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Mit szeretne keresni?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Kivágás</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Másolás</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Beillesztés</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Hely:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Méret:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Módosítási idő:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Megnyitás</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Megnyitási útvonal</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Másolási útvonal</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Kérlek menj a %1-be a ULLM telepítéséhez, és %2 automatikus index frissítés.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>be</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Kérlek %1 automatikus index frissítés.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Kérlek menj a %1-be a ULLM telepítéséhez.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Továbbiak</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">Nincs keresési eredmény</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Keresés</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Kivágás</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Másolás</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Beillesztés</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Módosítási idő:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>Módosított</translation>
     </message>

--- a/translations/dde-grand-search_hy.ts
+++ b/translations/dde-grand-search_hy.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Որոնել</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Ինչ ցանկանում եք որոնել?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Կտացնել</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Կպատճենել</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Ընթերցել</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Տեղը:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Վերահաստատում է տեղի ունեցել:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Բացել</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Բացել ճանապարհը</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Կպատճենել ճանապարհը</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Խնդրում ենք գնալ %1 և բացակայում է ավտոմատ ինդեքս թարմացումը</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>միացնել</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Խնդրում ենք ավտոմատ ինդեքս թարմացումը</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Խնդրում ենք գնալ %1 և ստանալ ULLM</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Ավելին</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Որոնել</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Կտացնել</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Կպատճենել</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Ընթերցել</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Վերակազմակերպման ժամանակը:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>փոխարկված</translation>
     </message>

--- a/translations/dde-grand-search_id.ts
+++ b/translations/dde-grand-search_id.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Cari</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Apa yang ingin Anda cari?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Potong</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Salin</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Tempel</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Lokasi:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Ukuran:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Waktu diubah:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Buka</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Buka Jalur</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Salin Jalur</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Silakan pergi ke %1 untuk menginstal ULLM, dan %2 Pembaruan indeks otomatis.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>nyalakan</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Silakan %1 Pembaruan indeks otomatis.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Silakan pergi ke %1 untuk menginstal ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Lebih banyak</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Cari</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Potong</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Salin</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Tempel</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Waktu diubah:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>diubah</translation>
     </message>

--- a/translations/dde-grand-search_it.ts
+++ b/translations/dde-grand-search_it.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Cerca</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Cosa desideri cercare?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Taglia</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Copia</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Incolla</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Luogo:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Dimensioni:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Ora modifica:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Apri percorso</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Copia percorso</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Di più...</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">Nessun risultato</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Cerca</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Taglia</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Copia</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Incolla</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Ora modifica:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>modificato</translation>
     </message>

--- a/translations/dde-grand-search_ja.ts
+++ b/translations/dde-grand-search_ja.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/dde-grand-search_ka.ts
+++ b/translations/dde-grand-search_ka.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>საძებვად</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>რას გსურთ საძებვად?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>კოპირება და ჩამოყალიბება</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>კოპირება</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>ჩასვება</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>მდებარეობა:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">ზომა:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>განახლების დრო:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>გახსნა</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>გახსნა გზით</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>გზის კოპირება</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>გთხოვთ გადაადგილდეთ %1 და დააყენეთ ULLM, და განახლების ინდექსისთვის გამოიყენეთ %2</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>ჩართვა</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>გთხოვთ გამოიყენოთ %1 ავტომატური ინდექსის განახლება</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>გთხოვთ გადაადგილდეთ %1 და დააყენოთ ULLM</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>მეტი</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">საძებვად</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">კოპირება და ჩამოყალიბება</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">კოპირება</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">ჩასვება</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>დრო შეცვლისთვის:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>შეცვლილი</translation>
     </message>

--- a/translations/dde-grand-search_km_KH.ts
+++ b/translations/dde-grand-search_km_KH.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>ស្រាវជ្រាវ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>អ្នកចង់ស្រាវជ្រាវអ្វី?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>កាត់</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>ថត</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>ត្រឡប់</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>ទីតាំង:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>ពេលកែប្រែ:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>បើក</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>បើកផ្លូវ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>ថតផែនកំណត់</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>សូមទៅកាន់ %1 ដើម្បីបើកដំណើរការ ULLM និង %2 ការផ្លាស់ប្ដូរបណ្ណាល័យដោយស្វ័យប្រវត្តិ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>បើក</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>សូម %1 ការផ្លាស់ប្ដូរបណ្ណាល័យដោយស្វ័យប្រវត្តិ។</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>សូមទៅកាន់ %1 ដើម្បីបើកដំណើរការ ULLM។</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>បន្ថែម</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">ស្រាវជ្រាវ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">កាត់</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">ថត</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">ត្រឡប់</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>ពេលបានកែសម្រួល:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>បានកែសម្រួល</translation>
     </message>

--- a/translations/dde-grand-search_kn_IN.ts
+++ b/translations/dde-grand-search_kn_IN.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>ಅನ್ವೇಷಣೆ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>ಈಗ ನೀವು ಯಾವುದನ್ನು ಅನ್ವೇಷಿಸಲು ಬಯಸುತ್ತೀರಾ?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>ಕತ್ತಿರಿಸಿ</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>ನಕಲಿಸಿ</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>ಪೇಸ್ಟ್ ಮಾಡಿ</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>ಸ್ಥಳ:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">ಆಕಾರ:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>ಸುರಕ್ಷತೆ ಬದಲಾವಣೆ ಸಮಯ:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>ಪ್ರಾರಂಭಿಸಿ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>ಪಥ ಪ್ರಾರಂಭಿಸಿ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>ಪಥ ನಕಲಿಸಿ</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>ಮುಂಚೆ %1 ಗೆ ಹೋಗಿ ULLM ಅನ್ನು ಸ್ಥಾಪಿಸಬೇಕು, ಮತ್ತು %2 ಆಟೋಮೇಟಿಕ್ ಇಂಡೆಕ್ಸ್ ಅಪ್ಡೇಟ್ ಮಾಡಬೇಕು.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>ಪರಿಮಾಣ ಮಾಡಿ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>ಮುಂಚೆ %1 ಆಟೋಮೇಟಿಕ್ ಇಂಡೆಕ್ಸ್ ಅಪ್ಡೇಟ್ ಮಾಡಬೇಕು.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>ಮುಂಚೆ %1 ಗೆ ಹೋಗಿ ULLM ಅನ್ನು ಸ್ಥಾಪಿಸಬೇಕು.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>ಹೆಚ್ಚು</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">ಅನ್ವೇಷಣೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">ಕತ್ತಿರಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">ನಕಲಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">ಪೇಸ್ಟ್ ಮಾಡಿ</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>ಸಂಪಾದನೆಯ ಸಮಯ:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>ಸಂಪಾದನೆಯ</translation>
     </message>

--- a/translations/dde-grand-search_ko.ts
+++ b/translations/dde-grand-search_ko.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>검색</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>검색할 내용은 무엇인가요?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>잘라내기</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>복사</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>붙여넣기</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>위치:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">크기:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>수정 시간:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>경로 열기</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>경로 복사</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>ULLM을 설치하려면 %1로 이동하세요, %2 자동 인덱스 업데이트.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>켜기</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>자동 인덱스 업데이트를 위해 %1을 설치하세요.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>ULLM을 설치하려면 %1로 이동하세요.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>더 보기</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">검색</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">잘라내기</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">복사</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">붙여넣기</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>수정 시간:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>수정됨</translation>
     </message>

--- a/translations/dde-grand-search_ku.ts
+++ b/translations/dde-grand-search_ku.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>کۆنەکردن</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>چەمەن بەکاربکرە؟</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>بەکەش</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>کۆپی کەن</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>بچووک کەن</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>ئەمەکە:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>زمانی دەگەڕاو:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>بەکەش</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>مسیری بەکەش</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>مسیری کۆپی کەن</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>لە %1 بەکەشەوە ULLM بەکەشەوە و %2 ئەوە بەکەشەوە</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>بەکەش</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>لە %1 بەکەشەوە</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>لە %1 بەکەشەوە ULLM بەکەشەوە</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>بەشێکتر</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">کۆنەکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">بەکەش</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">کۆپی کەن</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">بچووک کەن</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>زمانی تەمەمکردن:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>تەمەمکردن</translation>
     </message>

--- a/translations/dde-grand-search_ku_IQ.ts
+++ b/translations/dde-grand-search_ku_IQ.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>گەڕان</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>چەمەتەوە بەکارهێنەری گەڕان بکەرە؟</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>بەسەرکتە بکەرەوە</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>کۆپی بکەرەوە</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>پاست کەرەوە</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>ئەنجامەت:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>زمانی دەگەڕاوە:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>باز کەرەوە</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>مسیرەت باز کەرەوە</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>مسیرەت کۆپی کەرەوە</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>لە %1 بۆ ULLM ئەوە بکەرەوە، و %2 ئەوە بکەرەوە</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>بەسەرکتە بکەرەوە</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>لە %1 بۆ ئەوە بکەرەوە</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>لە %1 بۆ ULLM ئەوە بکەرەوە</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>بەرەوە</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">گەڕان</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">بەسەرکتە بکەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">کۆپی بکەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">پاست کەرەوە</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>زمانی تەمەم کردن:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>تەمەم کردن</translation>
     </message>

--- a/translations/dde-grand-search_ky.ts
+++ b/translations/dde-grand-search_ky.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Іздеу</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Сіз қандай іздеу үшін болар еді?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Жылып тартып</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Көчүрүп</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Жылып коюу</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Жайылтып</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Бөтөнөнөн</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Ачып</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Жолун ачып</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Жолун көчүрүп</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Кеңеш %1-де ULLM-ды инстолдоо керек, %2 Автоматтык индекс жаңылашуу</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>Жүзөгө тартып</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Кеңеш %1 Автоматтык индекс жаңылашуу</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Кеңеш %1-де ULLM-ды инстолдоо керек</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Көп</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Іздеу</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Жылып тартып</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Көчүрүп</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Жылып коюу</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Түзөлгөн узундугу:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>түзөлгөн</translation>
     </message>

--- a/translations/dde-grand-search_lo.ts
+++ b/translations/dde-grand-search_lo.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>ຄົ້ນຫາ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>ທ່ານຕ້ອງການຄົ້ນຫາຫຍັງ?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>ຕັດ</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>ສຳເນົາ</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>ວາງ</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>ສະຖານທີ່:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>ເວລາທີ່ຖືກແກ້ໄຂ:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>ເປີດ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>ເປີດເສັ້ນທາງ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>ສຳເນົາເສັ້ນທາງ</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>ກະລຸນາໄປທີ່ %1 ເພື່ອຕິດຕັ້ງ ULLM, ແລະ %2 ການອັບເດດດັດສະນີອັດຕະໂນມັດ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>ເປີດ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>ກະລຸນາ %1 ການອັບເດດດັດສະນີອັດຕະໂນມັດ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>ກະລຸນາໄປທີ່ %1 ເພື່ອຕິດຕັ້ງ ULLM</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>ຫຼາຍກວ່ານັ້ນ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation>ບໍ່ມີຜົນການຄົ້ນຫາ</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">ຄົ້ນຫາ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">ຕັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">ສຳເນົາ</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">ວາງ</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>ເວລາທີ່ແກ້ໄຂ:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>ແກ້ໄຂແລ້ວ</translation>
     </message>

--- a/translations/dde-grand-search_lt.ts
+++ b/translations/dde-grand-search_lt.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Paieška</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Ką norėtumėte ieškoti?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Pašalinkti</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Paleiskti</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Įkleisti</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Vietis:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Pakeitimų laikas:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Atverti</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Atverti kelią</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Paleisti kelią</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Įdiegti ULLM aplikacijų prekyvietėje, ir %2 Automatinis indekso atnaujinimas.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>įjungti</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Įdiegti %1 Automatinis indekso atnaujinimas.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Įdiegti ULLM aplikacijų prekyvietėje.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Daugiau</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Paieška</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Pašalinkti</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Paleiskti</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Įkleisti</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Pakeista laikas:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>pakeista</translation>
     </message>

--- a/translations/dde-grand-search_ml.ts
+++ b/translations/dde-grand-search_ml.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>സെർച്ച് ചെയ്യുക</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>നിങ്ങൾ എന്ത് തിരിച്ചറിയാൻ ആഗ്രഹിക്കുന്നു?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>ചിരിക്കുക</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>കോപ്പി ചെയ്യുക</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>പേസ്റ്റ് ചെയ്യുക</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>സ്ഥലം:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">വലുപ്പം:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>സമയം മാറ്റി:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>മുറിയിൽ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>പാത തുറക്കുക</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>പാത കോപ്പി ചെയ്യുക</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>നിങ്ങൾ ഉള്ള മോഡൽ ഇൻസ്റ്റാൾ ചെയ്യാൻ %1 എന്ന സ്ഥലത്ത് പോകുക, അതുപോലെ %2 ആട്ടോമാറ്റിക് ഇൻഡക്സ് അപ്ഡേറ്റ് ചെയ്യുക.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>ഓൺ ചെയ്യുക</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>നിങ്ങൾ %1 ആട്ടോമാറ്റിക് ഇൻഡക്സ് അപ്ഡേറ്റ് ചെയ്യുക.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>നിങ്ങൾ ഉള്ള മോഡൽ ഇൻസ്റ്റാൾ ചെയ്യാൻ %1 എന്ന സ്ഥലത്ത് പോകുക.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>ഇതിൽ കൂടുതൽ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">സെർച്ച് ചെയ്യുക</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">ചിരിക്കുക</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">കോപ്പി ചെയ്യുക</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">പേസ്റ്റ് ചെയ്യുക</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>തിരുത്തപ്പെട്ട സമയം:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>തിരുത്തപ്പെട്ട</translation>
     </message>

--- a/translations/dde-grand-search_mn.ts
+++ b/translations/dde-grand-search_mn.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Хайх</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Хэдэн түүхийг хайх болохыг сонгох?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Харагдах</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Хуваах</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Нэмэх</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Хаяг:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Хэмжээ:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Өдөр болон үед</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Хаах</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Хаах уур</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Хуваах уур</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Хүнсний хаягийг %1-д барих болно, %2 автомат индекс шинэчлэл.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>үүсгэх</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Хүнсний хаягийг %1-д барих болно.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Хүнсний хаягийг %1-д барих болно.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Боломжууд</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Хайх</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Харагдах</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Хуваах</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Нэмэх</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Засварлагдсан хугацаа:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>засварлагдсан</translation>
     </message>

--- a/translations/dde-grand-search_mr.ts
+++ b/translations/dde-grand-search_mr.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>सर्च करा</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>तुम्हाला काय सर्च करायचे आहे?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>काटा</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>कॉपी करा</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>पेस्ट करा</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>स्थळ:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>समय बदललेला:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>ओपन करा</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>ओपन पथ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>कॉपी पथ</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>कृपया %1 मध्ये जा आणि ULLM इंस्टॉल करा, आणि %2 स्वत: अपडेट करा.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>ओन करा</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>कृपया %1 स्वत: अपडेट करा.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>कृपया %1 मध्ये जा आणि ULLM इंस्टॉल करा.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>अधिक</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">सर्च करा</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">काटा</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">कॉपी करा</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">पेस्ट करा</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>સમય બદલાયો:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>બદલાયો</translation>
     </message>

--- a/translations/dde-grand-search_ms.ts
+++ b/translations/dde-grand-search_ms.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Cari</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Apa yang ingin anda cari?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Potong</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Salin</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Tempel</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Lokasi:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Saiz:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Masa dimodifikasi:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Buka</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Buka Lajur</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Salin Lajur</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Sila pergi ke %1 untuk memasang ULLM, dan %2 Pemperbaruan indeks automatik.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>hidupkan</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Sila %1 Pemperbaruan indeks automatik.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Sila pergi ke %1 untuk memasang ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Lebih Banyak</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Cari</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Potong</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Salin</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Tempel</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Masa dikemaskini:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>dikemaskini</translation>
     </message>

--- a/translations/dde-grand-search_my.ts
+++ b/translations/dde-grand-search_my.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>ရှာမှု</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>ကျွန်ုပ်အား ဘာကို ရှာလိုသလဲ။</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>ตัด</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>คัดลอก</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>วาง</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>ตำแหน่ง:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">အရွယ်အစား:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>เวลาที่แก้ไข:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>เปิด</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>เปิดเส้นทาง</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>คัดลอกเส้นผ่าน</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>กรุณาไปที่ %1 เพื่อติดตั้ง ULLM และ %2 การอัปเดตดัชนีอัตโนมัติ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>เปิดใช้งาน</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>กรุณา %1 การอัปเดตดัชนีอัตโนมัติ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>กรุณาไปที่ %1 เพื่อติดตั้ง ULLM</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>เพิ่มเติม</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">ရှာမှု</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">ตัด</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">คัดลอก</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">วาง</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>ပြင်ဆင်သည့်အချိန်:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>ပြင်ဆင်ထားသည့်</translation>
     </message>

--- a/translations/dde-grand-search_nb.ts
+++ b/translations/dde-grand-search_nb.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Søk</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Hva vil du søke etter?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Klipp</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Kopiér</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Lim</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Sted:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Størrelse:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Tid endret:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Åpne</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Åpne sti</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Kopiér sti</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Vennligst gå til %1 for å installere ULLM, og %2 automatisk indeksoppdatering.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>slå på</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Vennligst %1 automatisk indeksoppdatering.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Vennligst gå til %1 for å installere ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Mer</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Søk</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Klipp</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Kopiér</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Lim</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Tid endret:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>endret</translation>
     </message>

--- a/translations/dde-grand-search_ne.ts
+++ b/translations/dde-grand-search_ne.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>सर्च गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>तपाईं के खोज्न चाहानु छुन्छ?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>काट्नुहोस्</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>काट्नुहोस्</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>पेस्ट गर्नुहोस्</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>स्थान:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>समय बदलिलाँ:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>खोल्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>मार्ग खोल्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>मार्ग काट्नुहोस्</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>कृपया %1 मा जानुहोस् र %2 स्वचालित सूची अपडेट गर्नुहोस्।</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>सक्षम गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>कृपया %1 स्वचालित सूची अपडेट गर्नुहोस्।</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>कृपया %1 मा जानुहोस् र ULLM स्थापन गर्नुहोस्।</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>अधिक</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">सर्च गर्नुहोस्</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">काट्नुहोस्</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">काट्नुहोस्</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">पेस्ट गर्नुहोस्</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>समय बदलिएको:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>बदलिएको</translation>
     </message>

--- a/translations/dde-grand-search_nl.ts
+++ b/translations/dde-grand-search_nl.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Zoeken</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Waar ben je naar op zoek?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Knippen</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Klonen</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Plakken</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Locatie:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Grootte:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Laatst bewerkt om</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Locatie openen</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Locatie kopiëren</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Ga naar %1 om de ULLM te installeren, en %2 Automatische index-update.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>aanzetten</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Ga naar %1 voor automatische index-update.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Ga naar %1 om de ULLM te installeren.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Meer</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">Geen zoekresultaten</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Zoeken</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Knippen</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Klonen</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Plakken</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Laatst bewerkt om</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>bewerkt</translation>
     </message>

--- a/translations/dde-grand-search_pl.ts
+++ b/translations/dde-grand-search_pl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>GrandSearch::AiToolBar</name>
     <message>
@@ -179,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Szukaj</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Co chciałbyś wyszukać?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Wytnij</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Kopiuj</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Wklej</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Położenie:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation>Rozmiar:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Data modyfikacji:</translation>
     </message>
@@ -229,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Otwórz</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Otwórz ścieżkę</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Kopiuj ścieżkę</translation>
     </message>
@@ -247,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Proszę przejdź do %1, aby zainstalować ULLM, oraz %2 automatyczne aktualizowanie indeksu.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation>Konfiguracja wyszukiwania</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>włącz</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Proszę %1 automatyczne aktualizowanie indeksu.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Proszę przejdź do %1, aby zainstalować ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Więcej</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation>Brak wyników wyszukiwania</translation>
     </message>
@@ -540,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Szukaj</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Wytnij</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Kopiuj</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Wklej</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -792,7 +799,7 @@
         <translation>Data modyfikacji:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>zmodyfikowany</translation>
     </message>

--- a/translations/dde-grand-search_pt.ts
+++ b/translations/dde-grand-search_pt.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation type="unfinished">Pesquisar</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation type="unfinished">O que deseja pesquisar?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation type="unfinished">Cortar</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation type="unfinished">Copiar</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation type="unfinished">Colar</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation type="unfinished">Localização:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Tamanho:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation type="unfinished">Hora da modificação:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation type="unfinished">Abrir</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation type="unfinished">Abrir o caminho de acesso</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation type="unfinished">Copiar o caminho de acesso</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Por favor acesse %1 para instalar o ULLM, e %2 Atualização automática do índice.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>ligar</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Por favor %1 Atualização automática do índice.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Por favor acesse %1 para instalar o ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation type="unfinished">Mais</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">Sem resultados de pesquisa</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Pesquisar</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Cortar</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Copiar</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Colar</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Hora da modificação:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>modificado</translation>
     </message>

--- a/translations/dde-grand-search_pt_BR.ts
+++ b/translations/dde-grand-search_pt_BR.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Pesquisar</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Digite aqui para pesquisar...</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Recortar</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Copiar</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Colar</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Localização:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Tamanho:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Hora da modificação:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Acessar o caminho</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Copiar o caminho</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Mais</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">Sem resultados</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Pesquisar</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Recortar</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Copiar</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Colar</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Hora da modificação:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>modificado</translation>
     </message>

--- a/translations/dde-grand-search_ro.ts
+++ b/translations/dde-grand-search_ro.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Căutare</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Ce doriți să căutați?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Taie</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Copie</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Lipează</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Locație:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Timp modificare:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Deschide</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Deschide calea</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Copiază calea</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Vă rugăm să accesați %1 pentru a instala ULLM și %2 Actualizare automată a indexului.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>activează</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Vă rugăm să activează Actualizarea automată a indexului.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Vă rugăm să accesați %1 pentru a instala ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Mai mult</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Căutare</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Taie</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Copie</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Lipează</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Data modificării:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>modificat</translation>
     </message>

--- a/translations/dde-grand-search_ru.ts
+++ b/translations/dde-grand-search_ru.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Поиск</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Что Вы хотите найти?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Вырезать</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Копировать</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Вставить</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Расположение:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Размер:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Изменен:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Открыть</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Открыть месторасположение файла</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Копировать Путь к Файлу</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Пожалуйста, перейдите по %1 для установки ULLM, и %2 автоматическое обновление индекса.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>включить</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Пожалуйста, %1 автоматическое обновление индекса.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Пожалуйста, перейдите по %1 для установки ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Еще</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">Ничего не найдено</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Поиск</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Вырезать</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Копировать</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Вставить</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Изменен:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>изменен</translation>
     </message>

--- a/translations/dde-grand-search_si.ts
+++ b/translations/dde-grand-search_si.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>සෙවීම</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>ඔබ සෙවීමට අවශ්‍ය වන්නේ කුමක්ද?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>වයර් කරන්න</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>කොපි කරන්න</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>පාස්ට් කරන්න</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>ස්ථානය:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">ක්‍රමය:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>සමය වෙනස් කළ:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>වැනි පෙනීම</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>පථය වැනි පෙනීම</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>පථය කොපි කරන්න</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>කරුණාකර %1 වෙත ගොස් ULLM අනුග්‍රහ කරන්න, එවිට %2 අභියෝග අනුග්‍රහ කරන්න.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>සක්‍රිය කරන්න</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>කරුණාකර %1 අභියෝග අනුග්‍රහ කරන්න.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>කරුණාකර %1 වෙත ගොස් ULLM අනුග්‍රහ කරන්න.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>අමතර</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">සෙවීම</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">වයර් කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">කොපි කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">පාස්ට් කරන්න</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>සම්පූර්ණ වියාම් කාලය:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>සම්පූර්ණ වියාම්</translation>
     </message>

--- a/translations/dde-grand-search_sk.ts
+++ b/translations/dde-grand-search_sk.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Vyhľadávať</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Čo by ste chceli vyhľadávať?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Vystrihnúť</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Kopírovať</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Vložiť</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Polohovanie:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Veľkosť:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Čas upravenia:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Otvoriť</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Otvoriť cestu</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Kopírovať cestu</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Prosím, pôjdite do %1 na inštaláciu ULLM, a %2 automatické aktualizovanie indexu.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>zapnúť</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Prosím, %1 automatické aktualizovanie indexu.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Prosím, pôjdite do %1 na inštaláciu ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Viac</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Vyhľadávať</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Vystrihnúť</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Kopírovať</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Vložiť</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Čas upravenia:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>upravený</translation>
     </message>

--- a/translations/dde-grand-search_sl.ts
+++ b/translations/dde-grand-search_sl.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation type="unfinished">Iskanje</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation type="unfinished">Kaj bi radi posikali?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation type="unfinished">Izreži</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation type="unfinished">Kopiraj</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation type="unfinished">Prilepi</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation type="unfinished">Lokacija:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Velikost:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation type="unfinished">Čas spreminjanja:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation type="unfinished">Odpri</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation type="unfinished">Odpri pot</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation type="unfinished">Kopiraj pot</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>من فضلك اذهب إلى %1 لتثبيت ULLM، و%2 تحديث المؤشر تلقائيًا.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>zapnite</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Prosim %1 poskrbi za avtomatsko posodabljanje indeksa.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Prosim, odprite %1 za namestitev ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation type="unfinished">Več</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">Ni rezultatov iskanja</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Iskanje</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Izreži</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Kopiraj</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Prilepi</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Čas spreminjanja:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>izmenjen</translation>
     </message>

--- a/translations/dde-grand-search_sq.ts
+++ b/translations/dde-grand-search_sq.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Kërko</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Për çfarë doni të kërkohet?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Prije</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Kopjoje</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Ngjite</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Vendndodhje:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Madhësi:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Kohë kur u ndryshua:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Hape</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Hape Shtegun</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Kopjoje Shtegun</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Më tepër</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">S’ka përfundime kërkimi</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Kërko</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Prije</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Kopjoje</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Ngjite</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Kohë kur u ndryshua:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>ndryshuar më</translation>
     </message>

--- a/translations/dde-grand-search_sr.ts
+++ b/translations/dde-grand-search_sr.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation type="unfinished">Претражи</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation type="unfinished">Шта желите да претражите?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation type="unfinished">Исеци</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation type="unfinished">Копирај</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation type="unfinished">Убаци</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation type="unfinished">Локација:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Величина:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation type="unfinished">Измењено:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation type="unfinished">Покрени</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation type="unfinished">Отвори путању</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation type="unfinished">Копирај путању</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Молимо вас да отидете на %1 да бисте инсталирали ULLM, и %2 Аутоматско ажурирање индекса.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>Укључи</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Молимо %1 аутоматско ажурирање индекса.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Молимо појавите се на %1 да бисте инсталирали ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation type="unfinished">Више</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">Нема резултата претраге</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Претражи</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Исеци</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Копирај</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Убаци</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Измењено:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>modifikovano</translation>
     </message>

--- a/translations/dde-grand-search_sv.ts
+++ b/translations/dde-grand-search_sv.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Sök</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Vad vill du söka efter?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Klippa</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Kopiera</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Klistra in</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Läge:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Storlek:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Senast ändrad:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Öppna</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Öppna Sökväg</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Kopiera Sökväg</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Vänligen gå till %1 för att installera ULLM, och %2 automatisk indexuppdatering.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>aktivera</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Vänligen %1 automatisk indexuppdatering.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Vänligen gå till %1 för att installera ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Mer</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Sök</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Klippa</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Kopiera</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Klistra in</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Senast ändrad:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>ändrad</translation>
     </message>

--- a/translations/dde-grand-search_sw.ts
+++ b/translations/dde-grand-search_sw.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Kificha</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Nini unaweza kificha?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Kutia</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Kopia</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Lipia</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Jina ya mkopo:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Wakati wa kusafisha:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Openda</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Openda Jina ya Mkono</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Kopia Jina ya Mkono</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Tafadhali tuma %1 kusajili ULLM, na %2 Kusafisha indeksa kwa mbele.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>Badilisha kwa mbele</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Tafadhali %1 Kusafisha indeksa kwa mbele.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Tafadhali tuma %1 kusajili ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Zaidi</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Kificha</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Kutia</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Kopia</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Lipia</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Wakati wa kujitokeza:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>kujitokeza</translation>
     </message>

--- a/translations/dde-grand-search_ta.ts
+++ b/translations/dde-grand-search_ta.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>தேடல்</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>நீங்கள் என்னை தேட விரும்புகிறீர்களா?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>மீட்டர்</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>காப்பியெடு</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>அலசு</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>இடம்:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">அளவு:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>நேரம் மாற்றப்பட்டது:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>திறந்து</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>தொடர்புடைய பாதம் திறந்து</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>தொடர்புடைய பாதம் காப்பியெடு</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>மேலோடு %1 க்குச் சென்று ULLM ஐ பதிவிறக்கவும், %2 தாக்கல் செய்யப்பட்ட இடைவிவரத்தை தொடர்புபடுத்தவும்.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>மெய்ப்படுத்து</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>மெய்ப்படுத்து %1 தாக்கல் செய்யப்பட்ட இடைவிவரத்தை.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>மேலோடு %1 க்குச் சென்று ULLM ஐ பதிவிறக்கவும்.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>மேலும்</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">தேடல்</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">மீட்டர்</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">காப்பியெடு</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">அலசு</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>தேசிய மாற்றம்:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>மாற்றம்</translation>
     </message>

--- a/translations/dde-grand-search_th.ts
+++ b/translations/dde-grand-search_th.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>ค้นหา</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>คุณต้องการค้นหาอะไร?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>ตัด</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>คัดลอก</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>วาง</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>ตำแหน่ง:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">ขนาด:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>เวลาแก้ไข:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>เปิด</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>เปิดเส้นทาง</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>คัดลอกเส้นทาง</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>กรุณาไปที่ %1 เพื่อติดตั้ง ULLM และ %2 การอัปเดตดัชนีอัตโนมัติ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>เปิดใช้งาน</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>กรุณา %1 การอัปเดตดัชนีอัตโนมัติ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>กรุณาไปที่ %1 เพื่อติดตั้ง ULLM</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>เพิ่มเติม</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">ค้นหา</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">ตัด</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">คัดลอก</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">วาง</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>เวลาที่แก้ไขล่าสุด:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>แก้ไข</translation>
     </message>

--- a/translations/dde-grand-search_tr.ts
+++ b/translations/dde-grand-search_tr.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Arama</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Ne aramak istersin?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Kes</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Kopyala</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Yapıştır</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Konum:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Boyut:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Zaman değiştirildi:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Aç</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Yolu Aç</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Yolu Kopyala</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Lütfen %1 adresine gidin ve ULLM&apos;yi yükleyin, %2 Otomatik indeks güncelleme.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>aç</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Lütfen %1 Otomatik indeks güncelleme.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Lütfen %1 adresine gidin ve ULLM&apos;yi yükleyin.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Daha fazla</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">Arama sonucu bulunamadı</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Arama</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Kes</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Kopyala</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Yapıştır</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Zaman değiştirildi:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>değiştirildi</translation>
     </message>

--- a/translations/dde-grand-search_ug.ts
+++ b/translations/dde-grand-search_ug.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation type="unfinished">ئىزدەش</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation type="unfinished">لازىملىق مەزمۇننى ئىزدەڭ</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation type="unfinished">كېسىش</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation type="unfinished">كۆچۈرۈش</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation type="unfinished">چاپلاش</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation type="unfinished">ئورۇن:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">چوڭلىقى :</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation type="unfinished">ئۆزگەرتىلگەن ۋاقتى:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation type="unfinished">ئوچۇق</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation type="unfinished">مۇندەرىجىسىنى ئېچىش</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation type="unfinished">مۇندەرىجىسىنى كۆچۈرۈش</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>ئەتە %1 گە بارىڭ، ۋە %2 ئاوتوماتىك ئىندېكس ئۆزگەرتىشنى ئېچىش</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>ئېچىش</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>لكي %1 تكملة مؤشر تلقائية.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>لكي تذهَب إلى %1 لتنصيب ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation type="unfinished">تېخىمۇ كۆپ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">ئىزدەش نەتىجىسى تىپىلمىدى</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">ئىزدەش</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">كېسىش</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">كۆچۈرۈش</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">چاپلاش</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>ئۆزگەرتىلگەن ۋاقتى:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>تەسەرلىك چېكىش ھەجىمىنى كۆرسىتىش چۈشىنىدۇ.</translation>
     </message>

--- a/translations/dde-grand-search_uk.ts
+++ b/translations/dde-grand-search_uk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>GrandSearch::AiToolBar</name>
     <message>
@@ -179,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Пошук</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Що ви хочете знайти?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Вирізати</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Копіювати</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Вставити</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Місце:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation>Розмір:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Час внесення змін:</translation>
     </message>
@@ -229,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Відкрити шлях</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Копіювати шлях</translation>
     </message>
@@ -247,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Будь ласка, перейдіть до %1 для встановлення ULLM і %2 автоматичного оновлення покажчика.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation>Налаштування пошуку</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>вмикання</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Будь ласка, виконайте %1 автоматичного оновлення покажчика.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Будь ласка, перейдіть до %1 для встановлення ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Більше</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation>Нічого не знайдено</translation>
     </message>
@@ -540,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Пошук</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Вирізати</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Копіювати</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Вставити</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -792,7 +799,7 @@
         <translation>Час внесення змін:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>змінено</translation>
     </message>

--- a/translations/dde-grand-search_ur.ts
+++ b/translations/dde-grand-search_ur.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>تلاش</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>آپ کیا تلاش کرنا چاہتے ہیں؟</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>کٹ کریں</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>کاپی کریں</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>پیسٹ کریں</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>مقام:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">سائز:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>تاریخ تبدیلی:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>کھولیں</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>پٹھ کھولیں</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>پٹھ کاپی کریں</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>اپنی مدد کے لیے %1 میں ULLM انسٹال کریں، اور %2 اتومیٹک انڈیکس اپڈیٹ کریں۔</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>چاک کریں</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>اپنی مدد کے لیے %1 اتومیٹک انڈیکس اپڈیٹ کریں۔</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>اپنی مدد کے لیے %1 میں ULLM انسٹال کریں۔</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>زیادہ</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">تلاش</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">کٹ کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">کاپی کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">پیسٹ کریں</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>تاریخ ترمیم:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>ترمیم</translation>
     </message>

--- a/translations/dde-grand-search_vi.ts
+++ b/translations/dde-grand-search_vi.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>Tìm kiếm</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>Bạn muốn tìm kiếm điều gì?</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>Cắt</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>Sao chép</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>Dán</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>Vị trí:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation type="unfinished">Kích thước:</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>Thời gian sửa đổi:</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>Mở</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>Mở đường dẫn</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>Sao chép đường dẫn</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>Vui lòng truy cập %1 để cài đặt ULLM, và %2 Cập nhật chỉ mục tự động.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>Bật</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>Vui lòng %1 Cập nhật chỉ mục tự động.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>Vui lòng truy cập %1 để cài đặt ULLM.</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>Thêm</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation type="unfinished">Tìm kiếm</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation type="unfinished">Cắt</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation type="unfinished">Sao chép</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation type="unfinished">Dán</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>Thời gian chỉnh sửa:</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>đã chỉnh sửa</translation>
     </message>

--- a/translations/dde-grand-search_zh_CN.ts
+++ b/translations/dde-grand-search_zh_CN.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>搜索</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>搜索想要查找的内容</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>剪切</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>复制</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>粘贴</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>位置：</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation>大小：</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>修改时间：</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>打开路径</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>复制路径</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>请先前往%1安装统信有容大模型，并%2自动更新索引</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation>搜索配置</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>开启</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>请先%1自动更新索引</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>请先前往%1安装统信有容大模型</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>更多</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation>暂无搜索结果</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation>搜索</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation>剪切</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation>复制</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation>粘贴</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>修改时间：</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>修改</translation>
     </message>

--- a/translations/dde-grand-search_zh_HK.ts
+++ b/translations/dde-grand-search_zh_HK.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>搜索</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>搜索想要查找的內容</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>剪切</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>複製</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>粘貼</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>位置：</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation>大小：</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>修改時間：</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>打開</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>打開路徑</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>複製路徑</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>請先前往%1安裝統信有容大模型，並%2自動更新索引</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation>搜索配置</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>開啓</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>請先%1自動更新索引</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>請先前往%1安裝統信有容大模型</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>更多</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation>暫無搜索結果</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation>搜索</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation>剪切</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation>複製</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation>粘貼</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>修改時間：</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>修改</translation>
     </message>

--- a/translations/dde-grand-search_zh_TW.ts
+++ b/translations/dde-grand-search_zh_TW.ts
@@ -181,49 +181,31 @@
 <context>
     <name>GrandSearch::EntranceWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="246"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="61"/>
         <source>Search</source>
         <translation>搜尋</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="247"/>
+        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="62"/>
         <source>What would you like to search for?</source>
         <translation>搜尋想要查詢的內容</translation>
     </message>
 </context>
 <context>
-    <name>GrandSearch::EntranceWidgetPrivate</name>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="85"/>
-        <source>Cut</source>
-        <translation>剪下</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="89"/>
-        <source>Copy</source>
-        <translation>複製</translation>
-    </message>
-    <message>
-        <location filename="../src/grand-search/gui/entrance/entrancewidget.cpp" line="93"/>
-        <source>Paste</source>
-        <translation>粘貼</translation>
-    </message>
-</context>
-<context>
     <name>GrandSearch::GeneralPreviewPlugin</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="254"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="231"/>
         <source>Location:</source>
         <translation>位置：</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="283"/>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="350"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
         <translation>大小：</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
         <source>Time modified:</source>
         <translation>修改時間：</translation>
     </message>
@@ -231,17 +213,17 @@
 <context>
     <name>GrandSearch::GeneralToolBar</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="70"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="101"/>
         <source>Open</source>
         <translation>打開</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="75"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="106"/>
         <source>Open Path</source>
         <translation>打開路徑</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="80"/>
+        <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp" line="111"/>
         <source>Copy Path</source>
         <translation>複製路徑</translation>
     </message>
@@ -249,40 +231,40 @@
 <context>
     <name>GrandSearch::GroupWidget</name>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="287"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
         <translation>請先前往%1安裝統信有容大模型，並%2自動更新索引</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="288"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="297"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="294"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Search configuration</source>
         <translation>搜尋設定</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="289"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="293"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="295"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <source>turn on</source>
         <translation>開啟</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="292"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please %1 Automatic index update.</source>
         <translation>請先%1自動更新索引</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="296"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="302"/>
         <source>Please go to %1 to install the ULLM.</source>
         <translation>請先前往%1安裝統信有容大模型</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="349"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="355"/>
         <source>More</source>
         <translation>更多</translation>
     </message>
     <message>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
-        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="385"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="305"/>
+        <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="391"/>
         <source>No search results</source>
         <translation>暫無搜尋結果</translation>
     </message>
@@ -542,6 +524,29 @@
     </message>
 </context>
 <context>
+    <name>GrandSearch::SearchEdit</name>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="160"/>
+        <source>Search</source>
+        <translation>搜尋</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="256"/>
+        <source>Cut</source>
+        <translation>剪下</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="260"/>
+        <source>Copy</source>
+        <translation>複製</translation>
+    </message>
+    <message>
+        <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="264"/>
+        <source>Paste</source>
+        <translation>粘貼</translation>
+    </message>
+</context>
+<context>
     <name>GrandSearch::SearchEngineWidget</name>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="42"/>
@@ -794,7 +799,7 @@
         <translation>修改時間：</translation>
     </message>
     <message>
-        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="272"/>
+        <location filename="../src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp" line="233"/>
         <source>modified</source>
         <translation>修改</translation>
     </message>


### PR DESCRIPTION
1. Changed the vertical line from a local variable to a class member
(m_vLine)
2. Added explicit hide() calls for m_vLine when clearing data or hiding
preview
3. Added explicit show() call for m_vLine when displaying preview item
4. Fixed the issue where the vertical separator line remained visible
when it shouldn't

The vertical line was previously created as a local variable and never
properly managed for visibility state. This caused UI inconsistency
where the separator line could remain visible when the preview widget
was hidden. By making it a member variable, we can now properly
synchronize its visibility with the preview widget state.

Influence:
1. Test clearing search results and verify vertical line is hidden
2. Test selecting items that cannot be previewed and verify vertical
line is hidden
3. Test selecting items that can be previewed and verify vertical line
is shown
4. Test rapid switching between previewable and non-previewable items
5. Verify layout margins are correct when vertical line is hidden/shown
6. Test overall exhibition widget layout stability

fix: 修复展览部件中垂直分隔线的显示问题

1. 将垂直分隔线从局部变量改为类成员变量 (m_vLine)
2. 在清除数据或隐藏预览时添加显式的 hide() 调用
3. 在显示预览项时添加显式的 show() 调用
4. 修复了垂直分隔线在不应显示时仍然可见的问题

垂直分隔线之前作为局部变量创建，从未正确管理其可见性状态。这导致 UI 不一
致，当预览部件隐藏时分隔线可能仍然可见。通过将其设为成员变量，我们现在可
以将其可见性与预览部件状态正确同步。

Influence:
1. 测试清除搜索结果，验证垂直分隔线是否隐藏
2. 测试选择无法预览的项，验证垂直分隔线是否隐藏
3. 测试选择可以预览的项，验证垂直分隔线是否显示
4. 测试在可预览和不可预览项之间快速切换
5. 验证垂直分隔线隐藏/显示时的布局边距是否正确
6. 测试展览部件整体布局稳定性

BUG: https://pms.uniontech.com/bug-view-361063.html
