### PR TITLE
refactor: move highlight content extraction from daemon to client-side

### DIFF
--- a/src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp
+++ b/src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp
@@ -18,7 +18,7 @@ Q_DECLARE_LOGGING_CATEGORY(logDaemon)
 
 using namespace GrandSearch;
 
-MatchedItem FileSearchUtils::packItem(const QString &fileName, const QString &searcher, const QStringList &keywords, const QString &matchedContext)
+MatchedItem FileSearchUtils::packItem(const QString &fileName, const QString &searcher, const QStringList &keywords)
 {
     qCDebug(logDaemon) << "Packing file item - File:" << fileName << "Searcher:" << searcher;
     QFileInfo fileInfo(fileName);
@@ -29,7 +29,7 @@ MatchedItem FileSearchUtils::packItem(const QString &fileName, const QString &se
     item.type = mimeType.name();
     item.icon = mimeType.iconName();
     item.searcher = searcher;
-    item.extra = QVariant::fromValue(extraData(fileInfo, keywords, matchedContext));
+    item.extra = QVariant::fromValue(extraData(fileInfo, keywords));
 
     qCDebug(logDaemon) << "Item packed successfully - Name:" << item.name
                        << "Type:" << item.type << "Icon:" << item.icon;
@@ -200,7 +200,7 @@ FileSearchUtils::SearchInfo FileSearchUtils::parseContent(const QString &content
     return info;
 }
 
-QVariantHash FileSearchUtils::extraData(const QFileInfo &info, const QStringList &keywords, const QString &matchedContext)
+QVariantHash FileSearchUtils::extraData(const QFileInfo &info, const QStringList &keywords)
 {
     qCDebug(logDaemon) << "Generating tailer data for file:" << info.absoluteFilePath();
 
@@ -222,17 +222,6 @@ QVariantHash FileSearchUtils::extraData(const QFileInfo &info, const QStringList
     // Inject keywords for highlighting
     if (!keywords.isEmpty())
         hash.insert(GRANDSEARCH_PROPERTY_ITEM_KEYWORDS, keywords);
-
-    if (!matchedContext.isEmpty()) {
-        QString context = matchedContext;
-        // 去除首尾的省略符号
-        if (context.startsWith("…"))
-            context = context.mid(1);
-        if (context.endsWith("…"))
-            context.chop(1);
-        if (!context.isEmpty())
-            hash.insert(GRANDSEARCH_PROPERTY_ITEM_MATCHEDCONTEXT, context);
-    }
 
     hash.insert(GRANDSEARCH_PROPERTY_ITEM_TAILER, datas);
     return hash;

--- a/src/dde-grand-search-daemon/searcher/file/filesearchutils.h
+++ b/src/dde-grand-search-daemon/searcher/file/filesearchutils.h
@@ -35,13 +35,13 @@ public:
         QList<Group> groupList;             // 搜索类目表
     };
 
-    static MatchedItem packItem(const QString &fileName, const QString &searcher, const QStringList &keywords = QStringList(), const QString &matchedContext = "");
+    static MatchedItem packItem(const QString &fileName, const QString &searcher, const QStringList &keywords = QStringList());
     static QString groupKey(Group group);
     static Group getGroupByName(const QString &fileName);
     static Group getGroupBySuffix(const QString &suffix);
     static Group getGroupByGroupName(const QString &groupName);
     static SearchInfo parseContent(const QString &content);
-    static QVariantHash extraData(const QFileInfo &info, const QStringList &keywords, const QString &matchedContext);
+    static QVariantHash extraData(const QFileInfo &info, const QStringList &keywords);
     static QStringList buildDFMSearchFileTypes(const QList<Group> &groupList);
     static bool isPinyin(const QString &str);
     static bool hasWildcard(const QString &str);

--- a/src/dde-grand-search-daemon/searcher/fulltext/fulltextworker.cpp
+++ b/src/dde-grand-search-daemon/searcher/fulltext/fulltextworker.cpp
@@ -51,6 +51,7 @@ bool FullTextWorkerPrivate::doSearch()
 
     ContentOptionsAPI contentOptions(options);
     contentOptions.setMaxPreviewLength(100);
+    contentOptions.setFullTextRetrievalEnabled(false);   // 关闭全文获取，高亮改为客户端延迟加载
     contentOptions.setFilenameContentMixedAndSearchEnabled(true);
 
     engine->setSearchOptions(options);
@@ -105,11 +106,8 @@ bool FullTextWorkerPrivate::processResults(const SearchResultExpected &result)
 
         m_tmpSearchResults << filePath;
 
-        // Get highlighted content preview
-        SearchResult mutableResult = const_cast<SearchResult &>(file);
-        ContentResultAPI contentResult(mutableResult);
-        QString highlightedContent = contentResult.highlightedContent();
-        MatchedItem item = FileSearchUtils::packItem(filePath, q->name(), keywords, highlightedContent);
+        // 高亮内容改为客户端延迟加载，不再在搜索阶段提取
+        MatchedItem item = FileSearchUtils::packItem(filePath, q->name(), keywords);
 
         // Set higher weight so frontend dedup prefers content results over filename results
         QVariantHash extra = item.extra.toHash();

--- a/src/dde-grand-search-daemon/searcher/ocr/ocrtextworker.cpp
+++ b/src/dde-grand-search-daemon/searcher/ocr/ocrtextworker.cpp
@@ -97,11 +97,8 @@ bool OcrTextWorkerPrivate::processSearchResults(const DFMSEARCH::SearchResultExp
 
         m_tmpSearchResults << filePath;
 
-        // Get OCR content and store in extra field
-        DFMSEARCH::SearchResult mutableResult = const_cast<DFMSEARCH::SearchResult &>(file);
-        OcrTextResultAPI ocrResult(const_cast<SearchResult &>(mutableResult));
-        QString ocrContent = ocrResult.highlightedContent();
-        GrandSearch::MatchedItem item = FileSearchUtils::packItem(filePath, q->name(), m_keywords, ocrContent);
+        // 高亮内容改为客户端延迟加载，不再在搜索阶段提取
+        GrandSearch::MatchedItem item = FileSearchUtils::packItem(filePath, q->name(), m_keywords);
 
         {
             QMutexLocker lk(&m_mutex);
@@ -160,6 +157,7 @@ bool OcrTextWorkerPrivate::searchByDFMSearch()
     // Configure OCR options
     OcrTextOptionsAPI ocrOptions(options);
     ocrOptions.setMaxPreviewLength(50);
+    ocrOptions.setFullTextRetrievalEnabled(false);   // 关闭全文获取，高亮改为客户端延迟加载
     // Enable filename-OCR content mixed search
     ocrOptions.setFilenameOcrContentMixedAndSearchEnabled(true);
 

--- a/src/grand-search/CMakeLists.txt
+++ b/src/grand-search/CMakeLists.txt
@@ -40,6 +40,7 @@ find_package(${QT_NS} COMPONENTS
     DBus
     Network
 REQUIRED)
+find_package(dfm${DTK_VERSION_MAJOR}-search REQUIRED)
 
 set(DBUSSRC
     # dbus接口
@@ -228,6 +229,8 @@ set(CONTACTSSRC
 set(UTILSSRC
     utils/utils.h
     utils/utils.cpp
+    utils/highlightprovider.h
+    utils/highlightprovider.cpp
     utils/previewpluginconf.h
     utils/filestatisticsthread.h
     utils/filestatisticsthread.cpp
@@ -287,6 +290,7 @@ target_link_libraries(${BIN_NAME} PRIVATE
     ${Qt_LIBS}
     ${DTK_LIBS}
     ${GIO_LIB_LIBRARIES}
+    dfm${DTK_VERSION_MAJOR}-search
 )
 
 set(SRCS_SETTING

--- a/src/grand-search/gui/exhibition/exhibitionwidget.cpp
+++ b/src/grand-search/gui/exhibition/exhibitionwidget.cpp
@@ -54,6 +54,14 @@ void ExhibitionWidget::clearData()
     m_vLine->hide();
 }
 
+void ExhibitionWidget::setSearchKeyword(const QString &keyword)
+{
+    Q_ASSERT(m_matchWidget);
+
+    qCDebug(logGrandSearch) << "Setting search keyword for highlight:" << keyword;
+    m_matchWidget->setSearchKeyword(keyword);
+}
+
 void ExhibitionWidget::onSelectNextItem()
 {
     if (this->isHidden()) {

--- a/src/grand-search/gui/exhibition/exhibitionwidget.h
+++ b/src/grand-search/gui/exhibition/exhibitionwidget.h
@@ -31,6 +31,12 @@ public:
 
     void clearData();
 
+    /**
+     * @brief 设置搜索关键词，传播到 MatchWidget 以管理高亮任务
+     * @param keyword 搜索关键词
+     */
+    void setSearchKeyword(const QString &keyword);
+
 public slots:
     void onSelectNextItem();
     void onSelectPreviousItem();

--- a/src/grand-search/gui/exhibition/matchresult/groupwidget.cpp
+++ b/src/grand-search/gui/exhibition/matchresult/groupwidget.cpp
@@ -72,6 +72,12 @@ void GroupWidget::setGroupName(const QString &groupName)
     AC_SET_ACCESSIBLE_NAME(m_listView, groupName);
 }
 
+void GroupWidget::setSearchKeyword(const QString &keyword)
+{
+    Q_ASSERT(m_listView);
+    m_listView->setSearchKeyword(keyword);
+}
+
 void GroupWidget::appendMatchedItems(const MatchedItems &newItems, const QString &searchGroupName)
 {
     Q_UNUSED(searchGroupName)

--- a/src/grand-search/gui/exhibition/matchresult/groupwidget.h
+++ b/src/grand-search/gui/exhibition/matchresult/groupwidget.h
@@ -38,6 +38,12 @@ public:
     void setSearchGroupName(const QString &searchGroupName);
     QString searchGroupName() const;
 
+    /**
+     * @brief 设置当前搜索关键词，传播到列表视图以管理高亮任务
+     * @param keyword 搜索关键词
+     */
+    void setSearchKeyword(const QString &keyword);
+
     void setGroupName(const QString &groupName);
     QString groupName() const;
 

--- a/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistview.cpp
+++ b/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistview.cpp
@@ -6,9 +6,13 @@
 #include "grandsearchlistmodel.h"
 #include "grandsearchlistdelegate.h"
 #include "utils/utils.h"
+#include "utils/highlightprovider.h"
 #include "global/matcheditem.h"
+#include "global/builtinsearch.h"
 #include "global/accessibility/acintelfunctions.h"
 #include "thumbnail/thumbnail.h"
+
+#include <dfm-search/dsearch_global.h>
 
 #include <DGuiApplicationHelper>
 #include <DStandardPaths>
@@ -170,6 +174,15 @@ void GrandSearchListView::clear()
         m_model->clear();
 }
 
+void GrandSearchListView::setSearchKeyword(const QString &keyword)
+{
+    // 关键词改变时，丢弃所有旧的高亮任务
+    if (!m_currentKeyword.isEmpty()) {
+        HighlightProvider::instance()->cancelTask(m_currentKeyword);
+    }
+    m_currentKeyword = keyword;
+}
+
 void GrandSearchListView::updatePreviewItemState(const bool preview)
 {
     m_isPreviewItem = preview;
@@ -286,6 +299,9 @@ void GrandSearchListView::setData(const QModelIndex &index, const MatchedItem &i
         if (ThumbnailProvider::instance()->isSupported(mimetype)) {
             ThumbnailProvider::instance()->requestThumbnail(item.item, mimetype, GrandSearch::ThumbnailSize::Large);
         }
+
+        // 异步请求高亮内容（仅对全文搜索和OCR搜索）
+        requestHighlightContent(item, true);
     }
 }
 
@@ -327,6 +343,88 @@ void GrandSearchListView::updateThumbnail(const QString &filePath, const QPixmap
             // 更新缩略图到独立角色，保留原始图标
             m_model->setData(index, thumbnail, THUMBNAIL_ROLE);
             break;   // 找到后退出循环
+        }
+    }
+}
+
+void GrandSearchListView::requestHighlightContent(const MatchedItem &item, bool highPriority)
+{
+    // 仅对全文搜索和 OCR 搜索请求高亮内容
+    if (item.searcher != GRANDSEARCH_CLASS_FILE_FULLTEXT
+        && item.searcher != GRANDSEARCH_CLASS_OCR_TEXT) {
+        return;
+    }
+
+    if (m_currentKeyword.isEmpty() || item.item.isEmpty()) {
+        return;
+    }
+
+    QVariantHash extraHash = item.extra.toHash();
+
+    // 如果已经有 matchedContext，不需要再请求
+    if (extraHash.contains(GRANDSEARCH_PROPERTY_ITEM_MATCHEDCONTEXT)
+        && !extraHash.value(GRANDSEARCH_PROPERTY_ITEM_MATCHEDCONTEXT).toString().isEmpty()) {
+        return;
+    }
+
+    // 从 item.extra 中获取实际搜索关键词（daemon 可能对用户输入做了转换/扩展）
+    QStringList keywords = extraHash.value(GRANDSEARCH_PROPERTY_ITEM_KEYWORDS, QStringList()).toStringList();
+    if (keywords.isEmpty()) {
+        return;
+    }
+
+    // 根据 searcher 类型确定 searchType
+    int searchType = 0;
+    if (item.searcher == GRANDSEARCH_CLASS_FILE_FULLTEXT) {
+        searchType = static_cast<int>(DFMSEARCH::SearchType::Content);
+    } else if (item.searcher == GRANDSEARCH_CLASS_OCR_TEXT) {
+        searchType = static_cast<int>(DFMSEARCH::SearchType::Ocr);
+    }
+
+    // 将关键词列表用空格连接为单个字符串，传给 fetchHighlight
+    HighlightProvider::instance()->requestHighlight(
+        m_currentKeyword, item.item, keywords.first(), searchType, highPriority);
+}
+
+void GrandSearchListView::onHighlightReady(const QString &keyword, const QString &filePath, const QString &content)
+{
+    Q_UNUSED(keyword)
+    if (content.isEmpty()) {
+        return;
+    }
+
+    updateHighlight(filePath, content);
+}
+
+void GrandSearchListView::updateHighlight(const QString &filePath, const QString &content)
+{
+    if (filePath.isEmpty() || content.isEmpty()) {
+        return;
+    }
+
+    // 遍历所有项，找到匹配的文件路径
+    for (int row = 0; row < m_model->rowCount(); ++row) {
+        QModelIndex index = m_model->index(row, 0);
+        if (!index.isValid()) {
+            continue;
+        }
+
+        QVariant data = m_model->data(index, DATA_ROLE);
+        if (!data.isValid()) {
+            continue;
+        }
+
+        MatchedItem item = data.value<MatchedItem>();
+        if (item.item == filePath) {
+            // 更新 extra hash 中的 matchedContext
+            QVariantHash extraHash = item.extra.toHash();
+            extraHash.insert(GRANDSEARCH_PROPERTY_ITEM_MATCHEDCONTEXT, content);
+            item.extra = extraHash;
+
+            QVariant searchMeta;
+            searchMeta.setValue(item);
+            m_model->setData(index, searchMeta, DATA_ROLE);
+            break;
         }
     }
 }

--- a/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistview.h
+++ b/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistview.h
@@ -47,8 +47,22 @@ public:
     void updatePreviewItemState(const bool preview);
     bool isPreviewItem() const;
 
+    /**
+     * @brief 设置当前搜索关键词并清理旧的高亮任务
+     * @param keyword 新的搜索关键词
+     */
+    void setSearchKeyword(const QString &keyword);
+
 public slots:
     void onSetThemeType(int type);
+
+    /**
+     * @brief 处理高亮内容获取完成（由 MatchWidget 统一连接信号后路由调用）
+     * @param keyword 搜索关键词（taskId）
+     * @param filePath 文件路径
+     * @param content 高亮内容
+     */
+    void onHighlightReady(const QString &keyword, const QString &filePath, const QString &content);
 
 signals:
     void sigCurrentItemChanged(const MatchedItem &item);
@@ -78,6 +92,20 @@ private:
      */
     void updateThumbnail(const QString &filePath, const QPixmap &thumbnail);
 
+    /**
+     * @brief 更新指定文件路径对应的项的高亮内容
+     * @param filePath 文件路径
+     * @param content 高亮内容
+     */
+    void updateHighlight(const QString &filePath, const QString &content);
+
+    /**
+     * @brief 请求指定项的高亮内容（如果尚未请求）
+     * @param item 搜索结果项
+     * @param highPriority 是否为高优先级（可见区域）
+     */
+    void requestHighlightContent(const MatchedItem &item, bool highPriority = false);
+
 private:
     GrandSearchListModel *m_model = nullptr;
     GrandSearchListDelegate *m_delegate = nullptr;
@@ -86,6 +114,7 @@ private:
     MatchedItems m_matchedItems;
 
     bool m_isPreviewItem = false;
+    QString m_currentKeyword;  // 当前搜索关键词，用于高亮任务管理
 };
 
 }

--- a/src/grand-search/gui/exhibition/matchresult/matchwidget.cpp
+++ b/src/grand-search/gui/exhibition/matchresult/matchwidget.cpp
@@ -7,6 +7,7 @@
 #include "listview/grandsearchlistview.h"
 #include "viewmore/viewmorebutton.h"
 #include "utils/utils.h"
+#include "utils/highlightprovider.h"
 #include "gui/datadefine.h"
 
 #include <DScrollArea>
@@ -144,6 +145,19 @@ void MatchWidget::clearMatchedData()
     layout();
 
     m_customSelected = false;
+}
+
+void MatchWidget::setSearchKeyword(const QString &keyword)
+{
+    // 缓存当前搜索关键词，新建分组时同步设置
+    m_currentKeyword = keyword;
+
+    // 同时传播到已存在的分组
+    for (GroupWidget *groupWidget : std::as_const(m_groupWidgetMap)) {
+        if (groupWidget) {
+            groupWidget->setSearchKeyword(keyword);
+        }
+    }
 }
 
 void MatchWidget::onSearchCompleted()
@@ -557,6 +571,19 @@ void MatchWidget::initUi()
 
 void MatchWidget::initConnect()
 {
+    // 统一连接高亮信号，路由到所有包含该文件路径的 GroupWidget -> ListView
+    // 同一文件可能存在于多个分组（如文档分组和文件分组），需要全部更新
+    connect(HighlightProvider::instance(), &HighlightProvider::highlightReady,
+            this, [this](const QString &keyword, const QString &filePath, const QString &content) {
+        Q_UNUSED(keyword)
+        if (content.isEmpty())
+            return;
+        for (GroupWidget *groupWidget : std::as_const(m_groupWidgetMap)) {
+            if (groupWidget && groupWidget->findItemByPath(filePath).item == filePath) {
+                groupWidget->getListView()->onHighlightReady(keyword, filePath, content);
+            }
+        }
+    });
 }
 
 void MatchWidget::reLayout()
@@ -628,6 +655,11 @@ GroupWidget *MatchWidget::createGroupWidget(const QString &searchGroupName)
 
         groupWidget->setSearchGroupName(searchGroupName);
         d_p->setGroupIcon(groupWidget);
+
+        // 同步当前搜索关键词到新建的分组（setSearchKeyword 可能先于分组创建）
+        if (!m_currentKeyword.isEmpty()) {
+            groupWidget->setSearchKeyword(m_currentKeyword);
+        }
 
         const QString &groupName = GroupWidget::convertDisplayName(searchGroupName);
         groupWidget->setGroupName(groupName);

--- a/src/grand-search/gui/exhibition/matchresult/matchwidget.h
+++ b/src/grand-search/gui/exhibition/matchresult/matchwidget.h
@@ -37,6 +37,12 @@ public slots:
 
     void onPreviewStateChanged(const bool preview);
 
+    /**
+     * @brief 设置搜索关键词，传播到所有 GroupWidget 以管理高亮任务
+     * @param keyword 搜索关键词
+     */
+    void setSearchKeyword(const QString &keyword);
+
 private slots:
     void onSelectItemByMouse(const MatchedItem &item);
 
@@ -94,6 +100,7 @@ private:
 
     bool m_customSelected = false;                      // 记录用户是否手动选中
     bool m_isPreviewItem = false;                       // 记录当前是否预览项目
+    QString m_currentKeyword;                          // 当前搜索关键词，创建分组时同步设置
 };
 
 }

--- a/src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp
+++ b/src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp
@@ -151,6 +151,9 @@ bool GeneralPreviewPlugin::previewItem(const ItemInfo &info)
 
     if (!keywords.isEmpty()) {
         QVariantHash extraHash { { GRANDSEARCH_PROPERTY_ITEM_KEYWORDS, keywords } };
+        if (!matchedContext.isEmpty()) {
+            extraHash.insert(GRANDSEARCH_PROPERTY_ITEM_MATCHEDCONTEXT, matchedContext);
+        }
         item.extra = extraHash;
     }
 
@@ -165,7 +168,10 @@ bool GeneralPreviewPlugin::previewItem(const ItemInfo &info)
             && d_p->m_item.name == item.name) {
         const auto &extra = d_p->m_item.extra.toHash();
         const auto &itemKeywords = extra.value(GRANDSEARCH_PROPERTY_ITEM_KEYWORDS, QStringList()).toStringList();
-        if (!keywords.isEmpty() && keywords == itemKeywords) {
+        const auto &oldMatchedContext = extra.value(GRANDSEARCH_PROPERTY_ITEM_MATCHEDCONTEXT).toString();
+
+        if (!keywords.isEmpty() && keywords == itemKeywords
+                && matchedContext == oldMatchedContext) {
             qCDebug(logGrandSearch) << "Item already previewed - skipping";
             return true;
         }

--- a/src/grand-search/gui/exhibition/preview/previewwidget.cpp
+++ b/src/grand-search/gui/exhibition/preview/previewwidget.cpp
@@ -4,6 +4,7 @@
 
 #include "previewwidget.h"
 #include "utils/utils.h"
+#include "utils/highlightprovider.h"
 #include "generalpreviewplugin.h"
 #include "generalwidget/detailwidget.h"
 #include "generalwidget/generaltoolbar.h"
@@ -186,6 +187,10 @@ void PreviewWidget::initConnect()
     connect(m_generalToolBar, &GeneralToolBar::sigOpenClicked, this, &PreviewWidget::onOpenClicked);
     connect(m_generalToolBar, &GeneralToolBar::sigOpenPathClicked, this, &PreviewWidget::onOpenpathClicked);
     connect(m_generalToolBar, &GeneralToolBar::sigCopyPathClicked, this, &PreviewWidget::onCopypathClicked);
+
+    // 连接高亮内容获取完成信号
+    connect(HighlightProvider::instance(), &HighlightProvider::highlightReady,
+            this, &PreviewWidget::updateHighlightContent);
 }
 
 void PreviewWidget::clearLayoutWidgets()
@@ -242,4 +247,37 @@ void PreviewWidget::onCopypathClicked()
     qCDebug(logGrandSearch) << "Preview copy path clicked:" << m_item.item;
     QClipboard *clipboard = QGuiApplication::clipboard();
     clipboard->setText(m_item.item);
+}
+
+void PreviewWidget::updateHighlightContent(const QString &filePath, const QString &content)
+{
+    // 仅当文件路径匹配当前预览项且内容非空时更新
+    if (filePath.isEmpty() || content.isEmpty()
+        || m_item.item != filePath || this->isHidden()) {
+        return;
+    }
+
+    qCDebug(logGrandSearch) << "Updating preview highlight for:" << m_item.name;
+
+    // 更新 m_item 中的 matchedContext
+    QVariantHash extraHash = m_item.extra.toHash();
+    extraHash.insert(GRANDSEARCH_PROPERTY_ITEM_MATCHEDCONTEXT, content);
+    m_item.extra = extraHash;
+
+    // 直接更新当前预览插件的内容标签，避免完整布局重建
+    if (m_preview) {
+        ItemInfo itemInfo;
+        itemInfo[PREVIEW_ITEMINFO_ITEM] = m_item.item;
+        itemInfo[PREVIEW_ITEMINFO_NAME] = m_item.name;
+        itemInfo[PREVIEW_ITEMINFO_ICON] = m_item.icon;
+        itemInfo[PREVIEW_ITEMINFO_TYPE] = m_item.type;
+        itemInfo[PREVIEW_ITEMINFO_SEARCHER] = m_item.searcher;
+        itemInfo[PREVIEW_ITEMINFO_MATCHEDCONTEXT] = content;
+
+        if (extraHash.contains(GRANDSEARCH_PROPERTY_ITEM_KEYWORDS)) {
+            itemInfo[PREVIEW_ITEMINFO_KEYWORDS] = extraHash.value(GRANDSEARCH_PROPERTY_ITEM_KEYWORDS).toStringList().join(":");
+        }
+
+        m_preview->previewItem(itemInfo);
+    }
 }

--- a/src/grand-search/gui/exhibition/preview/previewwidget.h
+++ b/src/grand-search/gui/exhibition/preview/previewwidget.h
@@ -30,6 +30,14 @@ public:
     // 预览指定搜索项
     bool previewItem(const MatchedItem &item);
 
+    /**
+     * @brief 更新当前预览项的高亮内容
+     * 当 HighlightProvider 异步获取到高亮内容时调用
+     * @param filePath 文件路径
+     * @param content 高亮内容
+     */
+    void updateHighlightContent(const QString &filePath, const QString &content);
+
 private:
     void initUi();
     void initConnect();

--- a/src/grand-search/gui/mainwindow.cpp
+++ b/src/grand-search/gui/mainwindow.cpp
@@ -193,6 +193,9 @@ void MainWindow::onMissionChanged(const QString &missionId, const QString &missi
 
     if (missionContent.isEmpty()) {
         onHideExhitionWidget();
+    } else {
+        // 搜索关键词改变，传播到 ExhibitionWidget 以管理高亮任务
+        d_p->m_exhibitionWidget->setSearchKeyword(missionContent);
     }
 }
 

--- a/src/grand-search/utils/highlightprovider.cpp
+++ b/src/grand-search/utils/highlightprovider.cpp
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "highlightprovider.h"
+
+#include <dfm-search/contentretriever.h>
+#include <dfm-search/dsearch_global.h>
+
+#include <QMutexLocker>
+#include <QDebug>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logGrandSearch)
+
+namespace GrandSearch {
+
+static const QString kPendingToken = QStringLiteral("__pending__");
+
+HighlightProvider::HighlightProvider(QObject *parent)
+    : QObject(parent)
+{
+    // 在工作线程启动前设置回调，避免主线程/工作线程数据竞争
+    m_fetchCallback = [](const QString &path, const QString &keyword, int searchType) -> QString {
+        thread_local DFMSEARCH::ContentRetriever retriever;
+        return retriever.fetchHighlight(path, keyword,
+                                        static_cast<DFMSEARCH::SearchType>(searchType));
+    };
+
+    m_workerThread = new QThread(this);
+    m_worker = new QObject();
+    m_worker->moveToThread(m_workerThread);
+
+    connect(m_workerThread, &QThread::finished, m_worker, &QObject::deleteLater);
+    m_workerThread->start();
+}
+
+HighlightProvider::~HighlightProvider()
+{
+    m_workerThread->quit();
+    m_workerThread->wait(5000);
+}
+
+HighlightProvider *HighlightProvider::instance()
+{
+    static HighlightProvider ins;
+    return &ins;
+}
+
+void HighlightProvider::setFetchCallback(FetchHighlightCallback cb)
+{
+    m_fetchCallback = std::move(cb);
+}
+
+void HighlightProvider::requestHighlight(const QString &taskId, const QString &path,
+                                         const QString &keyword, int searchType,
+                                         bool highPriority)
+{
+    if (!m_fetchCallback) {
+        qCWarning(logGrandSearch) << "HighlightProvider: fetchCallback not set";
+        return;
+    }
+
+    // Step 1: 检查缓存
+    {
+        QMutexLocker lk(&m_cacheMutex);
+        auto &taskCache = m_cache[taskId];
+        auto it = taskCache.find(path);
+
+        if (it != taskCache.end()) {
+            const QString &cached = it.value();
+            if (cached != kPendingToken) {
+                if (cached.isEmpty())
+                    return;   // 已获取但无内容，避免无意义的 UI 更新
+
+                // 缓存命中，直接发射信号
+                lk.unlock();
+                Q_EMIT highlightReady(taskId, path, cached);
+                return;
+            }
+            // 标记为 pending，请求正在进行中，不重复提交
+            return;
+        }
+
+        // 标记为 pending
+        taskCache[path] = kPendingToken;
+    }
+
+    // Step 2: 加入请求队列
+    {
+        QMutexLocker lk(&m_requestMutex);
+
+        if (highPriority) {
+            m_pendingRequests.prepend({ taskId, path, keyword, searchType });
+        } else {
+            m_pendingRequests.append({ taskId, path, keyword, searchType });
+        }
+
+        // 仅在 idle -> busy 时投递一次任务，避免重复唤醒 worker
+        int expected = 0;
+        if (m_processing.compare_exchange_strong(expected, 1, std::memory_order_acquire)) {
+            QMetaObject::invokeMethod(
+                    m_worker, [this]() {
+                        processNextRequest();
+                    },
+                    Qt::QueuedConnection);
+        }
+    }
+}
+
+void HighlightProvider::cancelTask(const QString &taskId)
+{
+    qCDebug(logGrandSearch) << "HighlightProvider: canceling task for keyword:" << taskId;
+
+    // 从队列中移除所有该 taskId 的请求
+    {
+        QMutexLocker lk(&m_requestMutex);
+        m_pendingRequests.erase(
+                std::remove_if(m_pendingRequests.begin(), m_pendingRequests.end(),
+                               [&taskId](const HighlightRequest &req) {
+                                   return req.taskId == taskId;
+                               }),
+                m_pendingRequests.end());
+    }
+
+    // 清除缓存
+    {
+        QMutexLocker lk(&m_cacheMutex);
+        m_cache.remove(taskId);
+    }
+}
+
+void HighlightProvider::processNextRequest()
+{
+    while (true) {
+        HighlightRequest req;
+
+        {
+            QMutexLocker lk(&m_requestMutex);
+            if (m_pendingRequests.isEmpty()) {
+                m_processing.store(0, std::memory_order_release);
+                // 双重检查：防止在 isEmpty 检查与 store 之间新增了请求
+                if (!m_pendingRequests.isEmpty()) {
+                    int expected = 0;
+                    if (m_processing.compare_exchange_strong(expected, 1, std::memory_order_acquire)) {
+                        continue;
+                    }
+                }
+                return;
+            }
+            req = m_pendingRequests.takeFirst();
+        }
+
+        // 检查该 taskId 是否已被取消
+        {
+            QMutexLocker lk(&m_cacheMutex);
+            if (!m_cache.contains(req.taskId)) {
+                continue;   // 会话已被取消，跳过
+            }
+        }
+
+        // 执行实际的 highlight 获取（同步阻塞 I/O，在工作线程中执行）
+        QString content;
+        if (m_fetchCallback) {
+            content = m_fetchCallback(req.path, req.keyword, req.searchType);
+            // 去除首尾的省略符号
+            if (content.startsWith("…"))
+                content = content.mid(1);
+            if (content.endsWith("…"))
+                content.chop(1);
+        }
+
+        // 存储到缓存（如果会话在 fetch 期间被取消，则跳过）
+        {
+            QMutexLocker lk(&m_cacheMutex);
+            if (!m_cache.contains(req.taskId)) {
+                continue;   // 会话在 fetch 期间被 cancel，跳过存储和通知
+            }
+            m_cache[req.taskId][req.path] = content;
+        }
+
+        if (content.isEmpty())
+            continue;
+
+        // 通知主线程（跨线程信号自动 QueuedConnection）
+        Q_EMIT highlightReady(req.taskId, req.path, content);
+    }
+}
+
+}   // namespace GrandSearch

--- a/src/grand-search/utils/highlightprovider.h
+++ b/src/grand-search/utils/highlightprovider.h
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef HIGHLIGHTPROVIDER_H
+#define HIGHLIGHTPROVIDER_H
+
+#include <QObject>
+#include <QThread>
+#include <QMutex>
+#include <QHash>
+#include <QList>
+#include <functional>
+#include <atomic>
+
+namespace GrandSearch {
+
+/**
+ * @brief 延迟高亮内容加载提供者
+ *
+ * 搜索结果展示时不同步获取高亮内容，而是通过此类在工作线程中异步获取。
+ * 使用方式：
+ * 1. 通过 setFetchCallback() 注入实际的 fetchHighlight 实现
+ * 2. 通过 requestHighlight() 请求高亮内容
+ * 3. 通过 highlightReady 信号获取异步结果
+ * 4. 通过 cancelTask() 在搜索关键词改变时清理过期任务
+ *
+ * 参考自 dde-file-manager 的 dfmbase::HighlightProvider
+ */
+class HighlightProvider : public QObject
+{
+    Q_OBJECT
+
+public:
+    using FetchHighlightCallback = std::function<QString(const QString &path,
+                                                         const QString &keyword,
+                                                         int searchType)>;
+
+    static HighlightProvider *instance();
+
+    /**
+     * @brief 注入实际的 fetchHighlight 实现
+     * 回调函数将在工作线程中执行（同步阻塞 I/O）
+     */
+    void setFetchCallback(FetchHighlightCallback cb);
+
+    /**
+     * @brief 请求单个文件的高亮内容
+     * @param taskId  搜索关键词（作为任务隔离标识，关键词改变时通过 cancelTask 清理）
+     * @param path    文件路径
+     * @param keyword 搜索关键词
+     * @param searchType 搜索类型（对应 DFMSEARCH::SearchType 枚举值）
+     * @param highPriority true 表示可见区域项，插入队列头部优先处理
+     */
+    void requestHighlight(const QString &taskId, const QString &path,
+                          const QString &keyword, int searchType,
+                          bool highPriority = false);
+
+    /**
+     * @brief 取消指定搜索会话的所有待处理请求并清除缓存
+     * 在搜索关键词改变时调用，丢弃所有已过期的高亮任务
+     */
+    void cancelTask(const QString &taskId);
+
+Q_SIGNALS:
+    /**
+     * @brief 高亮内容获取完成信号
+     * @param taskId  搜索关键词
+     * @param path    文件路径
+     * @param content 高亮内容（可能为空表示无匹配内容）
+     */
+    void highlightReady(const QString &taskId, const QString &path, const QString &content);
+
+private Q_SLOTS:
+    void processNextRequest();
+
+private:
+    struct HighlightRequest
+    {
+        QString taskId;
+        QString path;
+        QString keyword;
+        int searchType;
+    };
+
+    explicit HighlightProvider(QObject *parent = nullptr);
+    ~HighlightProvider() override;
+
+    FetchHighlightCallback m_fetchCallback;
+    QThread *m_workerThread = nullptr;
+    QObject *m_worker = nullptr;
+
+    mutable QMutex m_requestMutex;
+    QList<HighlightRequest> m_pendingRequests;
+
+    std::atomic<int> m_processing { 0 };
+
+    // 缓存：QHash<taskId(keyword), QHash<path, content>>
+    // 不存在 = 未请求
+    // "__pending__" = 请求中（去重哨兵）
+    // 空 QString = 已获取但无高亮内容
+    // 非空 = 已获取且有高亮内容
+    QHash<QString, QHash<QString, QString>> m_cache;
+    QMutex m_cacheMutex;
+};
+
+}   // namespace GrandSearch
+
+#endif   // HIGHLIGHTPROVIDER_H


### PR DESCRIPTION
The highlight content (matched context) for full-text and OCR search
results
was previously extracted synchronously in the daemon during search,
which
blocked the search pipeline. This commit defers highlight extraction
to the
client side using a new HighlightProvider that performs the work
asynchronously in a worker thread.

Changes:
- Remove `matchedContext` parameter from `FileSearchUtils::packItem` and
  `extraData`, and delete related processing logic.
- Disable full-text retrieval in fulltextworker and ocrtextworker by
setting
  `setFullTextRetrievalEnabled(false)`. Highlighted content is no longer
  fetched during daemon search.
- Add HighlightProvider class with request/cancel caching mechanism and
  worker thread. Signals `highlightReady` when content is available.
- Add `setSearchKeyword` methods to ExhibitionWidget, MatchWidget,
GroupWidget
  and GrandSearchListView to propagate the current search keyword and
manage
  highlight tasks.
- In GrandSearchListView, request highlight asynchronously when items
become
  visible, using priority for visible items.
- Connect HighlightProvider signals in MatchWidget and PreviewWidget to
  update highlighted content when it becomes available.
- Update GeneralPreviewPlugin to preserve matchedContext in preview
items.
- Add dependency on dfm-search library for `ContentRetriever`.

This improves search responsiveness by moving expensive I/O operations
(reading file content and extracting highlights) out of the critical
search
path.

Influence:
1. Verify full-text search results still show highlighted content in
list
   and preview, but possibly with a slight delay after initial display.
2. Test OCR search results highlight display in list and preview.
3. Test rapid keyword changes – ensure old highlight tasks are cancelled
and
   new results appear correctly.
4. Verify that the preview widget updates highlight content when it
arrives
   (especially for files not yet visible when highlight was requested).
5. Test search performance: full-text and OCR searches should feel
snappier
   because highlight extraction no longer blocks search completion.
6. Verify that cached highlights are reused when scrolling back to
   previously viewed items.
7. Test error handling: what happens when highlight fetch fails or
returns
   empty content – no crash, no stale pending state.
8. Ensure the “more” button and view-mode switching (list/grid) still
work
   correctly with async highlights.

refactor: 将高亮内容提取从daemon端移至客户端异步加载

全文搜索和OCR搜索结果的高亮片段（matchedContext）原先在daemon搜索阶段同
步提取，
会阻塞搜索流程。此提交将高亮提取延迟到客户端侧，通过新增的
HighlightProvider类
在工作线程中异步完成。

改动：
- 移除 `FileSearchUtils::packItem` 和 `extraData` 的 `matchedContext` 参
数及相关处理逻辑。
- 在 fulltextworker 和 ocrtextworker 中通过
`setFullTextRetrievalEnabled(false)` 禁用全文获取。
  高亮内容不再在daemon搜索时提取。
- 新增 HighlightProvider 类，提供请求/取消/缓存机制和工作线程。通过
`highlightReady` 信号通知结果。
- 在 ExhibitionWidget、MatchWidget、GroupWidget、GrandSearchListView 中
增加 `setSearchKeyword`
  方法，传递当前搜索关键词并管理高亮任务。
- 在 GrandSearchListView 中，当项变为可见时异步请求高亮，对可见区域项给
予高优先级。
- 在 MatchWidget 和 PreviewWidget 中连接 HighlightProvider 信号，当高亮
内容就绪时更新显示。
- 更新 GeneralPreviewPlugin 以在预览项中保留 matchedContext。
- 增加对 dfm-search 库的依赖以使用 `ContentRetriever`。

通过将耗时的 I/O 操作（读取文件内容并提取高亮）移出关键搜索路径，提升了
搜索响应速度。

Influence:
1. 验证全文搜索结果列表和预览中仍显示高亮内容，但可能在初始显示后稍有
延迟。
2. 测试OCR搜索结果的高亮显示。
3. 测试快速切换关键词：旧高亮任务应被取消，新结果正确显示。
4. 验证预览控件在接收到高亮内容后更新（尤其是当请求时文件尚未可见的
情况）。
5. 测试搜索性能：全文和OCR搜索应感觉更快，因为高亮提取不再阻塞搜索完成。
6. 验证滚动回之前查看的项时，缓存的高亮内容被复用。
7. 测试错误处理：高亮获取失败或返回空内容时，不会崩溃或留下待处理状态。
8. 确保“更多”按钮和视图模式切换（列表/网格）在异步高亮下仍正常工作。
