### PR TITLE
chore: bump version to 6.0.36

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dde-grand-search (6.0.36) unstable; urgency=medium
+
+  * feat: optimize search UI icons and layout spacing
+  * feat: refactor search result display with fixed modification time
+  * chore: update translations
+  * refactor: migrate icons to theme-based system with DTK
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 28 May 2026 19:48:46 +0800
+
 dde-grand-search (6.0.35) unstable; urgency=medium
 
   * refactor: simplify search edit and fix UI issues


### PR DESCRIPTION
6.0.36

Log:

## Summary by Sourcery

Chores:
- Update Debian packaging metadata to reflect version 6.0.36.