### PR TITLE
refactor: simplify search edit and fix UI issues

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-grand-search (6.0.35) unstable; urgency=medium
+
+  * refactor: simplify search edit and fix UI issues
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Thu, 21 May 2026 09:49:52 +0800
+
 dde-grand-search (6.0.34) unstable; urgency=medium
 
   * refactor: extract SearchEdit component from EntranceWidget

--- a/src/grand-search/gui/entrance/searchedit.cpp
+++ b/src/grand-search/gui/entrance/searchedit.cpp
@@ -30,88 +30,6 @@ static constexpr int DelayResponseTime = 50;
 static constexpr int AppIconSize = 32;
 static constexpr int SearchIconSize = 20;
 
-class SearchLineEditStyle : public QProxyStyle
-{
-public:
-    using QProxyStyle::QProxyStyle;
-
-    int pixelMetric(PixelMetric metric, const QStyleOption *option = nullptr,
-                    const QWidget *widget = nullptr) const override
-    {
-        if (metric == QStyle::PM_TextCursorWidth)
-            return 0;
-        return QProxyStyle::pixelMetric(metric, option, widget);
-    }
-};
-
-SearchLineEdit::SearchLineEdit(QWidget *parent)
-    : QLineEdit(parent),
-      m_proxyStyle(new SearchLineEditStyle),
-      m_cursorBlinkTimer(new QTimer(this)),
-      m_cursorVisible(true)
-{
-    setStyle(m_proxyStyle);
-
-    // 调色板（暗色/亮色主题）
-    QPalette pa = palette();
-    QColor colorText(0, 0, 0);
-    QColor colorBkg(0, 0, 0, 25);
-    if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType) {
-        colorText = QColor(255, 255, 255);
-        colorBkg = QColor(255, 255, 255, 25);
-    }
-    pa.setColor(QPalette::Button, colorBkg);
-    pa.setColor(QPalette::Text, colorText);
-    pa.setColor(QPalette::ButtonText, colorText);
-    setPalette(pa);
-    DStyle::setFocusRectVisible(this, false);
-
-    m_cursorBlinkTimer->setInterval(500);
-    connect(m_cursorBlinkTimer, &QTimer::timeout, this, [this]() {
-        m_cursorVisible = !m_cursorVisible;
-        update();
-    });
-}
-
-SearchLineEdit::~SearchLineEdit()
-{
-    delete m_proxyStyle;
-}
-
-void SearchLineEdit::paintEvent(QPaintEvent *event)
-{
-    // 自绘光标
-    QPainter painter(this);
-    painter.setRenderHint(QPainter::Antialiasing);
-
-    if (m_cursorVisible && hasFocus()) {
-        QColor cursorColor(0, 0, 0);
-        if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType)
-            cursorColor = QColor(255, 255, 255);
-        QRect cursorRect = this->cursorRect();
-        cursorRect.setX(cursorRect.x() + 5);
-        cursorRect.setWidth(1);
-        cursorRect.setHeight(cursorRect.height() - 1);
-        painter.fillRect(cursorRect, cursorColor);
-    }
-
-    QLineEdit::paintEvent(event);
-}
-
-void SearchLineEdit::focusInEvent(QFocusEvent *event)
-{
-    QLineEdit::focusInEvent(event);
-    m_cursorVisible = true;
-    if (m_cursorBlinkTimer->interval() > 0)
-        m_cursorBlinkTimer->start();
-}
-
-void SearchLineEdit::focusOutEvent(QFocusEvent *event)
-{
-    m_cursorBlinkTimer->stop();
-    QLineEdit::focusOutEvent(event);
-}
-
 SearchEditPrivate::SearchEditPrivate(SearchEdit *qq)
     : q(qq)
 {
@@ -125,11 +43,25 @@ void SearchEditPrivate::init()
     QObject::connect(m_delayTimer, &QTimer::timeout, q, [this]() { notifyTextChanged(); });
 
     // 内部 QLineEdit
-    m_lineEdit = new SearchLineEdit(q);
+    m_lineEdit = new QLineEdit(q);
     m_lineEdit->installEventFilter(q);
     m_lineEdit->setMaxLength(512);
     m_lineEdit->setContextMenuPolicy(Qt::NoContextMenu);
     m_lineEdit->setClearButtonEnabled(false);
+
+    // 调色板（暗色/亮色主题）
+    QPalette pa = m_lineEdit->palette();
+    QColor colorText(0, 0, 0);
+    QColor colorBkg(0, 0, 0, 25);
+    if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType) {
+        colorText = QColor(255, 255, 255);
+        colorBkg = QColor(255, 255, 255, 25);
+    }
+    pa.setColor(QPalette::Button, colorBkg);
+    pa.setColor(QPalette::Text, colorText);
+    pa.setColor(QPalette::ButtonText, colorText);
+    m_lineEdit->setPalette(pa);
+    DStyle::setFocusRectVisible(m_lineEdit, false);
 
     // 字体
     QFont lineFont = m_lineEdit->font();

--- a/src/grand-search/gui/entrance/searchedit.h
+++ b/src/grand-search/gui/entrance/searchedit.h
@@ -13,24 +13,6 @@ class QIcon;
 
 namespace GrandSearch {
 
-class SearchLineEdit : public QLineEdit
-{
-    Q_OBJECT
-public:
-    explicit SearchLineEdit(QWidget *parent = nullptr);
-    ~SearchLineEdit() override;
-
-protected:
-    void paintEvent(QPaintEvent *event) override;
-    void focusInEvent(QFocusEvent *event) override;
-    void focusOutEvent(QFocusEvent *event) override;
-
-private:
-    QStyle *m_proxyStyle = nullptr;
-    QTimer *m_cursorBlinkTimer = nullptr;
-    bool m_cursorVisible = true;
-};
-
 class SearchEditPrivate;
 class SearchEdit : public QWidget
 {

--- a/src/grand-search/gui/entrance/searchedit_p.h
+++ b/src/grand-search/gui/entrance/searchedit_p.h
@@ -16,8 +16,6 @@
 
 namespace GrandSearch {
 
-class SearchLineEdit;
-
 class SearchEditPrivate
 {
     SearchEditPrivate(SearchEdit *qq);
@@ -30,7 +28,7 @@ class SearchEditPrivate
 
     SearchEdit *q = nullptr;
 
-    SearchLineEdit *m_lineEdit = nullptr;
+    QLineEdit *m_lineEdit = nullptr;
     QWidget *m_iconWidget = nullptr;
     QLabel *m_placeholderLabel = nullptr;
     QLabel *m_appIconLabel = nullptr;

--- a/src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp
+++ b/src/grand-search/gui/exhibition/preview/generalwidget/generaltoolbar.cpp
@@ -93,7 +93,7 @@ void GeneralToolBar::initUi()
     m_hMainLayout = new QHBoxLayout(this);
     // 下边距10
     m_hMainLayout->setContentsMargins(TOOLBAR_LEFT_MARGIN, 0, TOOLBAR_RIGHT_MARGIN, TOOLBAR_BOTTOM_MARGIN);
-    m_hMainLayout->setSpacing(0);
+    m_hMainLayout->setSpacing(2);
 
     QString suffix = Utils::iconThemeSuffix();
 
@@ -115,7 +115,7 @@ void GeneralToolBar::initUi()
     m_vLine1 = new DVerticalLine(this);
     m_vLine1->setFixedHeight(30);
     m_vLine2 = new DVerticalLine(this);
-    m_vLine1->setFixedHeight(30);
+    m_vLine2->setFixedHeight(30);
 
     m_hMainLayout->addWidget(m_openBtn);
     m_hMainLayout->addWidget(m_vLine1);

--- a/src/grand-search/thumbnail/generators/textthumbnailgenerator.cpp
+++ b/src/grand-search/thumbnail/generators/textthumbnailgenerator.cpp
@@ -63,7 +63,7 @@ QPixmap TextThumbnailGenerator::generate(const QString &filePath, const QSize &s
     }
 
     // 渲染文本
-    QImage image = renderText(content, size);
+    QImage image = renderText(content, { static_cast<int>(size.width() * 0.70707070), size.height() });
     if (image.isNull()) {
         return QPixmap();
     }


### PR DESCRIPTION
1. Remove custom SearchLineEdit class and replace with standard
QLineEdit
   - Eliminate custom cursor painting and blinking timer logic
   - Remove QProxyStyle subclass used to hide default cursor
   - Move palette setup to SearchEditPrivate::init()
   - This reduces code complexity and maintenance burden while relying
on Qt's native cursor behavior

2. Fix incorrect widget assignment in GeneralToolBar
   - Correct m_vLine2->setFixedHeight() call (was incorrectly setting
m_vLine1 again)
   - Adjust layout spacing from 0 to 2 for better visual separation

3. Optimize text thumbnail generation
   - Reduce thumbnail width by factor of 0.70707070 (√2 approximation)
for proper aspect ratio
   - Improves visual quality of text file previews

Log: Fixed search edit cursor behavior and toolbar layout issues

Influence:
1. Test search input field cursor visibility and blinking behavior in
both light and dark themes
2. Verify search edit accepts text input normally and responds to focus
changes
3. Test search edit palette colors adapt correctly to theme switches
4. Verify GeneralToolBar vertical divider lines display at correct 30px
height
5. Check toolbar button spacing is visually appropriate with 2px spacing
6. Test text file thumbnail generation produces properly proportioned
previews
7. Verify text thumbnails render correctly for various file sizes and
content types

refactor: 简化搜索编辑框并修复 UI 问题

1. 移除自定义 SearchLineEdit 类，替换为标准 QLineEdit
   - 消除自定义光标绘制和闪烁定时器逻辑
   - 移除用于隐藏默认光标的 QProxyStyle 子类
   - 将调色板设置移至 SearchEditPrivate::init()
   - 降低代码复杂度和维护负担，同时依赖 Qt 的原生光标行为

2. 修复 GeneralToolBar 中错误的控件赋值
   - 修正 m_vLine2->setFixedHeight() 调用（之前错误地再次设置了
m_vLine1）
   - 将布局间距从 0 调整为 2，以获得更好的视觉分隔效果

3. 优化文本缩略图生成
   - 将缩略图宽度按 0.70707070（√2 近似值）比例缩减，以获得正确的宽高比
   - 提升文本文件预览的视觉质量

Log: 修复搜索编辑框光标行为和工具栏布局问题

Influence:
1. 测试搜索输入框在浅色和深色主题下的光标可见性和闪烁行为
2. 验证搜索编辑框正常接收文本输入并响应焦点变化
3. 测试搜索编辑框调色板颜色是否正确适应主题切换
4. 验证 GeneralToolBar 垂直分隔线是否正确显示为 30px 高度
5. 检查工具栏按钮间距在 2px 设置下视觉效果是否合适
6. 测试文本文件缩略图生成是否产生比例适当的预览图
7. 验证各种文件大小和类型的文本缩略图渲染是否正确
