### PR TITLE
feat: refactor search result display with fixed modification time

### DIFF
--- a/src/dde-grand-search-daemon/configuration/configer.cpp
+++ b/src/dde-grand-search-daemon/configuration/configer.cpp
@@ -63,8 +63,7 @@ UserPreferencePointer ConfigerPrivate::fileSearcher()
 UserPreferencePointer ConfigerPrivate::tailerData()
 {
     QVariantHash data = {
-        { GRANDSEARCH_TAILER_PARENTDIR, false },
-        { GRANDSEARCH_TAILER_TIMEMODEFIED, true }
+        { GRANDSEARCH_TAILER_PARENTDIR, false }
     };
 
     return UserPreferencePointer(new UserPreference(data));
@@ -203,11 +202,7 @@ bool ConfigerPrivate::updateConfig1(QSettings *set)
     if (UserPreferencePointer conf = m_root->group(GRANDSEARCH_TAILER_GROUP)) {
         bool ret = set->value(GRANDSEARCH_TAILER_PARENTDIR, false).toBool();
         conf->setValue(GRANDSEARCH_TAILER_PARENTDIR, ret);
-
-        ret = set->value(GRANDSEARCH_TAILER_TIMEMODEFIED, true).toBool();
-        conf->setValue(GRANDSEARCH_TAILER_TIMEMODEFIED, ret);
-        qCDebug(logDaemon) << "Tailer configuration updated - Parent dir:" << conf->value<bool>(GRANDSEARCH_TAILER_PARENTDIR, false)
-                           << "Time modified:" << conf->value<bool>(GRANDSEARCH_TAILER_TIMEMODEFIED, true);
+        qCDebug(logDaemon) << "Tailer configuration updated - Parent dir:" << conf->value<bool>(GRANDSEARCH_TAILER_PARENTDIR, false);
     } else {
         qCWarning(logDaemon) << "Configuration not found:" << GRANDSEARCH_TAILER_GROUP;
     }

--- a/src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp
+++ b/src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp
@@ -29,24 +29,7 @@ MatchedItem FileSearchUtils::packItem(const QString &fileName, const QString &se
     item.type = mimeType.name();
     item.icon = mimeType.iconName();
     item.searcher = searcher;
-
-    QVariantHash extraData = tailerData(fileInfo);
-    // Inject keywords for highlighting
-    if (!keywords.isEmpty())
-        extraData.insert(GRANDSEARCH_PROPERTY_ITEM_KEYWORDS, keywords);
-
-    if (!matchedContext.isEmpty()) {
-        QString context = matchedContext;
-        // 去除首尾的省略符号
-        if (context.startsWith("…"))
-            context = context.mid(1);
-        if (context.endsWith("…"))
-            context.chop(1);
-        if (!context.isEmpty())
-            extraData.insert(GRANDSEARCH_PROPERTY_ITEM_MATCHEDCONTEXT, context);
-    }
-
-    item.extra = QVariant::fromValue(extraData);
+    item.extra = QVariant::fromValue(extraData(fileInfo, keywords, matchedContext));
 
     qCDebug(logDaemon) << "Item packed successfully - Name:" << item.name
                        << "Type:" << item.type << "Icon:" << item.icon;
@@ -217,31 +200,41 @@ FileSearchUtils::SearchInfo FileSearchUtils::parseContent(const QString &content
     return info;
 }
 
-QVariantHash FileSearchUtils::tailerData(const QFileInfo &info)
+QVariantHash FileSearchUtils::extraData(const QFileInfo &info, const QStringList &keywords, const QString &matchedContext)
 {
     qCDebug(logDaemon) << "Generating tailer data for file:" << info.absoluteFilePath();
 
     QVariantHash hash;
     QStringList datas;
     auto config = Configer::instance()->group(GRANDSEARCH_TAILER_GROUP);
+
+    // 修改时间
+    auto timeModified = CommonTools::getFileModifiedTime(info.absoluteFilePath()).toString("yyyy-MM-dd hh:mm");
+    hash.insert(GRANDSEARCH_PROPERTY_ITEM_MODIFIED_TIME, timeModified);
+    qCDebug(logDaemon) << "Added modification time:" << timeModified;
+
+    // 上级目录为可配置项
     if (config->value(GRANDSEARCH_TAILER_PARENTDIR, false)) {
         datas.append(info.absolutePath());
         qCDebug(logDaemon) << "Added parent directory to tailer:" << info.absolutePath();
     }
 
-    if (config->value(GRANDSEARCH_TAILER_TIMEMODEFIED, false)) {
-        auto timeModified = CommonTools::getFileModifiedTime(info.absoluteFilePath()).toString("yyyy-MM-dd hh:mm ") + QObject::tr("modified");
-        datas.append(timeModified);
-        qCDebug(logDaemon) << "Added modification time to tailer:" << timeModified;
+    // Inject keywords for highlighting
+    if (!keywords.isEmpty())
+        hash.insert(GRANDSEARCH_PROPERTY_ITEM_KEYWORDS, keywords);
+
+    if (!matchedContext.isEmpty()) {
+        QString context = matchedContext;
+        // 去除首尾的省略符号
+        if (context.startsWith("…"))
+            context = context.mid(1);
+        if (context.endsWith("…"))
+            context.chop(1);
+        if (!context.isEmpty())
+            hash.insert(GRANDSEARCH_PROPERTY_ITEM_MATCHEDCONTEXT, context);
     }
 
-    if (!datas.isEmpty()) {
-        hash.insert(GRANDSEARCH_PROPERTY_ITEM_TAILER, datas);
-        qCDebug(logDaemon) << "Tailer data generated - Entries:" << datas.size();
-    } else {
-        qCDebug(logDaemon) << "No tailer data configured";
-    }
-
+    hash.insert(GRANDSEARCH_PROPERTY_ITEM_TAILER, datas);
     return hash;
 }
 

--- a/src/dde-grand-search-daemon/searcher/file/filesearchutils.h
+++ b/src/dde-grand-search-daemon/searcher/file/filesearchutils.h
@@ -41,7 +41,7 @@ public:
     static Group getGroupBySuffix(const QString &suffix);
     static Group getGroupByGroupName(const QString &groupName);
     static SearchInfo parseContent(const QString &content);
-    static QVariantHash tailerData(const QFileInfo &info);
+    static QVariantHash extraData(const QFileInfo &info, const QStringList &keywords, const QString &matchedContext);
     static QStringList buildDFMSearchFileTypes(const QList<Group> &groupList);
     static bool isPinyin(const QString &str);
     static bool hasWildcard(const QString &str);

--- a/src/global/builtinsearch.h
+++ b/src/global/builtinsearch.h
@@ -55,6 +55,9 @@
 // 拖尾数据
 #define GRANDSEARCH_PROPERTY_ITEM_TAILER    "itemTailer"
 
+// 修改时间（独立于拖尾，不限制绘制宽度）
+#define GRANDSEARCH_PROPERTY_ITEM_MODIFIED_TIME    "itemModifiedTime"
+
 // 匹配的到具体信息
 #define GRANDSEARCH_PROPERTY_ITEM_MATCHEDCONTEXT    "itemMatchedContext"
 

--- a/src/global/widgets/highlightlabel.cpp
+++ b/src/global/widgets/highlightlabel.cpp
@@ -2,326 +2,14 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include "global/widgets/highlightlabel.h"
+#include "highlightlabel.h"
+#include "highlightutils.h"
 
 #include <QPainter>
 #include <QPaintEvent>
 #include <QResizeEvent>
 #include <QFontMetrics>
-#include <QRegularExpression>
 #include <QEvent>
-#include <algorithm>
-
-namespace {
-
-struct ElideResult
-{
-    QString text;
-    QVector<int> origPositions;   // text[i] -> original char position, -1 for ellipsis char
-};
-
-struct MatchRange
-{
-    int start;
-    int end;   // exclusive
-};
-
-static int charWidth(const QFontMetrics &fm, QChar ch)
-{
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    return fm.width(ch);
-#else
-    return fm.horizontalAdvance(ch);
-#endif
-}
-
-static int textWidth(const QFontMetrics &fm, const QString &text)
-{
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    return fm.width(text);
-#else
-    return fm.horizontalAdvance(text);
-#endif
-}
-
-static QVector<MatchRange> findMatchRanges(const QString &text, const QStringList &keywords)
-{
-    QVector<MatchRange> ranges;
-    for (const QString &kw : keywords) {
-        if (kw.isEmpty())
-            continue;
-        QRegularExpression re(QRegularExpression::escape(kw),
-                              QRegularExpression::CaseInsensitiveOption);
-        QRegularExpressionMatchIterator it = re.globalMatch(text);
-        while (it.hasNext()) {
-            auto m = it.next();
-            ranges.append({ static_cast<int>(m.capturedStart()),
-                            static_cast<int>(m.capturedStart() + m.capturedLength()) });
-        }
-    }
-    // sort by start, merge overlapping
-    std::sort(ranges.begin(), ranges.end(),
-              [](const MatchRange &a, const MatchRange &b) { return a.start < b.start; });
-    QVector<MatchRange> merged;
-    for (const auto &r : ranges) {
-        if (!merged.isEmpty() && r.start <= merged.last().end)
-            merged.last().end = std::max(merged.last().end, r.end);
-        else
-            merged.append(r);
-    }
-    return merged;
-}
-
-static ElideResult buildWindowElide(const QString &text, int keepStart, int keepEnd,
-                                    int maxWidth, const QFontMetrics &fm)
-{
-    ElideResult result;
-    const QString ellipsis = QStringLiteral("…");
-    int ellipsisWidth = charWidth(fm, QChar(0x2026));
-
-    bool needLeft = (keepStart > 0);
-    bool needRight = (keepEnd < text.length());
-    int numEllipsis = (needLeft ? 1 : 0) + (needRight ? 1 : 0);
-    int budget = maxWidth - numEllipsis * ellipsisWidth;
-    if (budget <= 0) {
-        result.text = ellipsis;
-        result.origPositions = { -1 };
-        return result;
-    }
-
-    int keepLen = keepEnd - keepStart;
-    // trim from both sides if needed
-    int trimLeft = 0, trimRight = 0;
-    int w = textWidth(fm, text.mid(keepStart, keepLen));
-    while (w > budget && keepLen > 0) {
-        int lNext = charWidth(fm, text[keepStart + trimLeft]);
-        int rNext = charWidth(fm, text[keepEnd - 1 - trimRight]);
-        if (trimRight >= keepLen - trimLeft - 1) {
-            w -= lNext;
-            ++trimLeft;
-        } else if (lNext >= rNext) {
-            w -= lNext;
-            ++trimLeft;
-        } else {
-            w -= rNext;
-            ++trimRight;
-        }
-        keepLen = (keepEnd - trimRight) - (keepStart + trimLeft);
-    }
-    if (keepLen <= 0) {
-        result.text = ellipsis;
-        result.origPositions = { -1 };
-        return result;
-    }
-
-    int actualStart = keepStart + trimLeft;
-    int actualEnd = keepEnd - trimRight;
-    QString kept = text.mid(actualStart, actualEnd - actualStart);
-
-    result.text = (needLeft ? ellipsis : QString()) + kept + (needRight ? ellipsis : QString());
-    int pos = 0;
-    result.origPositions.resize(result.text.length());
-    if (needLeft) {
-        result.origPositions[pos++] = -1;
-    }
-    for (int i = actualStart; i < actualEnd; ++i)
-        result.origPositions[pos++] = i;
-    if (needRight)
-        result.origPositions[pos] = -1;
-    return result;
-}
-
-static ElideResult smartElideWithTracking(const QString &text, int maxWidth,
-                                          const QFontMetrics &fm,
-                                          const QVector<MatchRange> &matchRanges)
-{
-    const QString ellipsis = QStringLiteral("…");
-    int ellipsisWidth = charWidth(fm, QChar(0x2026));
-
-    // 1. If full text fits, return it as-is
-    if (textWidth(fm, text) <= maxWidth) {
-        ElideResult result;
-        result.text = text;
-        result.origPositions.resize(text.length());
-        for (int i = 0; i < text.length(); ++i)
-            result.origPositions[i] = i;
-        return result;
-    }
-
-    // 2. If only ellipsis fits, return just ellipsis
-    if (maxWidth <= ellipsisWidth) {
-        ElideResult result;
-        result.text = ellipsis;
-        result.origPositions = { -1 };
-        return result;
-    }
-
-    // 3. Compute initial keyword window from match ranges
-    int keepStart = text.length();
-    int keepEnd = 0;
-    for (const auto &mr : matchRanges) {
-        keepStart = std::min(keepStart, mr.start);
-        keepEnd = std::max(keepEnd, mr.end);
-    }
-
-    if (keepStart >= keepEnd)
-        return {};
-
-    // 4. Expand outward from keyword range, filling available width with context
-    //    The key insight: expanding to an edge may eliminate an ellipsis,
-    //    freeing ellipsisWidth of budget for further expansion.
-    while (true) {
-        bool needLeft = (keepStart > 0);
-        bool needRight = (keepEnd < text.length());
-        int numEllipsis = (needLeft ? 1 : 0) + (needRight ? 1 : 0);
-        int budget = maxWidth - numEllipsis * ellipsisWidth;
-
-        int keptWidth = textWidth(fm, text.mid(keepStart, keepEnd - keepStart));
-        if (keptWidth > budget)
-            break;   // Already over budget; buildWindowElide will trim from inside
-
-        // Neither side to expand into
-        if (!needLeft && !needRight)
-            break;
-
-        // Try expanding left
-        bool expanded = false;
-        if (keepStart > 0) {
-            int cw = charWidth(fm, text[keepStart - 1]);
-            int newNeedLeft = (keepStart - 1 > 0);
-            int newNumEllipsis = (newNeedLeft ? 1 : 0) + (needRight ? 1 : 0);
-            int newBudget = maxWidth - newNumEllipsis * ellipsisWidth;
-            if (keptWidth + cw <= newBudget) {
-                --keepStart;
-                expanded = true;
-            }
-        }
-        // Try expanding right
-        if (!expanded && keepEnd < text.length()) {
-            int cw = charWidth(fm, text[keepEnd]);
-            int newNeedRight = (keepEnd + 1 < text.length());
-            int newNumEllipsis = (needLeft ? 1 : 0) + (newNeedRight ? 1 : 0);
-            int newBudget = maxWidth - newNumEllipsis * ellipsisWidth;
-            if (keptWidth + cw <= newBudget) {
-                ++keepEnd;
-                expanded = true;
-            }
-        }
-        if (!expanded)
-            break;
-    }
-
-    return buildWindowElide(text, keepStart, keepEnd, maxWidth, fm);
-}
-
-ElideResult elideWithTracking(const QString &text, Qt::TextElideMode mode,
-                              int maxWidth, const QFontMetrics &fm)
-{
-    ElideResult result;
-    if (text.isEmpty())
-        return result;
-
-    const QString ellipsis = QStringLiteral("…");
-    int ellipsisWidth = charWidth(fm, QChar(0x2026));
-
-    if (textWidth(fm, text) <= maxWidth) {
-        // No eliding needed
-        result.text = text;
-        result.origPositions.resize(text.length());
-        for (int i = 0; i < text.length(); ++i)
-            result.origPositions[i] = i;
-        return result;
-    }
-
-    if (maxWidth <= ellipsisWidth) {
-        // Not enough room even for ellipsis alone
-        result.text = ellipsis;
-        result.origPositions = { -1 };
-        return result;
-    }
-
-    int availWidth = maxWidth - ellipsisWidth;
-
-    switch (mode) {
-    case Qt::ElideRight: {
-        int w = 0;
-        int keep = 0;
-        for (int i = 0; i < text.length(); ++i) {
-            int cw = charWidth(fm, text[i]);
-            if (w + cw > availWidth)
-                break;
-            w += cw;
-            ++keep;
-        }
-        result.text = text.left(keep) + ellipsis;
-        result.origPositions.resize(result.text.length());
-        for (int i = 0; i < keep; ++i)
-            result.origPositions[i] = i;
-        result.origPositions[keep] = -1;   // ellipsis
-        break;
-    }
-    case Qt::ElideMiddle: {
-        // Binary-search style: try different head/tail splits from largest to smallest
-        int total = text.length();
-        int bestKeep = 0;
-        for (int tryChars = total - 1; tryChars >= 1; --tryChars) {
-            int head = tryChars / 2;
-            int tail = tryChars - head;
-            if (head < 0 || tail < 0 || head + tail > total)
-                continue;
-            int w = textWidth(fm, text.left(head)) + textWidth(fm, text.right(tail));
-            if (w <= availWidth) {
-                bestKeep = tryChars;
-                break;
-            }
-        }
-        if (bestKeep == 0) {
-            // Nothing fits besides ellipsis
-            result.text = ellipsis;
-            result.origPositions = { -1 };
-            break;
-        }
-        int head = bestKeep / 2;
-        int tail = bestKeep - head;
-        result.text = text.left(head) + ellipsis + text.right(tail);
-        result.origPositions.resize(result.text.length());
-        for (int i = 0; i < head; ++i)
-            result.origPositions[i] = i;
-        result.origPositions[head] = -1;   // ellipsis
-        for (int i = 0; i < tail; ++i)
-            result.origPositions[head + 1 + i] = total - tail + i;
-        break;
-    }
-    case Qt::ElideLeft: {
-        int w = 0;
-        int keep = 0;
-        for (int i = text.length() - 1; i >= 0; --i) {
-            int cw = charWidth(fm, text[i]);
-            if (w + cw > availWidth)
-                break;
-            w += cw;
-            ++keep;
-        }
-        result.text = ellipsis + text.right(keep);
-        result.origPositions.resize(result.text.length());
-        result.origPositions[0] = -1;   // ellipsis
-        for (int i = 0; i < keep; ++i)
-            result.origPositions[1 + i] = text.length() - keep + i;
-        break;
-    }
-    case Qt::ElideNone:
-    default:
-        result.text = text;
-        result.origPositions.resize(text.length());
-        for (int i = 0; i < text.length(); ++i)
-            result.origPositions[i] = i;
-        break;
-    }
-
-    return result;
-}
-
-}   // anonymous namespace
 
 HighlightLabel::HighlightLabel(QWidget *parent, Qt::WindowFlags f)
     : QLabel(parent, f)
@@ -444,7 +132,7 @@ HighlightLabel::ElideInfo HighlightLabel::computeElidedText(int layoutWidth) con
                 QFontMetrics fm(font());
                 QString remaining = m_text.mid(line.textStart());
 
-                ElideResult elideResult;
+                HighlightUtils::ElideResult elideResult;
                 if (m_elideMode == ElideMode::Smart) {
                     ElideInfo smartInfo = computeSmartElidedText(remaining, layoutWidth, fm);
                     elideResult.text = smartInfo.displayText;
@@ -452,14 +140,12 @@ HighlightLabel::ElideInfo HighlightLabel::computeElidedText(int layoutWidth) con
                     info.elided = smartInfo.elided;
                 } else {
                     auto qtMode = static_cast<Qt::TextElideMode>(m_elideMode);
-                    // For multi-line text, use left elision on the last line to show the end
                     Qt::TextElideMode lastLineElideMode =
                             (m_maxLines > 1 && qtMode == Qt::ElideMiddle) ? Qt::ElideLeft : qtMode;
-                    elideResult = elideWithTracking(remaining, lastLineElideMode, layoutWidth, fm);
+                    elideResult = HighlightUtils::elideWithTracking(remaining, lastLineElideMode, layoutWidth, fm);
                 }
                 info.displayText = m_text.left(line.textStart()) + elideResult.text;
 
-                // Build full position mapping: identity for head, elideResult mapping for tail
                 info.origPosMapping.resize(info.displayText.length());
                 int headLen = line.textStart();
                 for (int j = 0; j < headLen; ++j)
@@ -517,24 +203,21 @@ HighlightLabel::ElideInfo HighlightLabel::computeSmartElidedText(
     if (text.isEmpty() || m_keywords.isEmpty())
         return info;
 
-    if (textWidth(fm, text) <= maxWidth)
+    if (HighlightUtils::elideWithTracking(text, Qt::ElideRight, maxWidth, fm).text == text)
         return info;
 
-    QVector<MatchRange> matchRanges = findMatchRanges(text, m_keywords);
+    auto matchRanges = HighlightUtils::findMatchRanges(text, m_keywords);
     if (matchRanges.isEmpty()) {
-        // No keyword matches — fall back to ElideRight
-        ElideResult fallback = elideWithTracking(text, Qt::ElideRight, maxWidth, fm);
+        HighlightUtils::ElideResult fallback = HighlightUtils::elideWithTracking(text, Qt::ElideRight, maxWidth, fm);
         info.displayText = fallback.text;
         info.origPosMapping = fallback.origPositions;
         info.elided = true;
         return info;
     }
 
-    // smartElideWithTracking handles full-text-fits, too-narrow, and expansion internally
-    ElideResult windowResult = smartElideWithTracking(text, maxWidth, fm, matchRanges);
+    HighlightUtils::ElideResult windowResult = HighlightUtils::smartElideWithTracking(text, maxWidth, fm, matchRanges);
     if (windowResult.text.isEmpty()) {
-        // Should not happen since matchRanges is non-empty, but guard anyway
-        ElideResult fallback = elideWithTracking(text, Qt::ElideRight, maxWidth, fm);
+        HighlightUtils::ElideResult fallback = HighlightUtils::elideWithTracking(text, Qt::ElideRight, maxWidth, fm);
         info.displayText = fallback.text;
         info.origPosMapping = fallback.origPositions;
         info.elided = true;
@@ -550,78 +233,8 @@ HighlightLabel::ElideInfo HighlightLabel::computeSmartElidedText(
 QVector<QTextLayout::FormatRange> HighlightLabel::buildFormatRanges(
         const QString &displayText, const QVector<int> &origPosMapping) const
 {
-    QVector<QTextLayout::FormatRange> ranges;
-
-    if (m_keywords.isEmpty() || displayText.isEmpty())
-        return ranges;
-
-    QTextCharFormat fmt;
-    fmt.setFont(font());
-    fmt.setFontWeight(QFont::DemiBold);
-    fmt.setForeground(palette().color(QPalette::BrightText));
-
-    if (origPosMapping.isEmpty()) {
-        // Non-elided case: find matches directly in displayText
-        for (const QString &keyword : m_keywords) {
-            if (keyword.isEmpty())
-                continue;
-            QRegularExpression re(QRegularExpression::escape(keyword),
-                                  QRegularExpression::CaseInsensitiveOption);
-            QRegularExpressionMatchIterator it = re.globalMatch(displayText);
-            while (it.hasNext()) {
-                QRegularExpressionMatch match = it.next();
-                QTextLayout::FormatRange range;
-                range.start = match.capturedStart();
-                range.length = match.capturedLength();
-                range.format = fmt;
-                ranges.append(range);
-            }
-        }
-    } else {
-        // Elided case: find matches in original text, map to display positions
-        for (const QString &keyword : m_keywords) {
-            if (keyword.isEmpty())
-                continue;
-            QRegularExpression re(QRegularExpression::escape(keyword),
-                                  QRegularExpression::CaseInsensitiveOption);
-            QRegularExpressionMatchIterator it = re.globalMatch(m_text);
-            while (it.hasNext()) {
-                QRegularExpressionMatch match = it.next();
-                int origStart = match.capturedStart();
-                int origEnd = origStart + match.capturedLength();
-
-                // Scan display positions to find contiguous visible sub-ranges
-                int rangeStart = -1;
-                for (int i = 0; i < displayText.length(); ++i) {
-                    int origPos = origPosMapping.value(i, -1);
-                    bool inMatch = (origPos >= origStart && origPos < origEnd);
-                    if (inMatch) {
-                        if (rangeStart == -1)
-                            rangeStart = i;
-                    } else {
-                        if (rangeStart != -1) {
-                            QTextLayout::FormatRange range;
-                            range.start = rangeStart;
-                            range.length = i - rangeStart;
-                            range.format = fmt;
-                            ranges.append(range);
-                            rangeStart = -1;
-                        }
-                    }
-                }
-                // Close any trailing range
-                if (rangeStart != -1) {
-                    QTextLayout::FormatRange range;
-                    range.start = rangeStart;
-                    range.length = displayText.length() - rangeStart;
-                    range.format = fmt;
-                    ranges.append(range);
-                }
-            }
-        }
-    }
-
-    return ranges;
+    QTextCharFormat fmt = HighlightUtils::defaultHighlightFormat(font(), palette());
+    return HighlightUtils::buildFormatRanges(displayText, origPosMapping, m_text, m_keywords, fmt);
 }
 
 void HighlightLabel::paintEvent(QPaintEvent *event)
@@ -636,7 +249,6 @@ void HighlightLabel::paintEvent(QPaintEvent *event)
     QRectF layoutRect = m_layout.boundingRect();
     Qt::Alignment align = alignment();
 
-    // Vertical alignment
     qreal y = 0;
     Qt::Alignment vAlign = align & Qt::AlignVertical_Mask;
     if (vAlign & Qt::AlignBottom)
@@ -644,7 +256,6 @@ void HighlightLabel::paintEvent(QPaintEvent *event)
     else if (vAlign & Qt::AlignVCenter)
         y = (height() - layoutRect.height()) / 2.0;
 
-    // Draw the entire layout at the calculated position
     m_layout.draw(&painter, QPointF(0, y));
 }
 

--- a/src/global/widgets/highlightutils.cpp
+++ b/src/global/widgets/highlightutils.cpp
@@ -1,0 +1,444 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "highlightutils.h"
+
+#include <QPainter>
+#include <QFontMetrics>
+#include <QRegularExpression>
+#include <QPalette>
+#include <algorithm>
+
+namespace HighlightUtils {
+
+static int charWidth(const QFontMetrics &fm, QChar ch)
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    return fm.width(ch);
+#else
+    return fm.horizontalAdvance(ch);
+#endif
+}
+
+static int textWidth(const QFontMetrics &fm, const QString &text)
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    return fm.width(text);
+#else
+    return fm.horizontalAdvance(text);
+#endif
+}
+
+QVector<MatchRange> findMatchRanges(const QString &text, const QStringList &keywords)
+{
+    QVector<MatchRange> ranges;
+    for (const QString &kw : keywords) {
+        if (kw.isEmpty())
+            continue;
+        QRegularExpression re(QRegularExpression::escape(kw),
+                              QRegularExpression::CaseInsensitiveOption);
+        QRegularExpressionMatchIterator it = re.globalMatch(text);
+        while (it.hasNext()) {
+            auto m = it.next();
+            ranges.append({ static_cast<int>(m.capturedStart()),
+                            static_cast<int>(m.capturedStart() + m.capturedLength()) });
+        }
+    }
+    std::sort(ranges.begin(), ranges.end(),
+              [](const MatchRange &a, const MatchRange &b) { return a.start < b.start; });
+    QVector<MatchRange> merged;
+    for (const auto &r : ranges) {
+        if (!merged.isEmpty() && r.start <= merged.last().end)
+            merged.last().end = std::max(merged.last().end, r.end);
+        else
+            merged.append(r);
+    }
+    return merged;
+}
+
+static ElideResult buildWindowElide(const QString &text, int keepStart, int keepEnd,
+                                    int maxWidth, const QFontMetrics &fm)
+{
+    ElideResult result;
+    const QString ellipsis = QStringLiteral("…");
+    int ellipsisWidth = charWidth(fm, QChar(0x2026));
+
+    bool needLeft = (keepStart > 0);
+    bool needRight = (keepEnd < text.length());
+    int numEllipsis = (needLeft ? 1 : 0) + (needRight ? 1 : 0);
+    int budget = maxWidth - numEllipsis * ellipsisWidth;
+    if (budget <= 0) {
+        result.text = ellipsis;
+        result.origPositions = { -1 };
+        return result;
+    }
+
+    int keepLen = keepEnd - keepStart;
+    int trimLeft = 0, trimRight = 0;
+    int w = textWidth(fm, text.mid(keepStart, keepLen));
+    while (w > budget && keepLen > 0) {
+        int lNext = charWidth(fm, text[keepStart + trimLeft]);
+        int rNext = charWidth(fm, text[keepEnd - 1 - trimRight]);
+        if (trimRight >= keepLen - trimLeft - 1) {
+            w -= lNext;
+            ++trimLeft;
+        } else if (lNext >= rNext) {
+            w -= lNext;
+            ++trimLeft;
+        } else {
+            w -= rNext;
+            ++trimRight;
+        }
+        keepLen = (keepEnd - trimRight) - (keepStart + trimLeft);
+    }
+    if (keepLen <= 0) {
+        result.text = ellipsis;
+        result.origPositions = { -1 };
+        return result;
+    }
+
+    int actualStart = keepStart + trimLeft;
+    int actualEnd = keepEnd - trimRight;
+    QString kept = text.mid(actualStart, actualEnd - actualStart);
+
+    result.text = (needLeft ? ellipsis : QString()) + kept + (needRight ? ellipsis : QString());
+    int pos = 0;
+    result.origPositions.resize(result.text.length());
+    if (needLeft) {
+        result.origPositions[pos++] = -1;
+    }
+    for (int i = actualStart; i < actualEnd; ++i)
+        result.origPositions[pos++] = i;
+    if (needRight)
+        result.origPositions[pos] = -1;
+    return result;
+}
+
+ElideResult smartElideWithTracking(const QString &text, int maxWidth,
+                                   const QFontMetrics &fm,
+                                   const QVector<MatchRange> &matchRanges)
+{
+    const QString ellipsis = QStringLiteral("…");
+    int ellipsisWidth = charWidth(fm, QChar(0x2026));
+
+    if (textWidth(fm, text) <= maxWidth) {
+        ElideResult result;
+        result.text = text;
+        result.origPositions.resize(text.length());
+        for (int i = 0; i < text.length(); ++i)
+            result.origPositions[i] = i;
+        return result;
+    }
+
+    if (maxWidth <= ellipsisWidth) {
+        ElideResult result;
+        result.text = ellipsis;
+        result.origPositions = { -1 };
+        return result;
+    }
+
+    int keepStart = text.length();
+    int keepEnd = 0;
+    for (const auto &mr : matchRanges) {
+        keepStart = std::min(keepStart, mr.start);
+        keepEnd = std::max(keepEnd, mr.end);
+    }
+
+    if (keepStart >= keepEnd)
+        return {};
+
+    while (true) {
+        bool needLeft = (keepStart > 0);
+        bool needRight = (keepEnd < text.length());
+        int numEllipsis = (needLeft ? 1 : 0) + (needRight ? 1 : 0);
+        int budget = maxWidth - numEllipsis * ellipsisWidth;
+
+        int keptWidth = textWidth(fm, text.mid(keepStart, keepEnd - keepStart));
+        if (keptWidth > budget)
+            break;
+
+        if (!needLeft && !needRight)
+            break;
+
+        bool expanded = false;
+        if (keepStart > 0) {
+            int cw = charWidth(fm, text[keepStart - 1]);
+            int newNeedLeft = (keepStart - 1 > 0);
+            int newNumEllipsis = (newNeedLeft ? 1 : 0) + (needRight ? 1 : 0);
+            int newBudget = maxWidth - newNumEllipsis * ellipsisWidth;
+            if (keptWidth + cw <= newBudget) {
+                --keepStart;
+                expanded = true;
+            }
+        }
+        if (!expanded && keepEnd < text.length()) {
+            int cw = charWidth(fm, text[keepEnd]);
+            int newNeedRight = (keepEnd + 1 < text.length());
+            int newNumEllipsis = (needLeft ? 1 : 0) + (newNeedRight ? 1 : 0);
+            int newBudget = maxWidth - newNumEllipsis * ellipsisWidth;
+            if (keptWidth + cw <= newBudget) {
+                ++keepEnd;
+                expanded = true;
+            }
+        }
+        if (!expanded)
+            break;
+    }
+
+    return buildWindowElide(text, keepStart, keepEnd, maxWidth, fm);
+}
+
+ElideResult elideWithTracking(const QString &text, Qt::TextElideMode mode,
+                              int maxWidth, const QFontMetrics &fm)
+{
+    ElideResult result;
+    if (text.isEmpty())
+        return result;
+
+    const QString ellipsis = QStringLiteral("…");
+    int ellipsisWidth = charWidth(fm, QChar(0x2026));
+
+    if (textWidth(fm, text) <= maxWidth) {
+        result.text = text;
+        result.origPositions.resize(text.length());
+        for (int i = 0; i < text.length(); ++i)
+            result.origPositions[i] = i;
+        return result;
+    }
+
+    if (maxWidth <= ellipsisWidth) {
+        result.text = ellipsis;
+        result.origPositions = { -1 };
+        return result;
+    }
+
+    int availWidth = maxWidth - ellipsisWidth;
+
+    switch (mode) {
+    case Qt::ElideRight: {
+        int w = 0;
+        int keep = 0;
+        for (int i = 0; i < text.length(); ++i) {
+            int cw = charWidth(fm, text[i]);
+            if (w + cw > availWidth)
+                break;
+            w += cw;
+            ++keep;
+        }
+        result.text = text.left(keep) + ellipsis;
+        result.origPositions.resize(result.text.length());
+        for (int i = 0; i < keep; ++i)
+            result.origPositions[i] = i;
+        result.origPositions[keep] = -1;
+        break;
+    }
+    case Qt::ElideMiddle: {
+        int total = text.length();
+        int bestKeep = 0;
+        for (int tryChars = total - 1; tryChars >= 1; --tryChars) {
+            int head = tryChars / 2;
+            int tail = tryChars - head;
+            if (head < 0 || tail < 0 || head + tail > total)
+                continue;
+            int w = textWidth(fm, text.left(head)) + textWidth(fm, text.right(tail));
+            if (w <= availWidth) {
+                bestKeep = tryChars;
+                break;
+            }
+        }
+        if (bestKeep == 0) {
+            result.text = ellipsis;
+            result.origPositions = { -1 };
+            break;
+        }
+        int head = bestKeep / 2;
+        int tail = bestKeep - head;
+        result.text = text.left(head) + ellipsis + text.right(tail);
+        result.origPositions.resize(result.text.length());
+        for (int i = 0; i < head; ++i)
+            result.origPositions[i] = i;
+        result.origPositions[head] = -1;
+        for (int i = 0; i < tail; ++i)
+            result.origPositions[head + 1 + i] = total - tail + i;
+        break;
+    }
+    case Qt::ElideLeft: {
+        int w = 0;
+        int keep = 0;
+        for (int i = text.length() - 1; i >= 0; --i) {
+            int cw = charWidth(fm, text[i]);
+            if (w + cw > availWidth)
+                break;
+            w += cw;
+            ++keep;
+        }
+        result.text = ellipsis + text.right(keep);
+        result.origPositions.resize(result.text.length());
+        result.origPositions[0] = -1;
+        for (int i = 0; i < keep; ++i)
+            result.origPositions[1 + i] = text.length() - keep + i;
+        break;
+    }
+    case Qt::ElideNone:
+    default:
+        result.text = text;
+        result.origPositions.resize(text.length());
+        for (int i = 0; i < text.length(); ++i)
+            result.origPositions[i] = i;
+        break;
+    }
+
+    return result;
+}
+
+QVector<QTextLayout::FormatRange> buildFormatRanges(
+    const QString &displayText,
+    const QVector<int> &origPosMapping,
+    const QString &originalText,
+    const QStringList &keywords,
+    const QTextCharFormat &format)
+{
+    QVector<QTextLayout::FormatRange> ranges;
+
+    if (keywords.isEmpty() || displayText.isEmpty())
+        return ranges;
+
+    if (origPosMapping.isEmpty()) {
+        for (const QString &keyword : keywords) {
+            if (keyword.isEmpty())
+                continue;
+            QRegularExpression re(QRegularExpression::escape(keyword),
+                                  QRegularExpression::CaseInsensitiveOption);
+            QRegularExpressionMatchIterator it = re.globalMatch(displayText);
+            while (it.hasNext()) {
+                QRegularExpressionMatch match = it.next();
+                QTextLayout::FormatRange range;
+                range.start = match.capturedStart();
+                range.length = match.capturedLength();
+                range.format = format;
+                ranges.append(range);
+            }
+        }
+    } else {
+        for (const QString &keyword : keywords) {
+            if (keyword.isEmpty())
+                continue;
+            QRegularExpression re(QRegularExpression::escape(keyword),
+                                  QRegularExpression::CaseInsensitiveOption);
+            QRegularExpressionMatchIterator it = re.globalMatch(originalText);
+            while (it.hasNext()) {
+                QRegularExpressionMatch match = it.next();
+                int origStart = match.capturedStart();
+                int origEnd = origStart + match.capturedLength();
+
+                int rangeStart = -1;
+                for (int i = 0; i < displayText.length(); ++i) {
+                    int origPos = origPosMapping.value(i, -1);
+                    bool inMatch = (origPos >= origStart && origPos < origEnd);
+                    if (inMatch) {
+                        if (rangeStart == -1)
+                            rangeStart = i;
+                    } else {
+                        if (rangeStart != -1) {
+                            QTextLayout::FormatRange range;
+                            range.start = rangeStart;
+                            range.length = i - rangeStart;
+                            range.format = format;
+                            ranges.append(range);
+                            rangeStart = -1;
+                        }
+                    }
+                }
+                if (rangeStart != -1) {
+                    QTextLayout::FormatRange range;
+                    range.start = rangeStart;
+                    range.length = displayText.length() - rangeStart;
+                    range.format = format;
+                    ranges.append(range);
+                }
+            }
+        }
+    }
+
+    return ranges;
+}
+
+QTextCharFormat defaultHighlightFormat(const QFont &baseFont, const QPalette &palette)
+{
+    QTextCharFormat fmt;
+    fmt.setFont(baseFont);
+    fmt.setFontWeight(QFont::DemiBold);
+    fmt.setForeground(palette.color(QPalette::BrightText));
+    return fmt;
+}
+
+void drawHighlightedText(QPainter *painter, const QString &text,
+                         const QStringList &keywords,
+                         const QFont &font, const QColor &textColor,
+                         const QColor &highlightColor,
+                         const QRect &rect, Qt::Alignment alignment)
+{
+    if (text.isEmpty())
+        return;
+
+    QFontMetrics fm(font);
+    int maxWidth = rect.width();
+
+    // Elide
+    QVector<MatchRange> matchRanges = findMatchRanges(text, keywords);
+    ElideResult elideResult;
+
+    if (!matchRanges.isEmpty()) {
+        elideResult = smartElideWithTracking(text, maxWidth, fm, matchRanges);
+    }
+    if (elideResult.text.isEmpty()) {
+        elideResult = elideWithTracking(text, Qt::ElideRight, maxWidth, fm);
+    }
+
+    const QString &displayText = elideResult.text;
+    const QVector<int> &origPosMapping = elideResult.origPositions;
+
+    // Build format ranges for keywords
+    QVector<QTextLayout::FormatRange> formats;
+    if (!keywords.isEmpty()) {
+        QTextCharFormat fmt;
+        fmt.setFont(font);
+        fmt.setFontWeight(QFont::DemiBold);
+        fmt.setForeground(highlightColor);
+
+        // Create a temporary palette with our desired highlight color
+        QPalette tempPalette;
+        tempPalette.setColor(QPalette::BrightText, highlightColor);
+
+        formats = buildFormatRanges(displayText, origPosMapping, text, keywords, fmt);
+    }
+
+    // Setup QTextLayout
+    QTextLayout layout;
+    layout.setText(displayText);
+    layout.setFont(font);
+    layout.setFormats(formats);
+
+    layout.beginLayout();
+    QTextLine line = layout.createLine();
+    if (line.isValid())
+        line.setLineWidth(maxWidth);
+    layout.endLayout();
+
+    // Vertical alignment
+    int textHeight = fm.height();
+    int y = rect.y();
+    if (alignment & Qt::AlignVCenter)
+        y += (rect.height() - textHeight) / 2;
+    else if (alignment & Qt::AlignBottom)
+        y += rect.height() - textHeight;
+
+    painter->save();
+    painter->setPen(textColor);
+    painter->translate(rect.x(), y);
+    layout.draw(painter, QPointF(0, 0));
+    painter->restore();
+}
+
+}   // namespace HighlightUtils

--- a/src/global/widgets/highlightutils.h
+++ b/src/global/widgets/highlightutils.h
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef HIGHLIGHTUTILS_H
+#define HIGHLIGHTUTILS_H
+
+#include <QFontMetrics>
+#include <QTextLayout>
+#include <QString>
+#include <QStringList>
+#include <QVector>
+
+class QTextCharFormat;
+
+namespace HighlightUtils {
+
+struct MatchRange {
+    int start;
+    int end;   // exclusive
+};
+
+struct ElideResult {
+    QString text;
+    QVector<int> origPositions;   // text[i] -> original char position, -1 for ellipsis char
+};
+
+// Find all keyword match ranges in text (case-insensitive, merged, sorted)
+QVector<MatchRange> findMatchRanges(const QString &text, const QStringList &keywords);
+
+// Standard elide with position tracking
+ElideResult elideWithTracking(const QString &text, Qt::TextElideMode mode,
+                              int maxWidth, const QFontMetrics &fm);
+
+// Smart elide that keeps keyword matches visible
+ElideResult smartElideWithTracking(const QString &text, int maxWidth,
+                                   const QFontMetrics &fm,
+                                   const QVector<MatchRange> &matchRanges);
+
+// Build QTextLayout format ranges for keyword highlighting
+// If origPosMapping is empty, matches are found directly in displayText
+// Otherwise, matches are found in originalText and mapped to display positions via origPosMapping
+QVector<QTextLayout::FormatRange> buildFormatRanges(
+    const QString &displayText,
+    const QVector<int> &origPosMapping,
+    const QString &originalText,
+    const QStringList &keywords,
+    const QTextCharFormat &format);
+
+// Convenience: create a default highlight format (DemiBold + BrightText foreground)
+QTextCharFormat defaultHighlightFormat(const QFont &baseFont, const QPalette &palette);
+
+// Render a highlighted, elided text using QTextLayout at a given rect
+void drawHighlightedText(QPainter *painter, const QString &text,
+                         const QStringList &keywords,
+                         const QFont &font, const QColor &textColor,
+                         const QColor &highlightColor,
+                         const QRect &rect, Qt::Alignment alignment = Qt::AlignVCenter | Qt::AlignLeft);
+
+}   // namespace HighlightUtils
+
+#endif // HIGHLIGHTUTILS_H

--- a/src/grand-search/CMakeLists.txt
+++ b/src/grand-search/CMakeLists.txt
@@ -194,6 +194,8 @@ set(GUISRC
     # shared widgets
     ../global/widgets/highlightlabel.h
     ../global/widgets/highlightlabel.cpp
+    ../global/widgets/highlightutils.h
+    ../global/widgets/highlightutils.cpp
     )
 
 # business

--- a/src/grand-search/gui/exhibition/matchresult/groupwidget.cpp
+++ b/src/grand-search/gui/exhibition/matchresult/groupwidget.cpp
@@ -151,7 +151,9 @@ int GroupWidget::getCurSelectHeight()
     int nHeight = 0;
     if (m_listView->currentIndex().isValid() || m_viewMoreButton->isSelected()) {
         nHeight += m_groupLabel->height();
-        nHeight += (m_listView->currentIndex().row() + 1) * ListItemHeight;
+        int curRow = m_listView->currentIndex().row();
+        for (int i = 0; i <= curRow; ++i)
+            nHeight += m_listView->sizeHintForRow(i);
     }
 
     return nHeight;
@@ -163,7 +165,10 @@ void GroupWidget::reLayout()
     Q_ASSERT(m_groupLabel);
     Q_ASSERT(m_line);
 
-    m_listView->setFixedHeight(m_listView->rowCount() * ListItemHeight);
+    int totalHeight = 0;
+    for (int i = 0; i < m_listView->rowCount(); ++i)
+        totalHeight += m_listView->sizeHintForRow(i);
+    m_listView->setFixedHeight(totalHeight);
 
     int labelWidth = this->width() - LayoutMagrinSize * 2 - (m_groupIcon->isVisible() ? 23 : 0);
     QTextDocument doc;

--- a/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistdelegate.cpp
+++ b/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistdelegate.cpp
@@ -5,27 +5,28 @@
 #include "grandsearchlistdelegate.h"
 #include "grandsearchlistview.h"
 #include "global/builtinsearch.h"
+#include "global/widgets/highlightutils.h"
 
 #include <DGuiApplicationHelper>
+#include <DFontSizeManager>
 
 #include <QDebug>
 #include <QPainter>
 #include <QPainterPath>
-#include <QTextDocument>
 #include <QStyleOptionViewItem>
+#include <QTextDocument>
 #include <QTextCursor>
-#include <QTextBlock>
 #include <QAbstractTextDocumentLayout>
 #include <QApplication>
 #include <QToolTip>
 
-#define ListItemSpace 10   // 列表图标与文本间间距
-#define ListItemHeight 36   // 列表行高
+#define ListItemHeight 36   // 列表行高（单行）
 #define ListIconSize 24   // 列表图标大小
 #define ListRowWidth 740   // 列表行宽
-#define ListIconMargin 10   // 列表图标边距
-#define TailDataMargin 10   // 拖尾信息显示间隔
+#define ItemDataSpacing 10   // 信息显示间隔
 #define TailMaxWidth 150   // 拖尾信息最大显示宽度
+#define ContextLineSpacing 1   // 文件名与匹配内容行间距
+#define ListLineMargin 8   // 行上下边距
 
 DWIDGET_USE_NAMESPACE
 DGUI_USE_NAMESPACE
@@ -82,8 +83,27 @@ void GrandSearchListDelegate::paint(QPainter *painter, const QStyleOptionViewIte
 QSize GrandSearchListDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     Q_UNUSED(option)
-    Q_UNUSED(index)
-    return QSize(ListRowWidth, ListItemHeight);
+
+    bool hasSecondLine = false;
+    if (index.isValid()) {
+        QVariant extra = index.data(DATA_ROLE).value<MatchedItem>().extra;
+        if (extra.isValid()) {
+            const QVariantHash &hash = extra.toHash();
+            hasSecondLine = hash.contains(GRANDSEARCH_PROPERTY_ITEM_MATCHEDCONTEXT)
+                    || hash.contains(GRANDSEARCH_PROPERTY_ITEM_TAILER)
+                    || hash.contains(GRANDSEARCH_PROPERTY_ITEM_MODIFIED_TIME);
+        }
+    }
+
+    if (!hasSecondLine)
+        return QSize(ListRowWidth, ListItemHeight);
+
+    QFontMetrics nameFm(DFontSizeManager::instance()->get(DFontSizeManager::T6));
+    QFontMetrics contextFm(DFontSizeManager::instance()->get(DFontSizeManager::T8));
+    int totalHeight = ListLineMargin + nameFm.height() + ContextLineSpacing + contextFm.height() + ListLineMargin;
+    totalHeight = qMax(totalHeight, ListItemHeight);
+
+    return QSize(ListRowWidth, totalHeight);
 }
 
 static void hideTooltipImmediately()
@@ -130,7 +150,7 @@ void GrandSearchListDelegate::drawIcon(QPainter *painter, const QStyleOptionView
         // 按实际比例缩放，宽高不超过 ListIconSize
         QSize scaledSize = thumbnail.size().scaled(ListIconSize, ListIconSize, Qt::KeepAspectRatio);
         QRect iconRect(QPoint(), scaledSize);
-        iconRect.moveCenter(QPoint(option.rect.x() + ListIconMargin + ListIconSize / 2,
+        iconRect.moveCenter(QPoint(option.rect.x() + ItemDataSpacing + ListIconSize / 2,
                                    option.rect.y() + option.rect.height() / 2));
 
         painter->save();
@@ -157,7 +177,7 @@ void GrandSearchListDelegate::drawIcon(QPainter *painter, const QStyleOptionView
         if (icon.isNull())
             return;
 
-        QRect iconRect(option.rect.x() + ListIconMargin, option.rect.y() + (option.rect.height() - ListIconSize) / 2,
+        QRect iconRect(option.rect.x() + ItemDataSpacing, option.rect.y() + (option.rect.height() - ListIconSize) / 2,
                        ListIconSize, ListIconSize);
         painter->save();
         icon.paint(painter, iconRect);
@@ -193,32 +213,84 @@ void GrandSearchListDelegate::drawSelectState(QPainter *painter, const QStyleOpt
 
 void GrandSearchListDelegate::drawSearchResultText(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
-    QColor nameTextColor;
-    const GrandSearchListView *listview = qobject_cast<const GrandSearchListView *>(option.widget);
+    const MatchedItem &item = index.data(DATA_ROLE).value<MatchedItem>();
+    const QVariantHash &extraHash = item.extra.toHash();
 
-    if ((listview->getThemeType() == DGuiApplicationHelper::DarkType)
-        || (index.isValid() && index == listview->currentIndex())) {
-        nameTextColor = QColor("#FFFFFF");
-    } else {
-        nameTextColor = QColor("#000000");
+    const GrandSearchListView *listview = qobject_cast<const GrandSearchListView *>(option.widget);
+    bool isDark = (listview->getThemeType() == DGuiApplicationHelper::DarkType)
+            || (index.isValid() && index == listview->currentIndex());
+    QColor nameTextColor = isDark ? QColor("#FFFFFF") : QColor("#000000");
+    nameTextColor.setAlpha(255 * 0.9);
+
+    QStringList keywords = extraHash.value(GRANDSEARCH_PROPERTY_ITEM_KEYWORDS, QStringList()).toStringList();
+    QFont nameFont = DFontSizeManager::instance()->get(DFontSizeManager::T6);
+    QFontMetrics nameFontMetrics(nameFont);
+
+    QFont secondFont = DFontSizeManager::instance()->get(DFontSizeManager::T8);
+    QFontMetrics secondFontMetrics(secondFont);
+    int textStartX = ItemDataSpacing + ListIconSize + ItemDataSpacing;
+    int firstLineY = option.rect.y() + ListLineMargin;
+    int secondLineY = firstLineY + nameFontMetrics.height() + ContextLineSpacing;
+
+    // 第一行：文件名
+    drawItemName(painter, option, item.name, item.searcher, keywords,
+                 nameFont, nameFontMetrics, nameTextColor, isDark, firstLineY);
+
+    // 第二行颜色（修改时间、拖尾共用）
+    QColor secondLineColor = isDark ? QColor("#FFFFFF") : QColor("#000000");
+    secondLineColor.setAlphaF(0.5);
+
+    bool isPreview = listview->isPreviewItem();
+    int currentX = textStartX;
+    int remainingWidth = option.rect.width() - currentX;
+
+    // 修改时间（独立字段，不限制宽度）
+    QString modifiedTime = extraHash.value(GRANDSEARCH_PROPERTY_ITEM_MODIFIED_TIME).toString();
+    if (!modifiedTime.isEmpty()) {
+        modifiedTime.prepend(tr("Modified at "));
+        drawSecondLineText(painter, modifiedTime, secondFont, secondFontMetrics, secondLineColor, currentX, secondLineY);
+        remainingWidth = option.rect.width() - currentX;
     }
 
-    // 设置字体
-    QFont nameFont = DFontSizeManager::instance()->get(DFontSizeManager::T6);
-    nameFont.setWeight(QFont::Medium);
+    // 拖尾数据（预览时不显示）
+    if (!isPreview) {
+        QStringList tailList = extraHash.value(GRANDSEARCH_PROPERTY_ITEM_TAILER, QStringList()).toStringList();
+        if (!tailList.isEmpty()) {
+            if (remainingWidth > ItemDataSpacing) {
+                currentX += ItemDataSpacing;
+                remainingWidth = option.rect.width() - currentX;
+            }
+            currentX = drawTailText(painter, tailList, secondFont, secondFontMetrics, secondLineColor,
+                                    remainingWidth, currentX, secondLineY);
+            remainingWidth = option.rect.width() - currentX;
+        }
+    }
 
-    const QString &name = index.data(DATA_ROLE).value<MatchedItem>().name;
-    const QString &searcher = index.data(DATA_ROLE).value<MatchedItem>().searcher;
+    // 匹配摘要
+    if (!isPreview && remainingWidth > ItemDataSpacing) {
+        QString context = extraHash.value(GRANDSEARCH_PROPERTY_ITEM_MATCHEDCONTEXT).toString();
+        if (!context.isEmpty()) {
+            currentX += ItemDataSpacing;
+            drawMatchedContext(painter, option, context, keywords,
+                               secondFont, secondFontMetrics, isDark, secondLineY, currentX);
+        }
+    }
+}
 
-    int listItemTextMaxWidth = option.rect.width() - ListIconMargin - ListIconSize - ListItemSpace;
-    QFontMetrics nameFontMetrics(nameFont);
-    QString elidedName = nameFontMetrics.elidedText(name, Qt::ElideRight, listItemTextMaxWidth);
+void GrandSearchListDelegate::drawItemName(QPainter *painter, const QStyleOptionViewItem &option,
+                                           const QString &name, const QString &searcher,
+                                           const QStringList &keywords, const QFont &font,
+                                           const QFontMetrics &fontMetrics, const QColor &textColor,
+                                           bool isDark, int startY) const
+{
+    int textStartX = ItemDataSpacing + ListIconSize + ItemDataSpacing;
+    int nameTextMaxWidth = option.rect.width() - textStartX;
+
+    QString elidedName = fontMetrics.elidedText(name, Qt::ElideRight, nameTextMaxWidth);
     if (elidedName != name && GRANDSEARCH_CLASS_WEB_STATICTEXT == searcher) {
-        // 如果存在截断显示，且该项属于web搜索，则截断时需要保留尾部的双引号
-        // 根据文档工程师给出的翻译规范，双引号会被翻译，需要使用翻译后的字符计算宽度
         static const QString markStr = name.right(1);
-        static const int markWidth = nameFontMetrics.size(Qt::TextSingleLine, markStr).width();
-        elidedName = nameFontMetrics.elidedText(name.left(name.count() - 1), Qt::ElideRight, listItemTextMaxWidth - markWidth);
+        static const int markWidth = fontMetrics.size(Qt::TextSingleLine, markStr).width();
+        elidedName = fontMetrics.elidedText(name.left(name.size() - 1), Qt::ElideRight, nameTextMaxWidth - markWidth);
         elidedName.append(markStr);
     }
 
@@ -230,123 +302,139 @@ void GrandSearchListDelegate::drawSearchResultText(QPainter *painter, const QSty
     nameCursor.beginEditBlock();
     nameCursor.select(QTextCursor::LineUnderCursor);
     QTextCharFormat nameFmt;
-    nameFmt.setForeground(nameTextColor);
-    nameFmt.setFont(nameFont);
+    nameFmt.setForeground(textColor);
+    nameFmt.setFont(font);
     nameCursor.mergeCharFormat(nameFmt);
+
+    if (!keywords.isEmpty()) {
+        QTextCharFormat hlFmt;
+        hlFmt.setFontWeight(QFont::DemiBold);
+        hlFmt.setForeground(isDark ? QColor("#FFFFFF") : QColor("#000000"));
+        for (const QString &kw : keywords) {
+            if (kw.isEmpty()) continue;
+            QTextCursor searchCursor(&nameDocument);
+            while (!searchCursor.isNull() && !searchCursor.atEnd()) {
+                searchCursor = nameDocument.find(kw, searchCursor,
+                                                 QTextDocument::FindCaseSensitively);
+                if (!searchCursor.isNull())
+                    searchCursor.mergeCharFormat(hlFmt);
+            }
+        }
+    }
+
     nameCursor.clearSelection();
     nameCursor.movePosition(QTextCursor::EndOfLine);
     nameCursor.endEditBlock();
 
-    // 设置文字边距，保证绘制文字居中
     QAbstractTextDocumentLayout::PaintContext paintContext;
-    int nameMargin = static_cast<int>((option.rect.height() - nameFontMetrics.height()) / 2);
-    int actualNameWidth = nameFontMetrics.size(Qt::TextSingleLine, elidedName).width();
-    int actualStartX = ListIconMargin + ListIconSize + ListItemSpace;
-    QRect nameTextRect(actualStartX, option.rect.y() + nameMargin, actualNameWidth, option.rect.height());
+    int actualNameWidth = fontMetrics.size(Qt::TextSingleLine, elidedName).width();
+    QRect drawRect(textStartX, startY, actualNameWidth, fontMetrics.height());
 
     painter->save();
-    painter->translate(nameTextRect.topLeft());
-    painter->setClipRect(nameTextRect.translated(-nameTextRect.topLeft()));
+    painter->translate(drawRect.topLeft());
+    painter->setClipRect(drawRect.translated(-drawRect.topLeft()));
     nameDocument.documentLayout()->draw(painter, paintContext);
     painter->restore();
-
-    // 未显示预览窗口时，需要显示拖尾数据
-    if (!listview->isPreviewItem()) {
-        drawTailText(painter, option, index, option.rect.width(), actualStartX + nameTextRect.width());
-    }
 }
 
-void GrandSearchListDelegate::drawTailText(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index, int textMaxWidth, int actualStartX) const
+void GrandSearchListDelegate::drawMatchedContext(QPainter *painter, const QStyleOptionViewItem &option,
+                                                 const QString &matchedContext, const QStringList &keywords,
+                                                 const QFont &font, const QFontMetrics &fontMetrics,
+                                                 bool isDark, int startY, int startX) const
 {
-    QFont tailFont = DFontSizeManager::instance()->get(DFontSizeManager::T8);
-    QFontMetrics tailFontMetrics(tailFont);
+    if (startX <= 0)
+        startX = ItemDataSpacing + ListIconSize + ItemDataSpacing;
+    int maxWidth = option.rect.width() - startX;
 
-    // 计算拖尾间隔符号显示宽度
-    static QString separator("— ");
-    int separatorWidth = tailFontMetrics.size(Qt::TextSingleLine, separator).width();
+    QColor textColor = isDark ? QColor(255, 255, 255, int(255 * 0.5)) : QColor(0, 0, 0, int(255 * 0.5));
+    QColor highlightColor = isDark ? QColor(255, 255, 255, int(255 * 0.8)) : QColor(0, 0, 0, int(255 * 0.85));
 
-    // 计算是否有空间显示拖尾信息
-    int totalTailWidth = textMaxWidth - actualStartX;
-    // 显示拖尾信息前，必须先显示分隔符
-    totalTailWidth = totalTailWidth - TailDataMargin - separatorWidth;
+    // 以最左边的关键词匹配为锚点进行省略
+    auto allRanges = HighlightUtils::findMatchRanges(matchedContext, keywords);
+    QVector<HighlightUtils::MatchRange> leftmostOnly;
+    if (!allRanges.isEmpty())
+        leftmostOnly.append(allRanges.constFirst());
 
-    // 存在剩余空间来显示拖尾信息
-    if (totalTailWidth > 0) {
+    HighlightUtils::ElideResult elideResult;
+    if (!leftmostOnly.isEmpty())
+        elideResult = HighlightUtils::smartElideWithTracking(matchedContext, maxWidth, fontMetrics, leftmostOnly);
+    if (elideResult.text.isEmpty())
+        elideResult = HighlightUtils::elideWithTracking(matchedContext, Qt::ElideRight, maxWidth, fontMetrics);
 
-        // 提取拖尾数据
-        const QVariant &extra = index.data(DATA_ROLE).value<MatchedItem>().extra;
-        QStringList tailStringList = extra.toHash().value(GRANDSEARCH_PROPERTY_ITEM_TAILER, QStringList()).toStringList();
-        if (!tailStringList.isEmpty()) {
+    // 构建高亮格式
+    QTextCharFormat hlFmt;
+    hlFmt.setFont(font);
+    hlFmt.setFontWeight(QFont::DemiBold);
+    hlFmt.setForeground(highlightColor);
+    auto formats = HighlightUtils::buildFormatRanges(
+            elideResult.text, elideResult.origPositions, matchedContext, keywords, hlFmt);
 
-            // 根据剩余宽度，计算能够显示的拖尾数量
-            int tailCount = tailStringList.count();
-            int tailAverageWidth = totalTailWidth;
-            calcTailShowInfo(totalTailWidth, tailCount, tailAverageWidth);
-            const QMap<int, QString> &tailMap = calcTailShowData(tailStringList, tailCount, tailAverageWidth, tailFontMetrics);
+    // 绘制
+    QTextLayout layout;
+    layout.setText(elideResult.text);
+    layout.setFont(font);
+    layout.setFormats(formats);
+    layout.beginLayout();
+    QTextLine line = layout.createLine();
+    if (line.isValid())
+        line.setLineWidth(maxWidth);
+    layout.endLayout();
 
-            if (tailMap.isEmpty())
-                return;
-
-            // 设置拖尾字体属性
-            QColor tailTextColor;
-            const GrandSearchListView *listview = qobject_cast<const GrandSearchListView *>(option.widget);
-
-            if ((listview->getThemeType() == DGuiApplicationHelper::DarkType)
-                || (index.isValid() && index == listview->currentIndex())) {
-                tailTextColor = QColor("#FFFFFF");
-            } else {
-                tailTextColor = QColor("#000000");
-            }
-
-            tailTextColor.setAlphaF(0.5);
-
-            // 先绘制分隔符,与名称间隔10个像素
-            actualStartX += TailDataMargin;
-            drawTailDetailedInfo(painter, option, separator, tailTextColor, tailFont, tailFontMetrics, actualStartX);
-
-            // 再逐个绘制拖尾信息
-            for (auto index : tailMap.keys()) {
-
-                if (0 != index) {
-                    // 如果不是第一个拖尾数据，则需要保留必要的间隔空间
-                    actualStartX += TailDataMargin;
-                }
-
-                const QString &showTailInfo = tailMap.value(index);
-                drawTailDetailedInfo(painter, option, showTailInfo, tailTextColor, tailFont, tailFontMetrics, actualStartX);
-            }
-        }
-    }
+    painter->save();
+    painter->setPen(textColor);
+    painter->translate(startX, startY);
+    layout.draw(painter, QPointF(0, 0));
+    painter->restore();
 }
 
-void GrandSearchListDelegate::drawTailDetailedInfo(QPainter *painter, const QStyleOptionViewItem &option, const QString &text, const QColor &color, const QFont &font, const QFontMetrics &fontMetrics, int &startX) const
+int GrandSearchListDelegate::drawTailText(QPainter *painter, const QStringList &tailList, const QFont &font,
+                                            const QFontMetrics &fontMetrics, const QColor &color,
+                                            int maxWidth, int startX, int startY) const
 {
-    QTextDocument document;
-    document.setDocumentMargin(0);
-    document.setPlainText(text);
-    QTextCursor cursor(&document);
+    if (tailList.isEmpty())
+        return startX;
 
-    cursor.beginEditBlock();
-    cursor.select(QTextCursor::LineUnderCursor);
+    int tailCount = tailList.count();
+    int tailAverageWidth = maxWidth;
+    calcTailShowInfo(maxWidth, tailCount, tailAverageWidth);
+
+    QStringList mutableList = tailList;
+    const QMap<int, QString> &tailMap = calcTailShowData(mutableList, tailCount, tailAverageWidth, fontMetrics);
+    if (tailMap.isEmpty())
+        return startX;
+
+    int currentX = startX;
+    for (auto tailIndex : tailMap.keys()) {
+        if (tailIndex != 0)
+            currentX += ItemDataSpacing;
+        drawSecondLineText(painter, tailMap.value(tailIndex), font, fontMetrics, color, currentX, startY);
+    }
+
+    return currentX;
+}
+
+void GrandSearchListDelegate::drawSecondLineText(QPainter *painter, const QString &text, const QFont &font,
+                                                     const QFontMetrics &fontMetrics, const QColor &color,
+                                                     int &startX, int startY) const
+{
+    int showWidth = fontMetrics.size(Qt::TextSingleLine, text).width();
+
+    QTextLayout layout;
+    layout.setText(text);
+    layout.setFont(font);
     QTextCharFormat fmt;
     fmt.setForeground(color);
-    fmt.setFont(font);
-    cursor.mergeCharFormat(fmt);
-    cursor.clearSelection();
-    cursor.movePosition(QTextCursor::EndOfLine);
-    cursor.endEditBlock();
+    layout.setFormats({QTextLayout::FormatRange{0, static_cast<int>(text.length()), fmt}});
 
-    int margin = static_cast<int>((option.rect.height() - fontMetrics.height()) / 2);
-    int showWidth = fontMetrics.size(Qt::TextSingleLine, text).width();
-    QRect rect(startX, option.rect.y() + margin, showWidth, option.rect.height());
+    layout.beginLayout();
+    layout.createLine();
+    layout.endLayout();
 
-    QAbstractTextDocumentLayout::PaintContext paintContext;
     painter->save();
-    painter->translate(rect.topLeft());
-    painter->setClipRect(rect.translated(-rect.topLeft()));
-    document.documentLayout()->draw(painter, paintContext);
+    painter->translate(startX, startY);
+    layout.draw(painter, QPointF(0, 0));
     painter->restore();
-    // 更新绘制开始位置
+
     startX += showWidth;
 }
 
@@ -356,7 +444,7 @@ void GrandSearchListDelegate::calcTailShowInfo(const int totalTailWidth, int &ta
 
     while (1 != tailCount) {
         // 计算每个拖尾信息平均可显示宽度(每个拖尾信息之间显示间隔10个像素)
-        averageWidth = (totalTailWidth - (tailCount - 1) * TailDataMargin) / tailCount;
+        averageWidth = (totalTailWidth - (tailCount - 1) * ItemDataSpacing) / tailCount;
         if (averageWidth > 0)
             break;
         // 宽度不够显示 (tailCount - 1) * TailDataMargin 个间隔，则减少拖尾数量继续计算

--- a/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistdelegate.h
+++ b/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistdelegate.h
@@ -35,8 +35,21 @@ private:
     void drawSelectState(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     void drawIcon(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     void drawSearchResultText(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-    void drawTailText(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index, int textMaxWidth, int actualStartX) const;
-    void drawTailDetailedInfo(QPainter *painter, const QStyleOptionViewItem &option, const QString &text, const QColor &color, const QFont &font, const QFontMetrics &fontMetrics, int &startX) const;
+    void drawItemName(QPainter *painter, const QStyleOptionViewItem &option,
+                      const QString &name, const QString &searcher,
+                      const QStringList &keywords, const QFont &font,
+                      const QFontMetrics &fontMetrics, const QColor &textColor,
+                      bool isDark, int startY) const;
+    void drawMatchedContext(QPainter *painter, const QStyleOptionViewItem &option,
+                            const QString &matchedContext, const QStringList &keywords,
+                            const QFont &font, const QFontMetrics &fontMetrics,
+                            bool isDark, int startY, int startX = 0) const;
+    int drawTailText(QPainter *painter, const QStringList &tailList, const QFont &font,
+                     const QFontMetrics &fontMetrics, const QColor &color,
+                     int maxWidth, int startX, int startY) const;
+    void drawSecondLineText(QPainter *painter, const QString &text, const QFont &font,
+                              const QFontMetrics &fontMetrics, const QColor &color,
+                              int &startX, int startY) const;
 
     void calcTailShowInfo(const int totalTailWidth, int &tailCount, int &averageWidth) const;
     QMap<int, QString> calcTailShowData(QStringList &strings, const int &tailCount, int averageWidth, const QFontMetrics &fontMetrics) const;
@@ -46,4 +59,4 @@ private:
 
 }
 
-#endif // GRANDSEARCHLISTDELEGATE_H
+#endif   // GRANDSEARCHLISTDELEGATE_H

--- a/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistview.cpp
+++ b/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistview.cpp
@@ -34,7 +34,7 @@ GrandSearchListView::GrandSearchListView(QWidget *parent)
     m_delegate = new GrandSearchListDelegate(this);
     setItemDelegate(m_delegate);
     setViewportMargins(0, 0, 0, 0);
-    setUniformItemSizes(true);
+    setUniformItemSizes(false);
     setIconSize({ ICON_SIZE, ICON_SIZE });
 
     setViewMode(QListView::ListMode);

--- a/src/grand-search/gui/searchconfig/checkboxwidget/checkboxwidget.cpp
+++ b/src/grand-search/gui/searchconfig/checkboxwidget/checkboxwidget.cpp
@@ -50,14 +50,10 @@ void CheckBoxWidget::addCheckBox(int index, CheckBoxItem *item, bool isChecked)
     m_checkBoxList << item;
 
     for (int i = 0; i < m_checkBoxList.count(); ++i) {
-        if (i == 0) {
-            m_checkBoxList[i]->setTopRound(true);
-        } else if (i == m_checkBoxList.count() - 1) {
-            m_checkBoxList[i]->setBottomRound(true);
-        } else {
-            m_checkBoxList[i]->setTopRound(false);
-            m_checkBoxList[i]->setBottomRound(false);
-        }
+        bool isFirst = (i == 0);
+        bool isLast = (i == m_checkBoxList.count() - 1);
+        m_checkBoxList[i]->setTopRound(isFirst);
+        m_checkBoxList[i]->setBottomRound(isLast);
     }
 
     connect(item, &CheckBoxItem::toggled, this, &CheckBoxWidget::onCheckBoxChecked);

--- a/src/grand-search/gui/searchconfig/tailerwidget.cpp
+++ b/src/grand-search/gui/searchconfig/tailerwidget.cpp
@@ -37,8 +37,6 @@ TailerWidget::TailerWidget(QWidget *parent)
     m_checkBoxWidget = new CheckBoxWidget(this);
     m_checkBoxWidget->addCheckBox(tr("Parent directory"),
                                   SearchConfig::instance()->getConfig(GRANDSEARCH_TAILER_GROUP, GRANDSEARCH_TAILER_PARENTDIR, false).toBool());
-    m_checkBoxWidget->addCheckBox(tr("Time modified"),
-                                  SearchConfig::instance()->getConfig(GRANDSEARCH_TAILER_GROUP, GRANDSEARCH_TAILER_TIMEMODEFIED, true).toBool());
     m_mainLayout->addWidget(m_checkBoxWidget);
 
     connect(m_checkBoxWidget, &CheckBoxWidget::checkedChanged, this, &TailerWidget::onCheckBoxStateChanged);
@@ -50,14 +48,6 @@ TailerWidget::~TailerWidget()
 
 void TailerWidget::onCheckBoxStateChanged(int index, bool checked)
 {
-    switch (index) {
-    case ParentDirectory:
+    if (index == ParentDirectory)
         SearchConfig::instance()->setConfig(GRANDSEARCH_TAILER_GROUP, GRANDSEARCH_TAILER_PARENTDIR, checked);
-        break;
-    case TimeModified:
-        SearchConfig::instance()->setConfig(GRANDSEARCH_TAILER_GROUP, GRANDSEARCH_TAILER_TIMEMODEFIED, checked);
-        break;
-    default:
-        break;
-    }
 }

--- a/src/grand-search/gui/searchconfig/tailerwidget.h
+++ b/src/grand-search/gui/searchconfig/tailerwidget.h
@@ -21,8 +21,7 @@ class TailerWidget : public Dtk::Widget::DWidget
 public:
     enum TailerProperty
     {
-        ParentDirectory,
-        TimeModified
+        ParentDirectory
     };
 
     explicit TailerWidget(QWidget *parent = nullptr);

--- a/src/preview-plugin/image-preview/CMakeLists.txt
+++ b/src/preview-plugin/image-preview/CMakeLists.txt
@@ -13,6 +13,8 @@ set(SRCS
     imageview.cpp
     ${CMAKE_SOURCE_DIR}/src/global/widgets/highlightlabel.h
     ${CMAKE_SOURCE_DIR}/src/global/widgets/highlightlabel.cpp
+    ${CMAKE_SOURCE_DIR}/src/global/widgets/highlightutils.h
+    ${CMAKE_SOURCE_DIR}/src/global/widgets/highlightutils.cpp
 )
 
 add_library(${LIB_NAME} SHARED ${SRCS} ${QRCS})


### PR DESCRIPTION
1. Remove GRANDSEARCH_TAILER_TIMEMODEFIED configuration option from
tailer settings
2. Make file modification time always display as first tailer item
instead of configurable
3. Extract highlight utilities from HighlightLabel into separate
HighlightUtils namespace
4. Refactor GrandSearchListDelegate to support two-line layout with
filename and context
5. Add keyword highlighting support for matched context in search
results
6. Make list view item sizes dynamic based on content
(setUniformItemSizes(false))
7. Fix checkbox widget border radius logic to use cleaner boolean
expressions
8. Update CMakeLists.txt to include new highlightutils files in both
grand-search and image-preview

The modification time is now always shown as it provides essential file
information, while parent directory remains optional. The HighlightUtils
extraction enables code reuse across multiple components. The two-line
layout improves readability by showing matched context below filenames.

Log: Changed search result list to display modification time fixedly and
added matched context preview with keyword highlighting

Influence:
1. Test search results display with files having different modification
times
2. Verify parent directory toggle still works in search configuration
3. Test keyword highlighting in both filename and matched context
4. Verify two-line layout renders correctly with varying content lengths
5. Test list view scrolling and selection with dynamic item sizes
6. Verify checkbox widget border radius renders correctly for first/
last items
7. Test image preview plugin still compiles and functions with
HighlightUtils
8. Verify tailer configuration migration handles removed TimeModified
option gracefully

feat: 重构搜索结果展示，固定显示修改时间

1. 从拖尾设置中移除 GRANDSEARCH_TAILER_TIMEMODEFIED 配置选项
2. 将文件修改时间设为始终显示的首个拖尾项，而非可配置项
3. 将高亮工具函数从 HighlightLabel 提取到独立的 HighlightUtils 命名空间
4. 重构 GrandSearchListDelegate 以支持文件名和上下文的双行布局
5. 为搜索结果中的匹配摘要添加关键词高亮支持
6. 使列表视图项大小根据内容动态调整（setUniformItemSizes(false)）
7. 优化复选框控件圆角逻辑，使用更清晰的布尔表达式
8. 更新 CMakeLists.txt 以在 grand-search 和 image-preview 中包含新的
highlightutils 文件

修改时间现在始终显示，因为它提供了重要的文件信息，而上级目录保持可选。
HighlightUtils 的提取实现了跨组件的代码复用。双行布局通过在文件名下方显
示匹配摘要提升了可读性。

Log: 搜索结果列表改为固定显示修改时间，并添加带关键词高亮的匹配摘要预览

Influence:
1. 测试不同修改时间的文件在搜索结果中的显示效果
2. 验证搜索配置中的上级目录开关仍然正常工作
3. 测试文件名和匹配摘要中的关键词高亮功能
4. 验证双行布局在不同内容长度下的渲染效果
5. 测试动态项大小下的列表视图滚动和选择功能
6. 验证首尾项复选框控件的圆角渲染是否正确
7. 测试图像预览插件使用 HighlightUtils 后仍能正常编译和运行
8. 验证拖尾配置迁移能否正确处理已移除的 TimeModified 选项

Task: https://pms.uniontech.com/task-view-390089.html
