### PR TITLE
fix: remove symbol preprocessing and fix list delegate rect

### DIFF
--- a/src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp
+++ b/src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp
@@ -191,11 +191,11 @@ FileSearchUtils::SearchInfo FileSearchUtils::parseContent(const QString &content
             continue;
         }
 
-        keywordList.append(searchHelper->tropeInputSymbol(key));
+        keywordList.append(key);
         qCDebug(logDaemon) << "Added keyword to search:" << key;
     }
 
-    info.keyword = QString(R"((%1).*)").arg(keywordList.join('|'));
+    info.keyword = content;
     info.typeKeywords = keywordList;
     return info;
 }

--- a/src/dde-grand-search-daemon/searcher/ocr/ocrtextworker.cpp
+++ b/src/dde-grand-search-daemon/searcher/ocr/ocrtextworker.cpp
@@ -124,7 +124,7 @@ QStringList OcrTextWorkerPrivate::parserKeywords(const QString &context)
     QJsonParseError error;
     QJsonDocument doc = QJsonDocument::fromJson(context.toLocal8Bit(), &error);
     if (error.error != QJsonParseError::NoError || doc.isEmpty())
-        return searchHelper->tropeInputSymbol(context).split(" ");
+        return context.split(" ");
 
     // 应用搜索类目，只需要获取关键字信息
     QStringList keywordList;
@@ -134,11 +134,11 @@ QStringList OcrTextWorkerPrivate::parserKeywords(const QString &context)
         const QString &key = arr[i].toString();
         if (key.isEmpty())
             continue;
-        keywordList.append(searchHelper->tropeInputSymbol(key));
+        keywordList.append(key);
     }
 
     if (keywordList.isEmpty())
-        return { searchHelper->tropeInputSymbol(context) };
+        return { context };
 
     return keywordList;
 }

--- a/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistdelegate.cpp
+++ b/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistdelegate.cpp
@@ -44,6 +44,8 @@ GrandSearchListDelegate::~GrandSearchListDelegate()
 void GrandSearchListDelegate::initStyleOption(QStyleOptionViewItem *option, const QModelIndex &index) const
 {
     DStyledItemDelegate::initStyleOption(option, index);
+    option->text = "";
+    option->icon = QIcon();
 }
 
 bool GrandSearchListDelegate::editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option, const QModelIndex &index)
@@ -65,13 +67,14 @@ void GrandSearchListDelegate::paint(QPainter *painter, const QStyleOptionViewIte
     // 让基类绘制背景和选中状态（不绘制图标和文本）
     QStyleOptionViewItem viewOption(option);
     initStyleOption(&viewOption, index);
-    viewOption.text = "";
-    viewOption.icon = QIcon();
     QStyle *pStyle = viewOption.widget ? viewOption.widget->style() : QApplication::style();
     pStyle->drawControl(QStyle::CE_ItemViewItem, &viewOption, painter, viewOption.widget);
 
     // 绘制选中状态
     drawSelectState(painter, viewOption, index);
+
+    // 调整右边距10px
+    viewOption.rect.adjust(0, 0, -10, 0);
 
     // 绘制图标（普通图标或缩略图）
     drawIcon(painter, viewOption, index);
@@ -388,8 +391,8 @@ void GrandSearchListDelegate::drawMatchedContext(QPainter *painter, const QStyle
 }
 
 int GrandSearchListDelegate::drawTailText(QPainter *painter, const QStringList &tailList, const QFont &font,
-                                            const QFontMetrics &fontMetrics, const QColor &color,
-                                            int maxWidth, int startX, int startY) const
+                                          const QFontMetrics &fontMetrics, const QColor &color,
+                                          int maxWidth, int startX, int startY) const
 {
     if (tailList.isEmpty())
         return startX;
@@ -414,8 +417,8 @@ int GrandSearchListDelegate::drawTailText(QPainter *painter, const QStringList &
 }
 
 void GrandSearchListDelegate::drawSecondLineText(QPainter *painter, const QString &text, const QFont &font,
-                                                     const QFontMetrics &fontMetrics, const QColor &color,
-                                                     int &startX, int startY) const
+                                                 const QFontMetrics &fontMetrics, const QColor &color,
+                                                 int &startX, int startY) const
 {
     int showWidth = fontMetrics.size(Qt::TextSingleLine, text).width();
 
@@ -424,7 +427,7 @@ void GrandSearchListDelegate::drawSecondLineText(QPainter *painter, const QStrin
     layout.setFont(font);
     QTextCharFormat fmt;
     fmt.setForeground(color);
-    layout.setFormats({QTextLayout::FormatRange{0, static_cast<int>(text.length()), fmt}});
+    layout.setFormats({ QTextLayout::FormatRange { 0, static_cast<int>(text.length()), fmt } });
 
     layout.beginLayout();
     layout.createLine();

--- a/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistdelegate.cpp
+++ b/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistdelegate.cpp
@@ -64,6 +64,9 @@ void GrandSearchListDelegate::paint(QPainter *painter, const QStyleOptionViewIte
     painter->setRenderHint(QPainter::HighQualityAntialiasing);
 #endif
 
+    // 清除该行的 tooltip 区域缓存
+    m_tooltipRegionCache[index.row()].clear();
+
     // 让基类绘制背景和选中状态（不绘制图标和文本）
     QStyleOptionViewItem viewOption(option);
     initStyleOption(&viewOption, index);
@@ -122,27 +125,40 @@ static void hideTooltipImmediately()
 bool GrandSearchListDelegate::helpEvent(QHelpEvent *event, QAbstractItemView *view, const QStyleOptionViewItem &option, const QModelIndex &index)
 {
     if (event->type() == QEvent::ToolTip) {
-        const QString tooltip = index.data(Qt::ToolTipRole).toString();
-
-        if (tooltip.isEmpty()) {
-            hideTooltipImmediately();
-        } else {
-            int tooltipsize = tooltip.size();
-            const int nlong = 32;
-            int lines = tooltipsize / nlong + 1;
-            QString strtooltip;
-            for (int i = 0; i < lines; ++i) {
-                strtooltip.append(tooltip.mid(i * nlong, nlong));
-                strtooltip.append("\n");
+        const QPoint itemLocalPos = event->pos();
+        const QList<TooltipRegion> &regions = m_tooltipRegionCache.value(index.row());
+        for (const TooltipRegion &region : regions) {
+            if (region.rect.contains(itemLocalPos)) {
+                int tooltipsize = region.fullText.size();
+                const int nlong = 32;
+                int lines = tooltipsize / nlong + 1;
+                QString strtooltip;
+                for (int i = 0; i < lines; ++i) {
+                    strtooltip.append(region.fullText.mid(i * nlong, nlong));
+                    strtooltip.append("\n");
+                }
+                strtooltip.chop(1);
+                QToolTip::showText(event->globalPos(), strtooltip, view, region.rect);
+                return true;
             }
-            strtooltip.chop(1);
-            QToolTip::showText(event->globalPos(), strtooltip, view);
         }
 
+        // 鼠标在非省略区域，隐藏 tooltip
+        hideTooltipImmediately();
         return true;
     }
 
     return DStyledItemDelegate::helpEvent(event, view, option, index);
+}
+
+void GrandSearchListDelegate::recordTooltipRegion(int row, const QRect &rect, const QString &fullText) const
+{
+    m_tooltipRegionCache[row].append({ rect, fullText });
+}
+
+void GrandSearchListDelegate::clearTooltipCache()
+{
+    m_tooltipRegionCache.clear();
 }
 
 void GrandSearchListDelegate::drawIcon(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
@@ -236,7 +252,7 @@ void GrandSearchListDelegate::drawSearchResultText(QPainter *painter, const QSty
     int secondLineY = firstLineY + nameFontMetrics.height() + ContextLineSpacing;
 
     // 第一行：文件名
-    drawItemName(painter, option, item.name, item.searcher, keywords,
+    drawItemName(painter, index, option, item.name, item.searcher, keywords,
                  nameFont, nameFontMetrics, nameTextColor, isDark, firstLineY);
 
     // 第二行颜色（修改时间、拖尾共用）
@@ -263,8 +279,8 @@ void GrandSearchListDelegate::drawSearchResultText(QPainter *painter, const QSty
                 currentX += ItemDataSpacing;
                 remainingWidth = option.rect.width() - currentX;
             }
-            currentX = drawTailText(painter, tailList, secondFont, secondFontMetrics, secondLineColor,
-                                    remainingWidth, currentX, secondLineY);
+            currentX = drawTailText(painter, index, tailList, secondFont, secondFontMetrics,
+                                    secondLineColor, remainingWidth, currentX, secondLineY);
             remainingWidth = option.rect.width() - currentX;
         }
     }
@@ -274,13 +290,13 @@ void GrandSearchListDelegate::drawSearchResultText(QPainter *painter, const QSty
         QString context = extraHash.value(GRANDSEARCH_PROPERTY_ITEM_MATCHEDCONTEXT).toString();
         if (!context.isEmpty()) {
             currentX += ItemDataSpacing;
-            drawMatchedContext(painter, option, context, keywords,
+            drawMatchedContext(painter, index, option, context, keywords,
                                secondFont, secondFontMetrics, isDark, secondLineY, currentX);
         }
     }
 }
 
-void GrandSearchListDelegate::drawItemName(QPainter *painter, const QStyleOptionViewItem &option,
+void GrandSearchListDelegate::drawItemName(QPainter *painter, const QModelIndex &index, const QStyleOptionViewItem &option,
                                            const QString &name, const QString &searcher,
                                            const QStringList &keywords, const QFont &font,
                                            const QFontMetrics &fontMetrics, const QColor &textColor,
@@ -333,6 +349,11 @@ void GrandSearchListDelegate::drawItemName(QPainter *painter, const QStyleOption
     int actualNameWidth = fontMetrics.size(Qt::TextSingleLine, elidedName).width();
     QRect drawRect(textStartX, startY, actualNameWidth, fontMetrics.height());
 
+    // 文件名被省略时，记录 tooltip 区域
+    if (elidedName != name) {
+        recordTooltipRegion(index.row(), drawRect, name);
+    }
+
     painter->save();
     painter->translate(drawRect.topLeft());
     painter->setClipRect(drawRect.translated(-drawRect.topLeft()));
@@ -340,7 +361,7 @@ void GrandSearchListDelegate::drawItemName(QPainter *painter, const QStyleOption
     painter->restore();
 }
 
-void GrandSearchListDelegate::drawMatchedContext(QPainter *painter, const QStyleOptionViewItem &option,
+void GrandSearchListDelegate::drawMatchedContext(QPainter *painter, const QModelIndex &index, const QStyleOptionViewItem &option,
                                                  const QString &matchedContext, const QStringList &keywords,
                                                  const QFont &font, const QFontMetrics &fontMetrics,
                                                  bool isDark, int startY, int startX) const
@@ -388,10 +409,18 @@ void GrandSearchListDelegate::drawMatchedContext(QPainter *painter, const QStyle
     painter->translate(startX, startY);
     layout.draw(painter, QPointF(0, 0));
     painter->restore();
+
+    // 摘要被省略时，记录 tooltip 区域
+    if (elideResult.text != matchedContext) {
+        QTextLine tl = layout.lineAt(0);
+        recordTooltipRegion(index.row(),
+                            QRect(startX, startY, int(tl.naturalTextWidth()), fontMetrics.height()),
+                            matchedContext);
+    }
 }
 
-int GrandSearchListDelegate::drawTailText(QPainter *painter, const QStringList &tailList, const QFont &font,
-                                          const QFontMetrics &fontMetrics, const QColor &color,
+int GrandSearchListDelegate::drawTailText(QPainter *painter, const QModelIndex &index, const QStringList &tailList,
+                                          const QFont &font, const QFontMetrics &fontMetrics, const QColor &color,
                                           int maxWidth, int startX, int startY) const
 {
     if (tailList.isEmpty())
@@ -410,7 +439,16 @@ int GrandSearchListDelegate::drawTailText(QPainter *painter, const QStringList &
     for (auto tailIndex : tailMap.keys()) {
         if (tailIndex != 0)
             currentX += ItemDataSpacing;
-        drawSecondLineText(painter, tailMap.value(tailIndex), font, fontMetrics, color, currentX, startY);
+        const QString &elidedTail = tailMap.value(tailIndex);
+
+        // 拖尾文本被截断时，记录 tooltip 区域
+        if (elidedTail != tailList.value(tailIndex)) {
+            int tailWidth = fontMetrics.size(Qt::TextSingleLine, elidedTail).width();
+            recordTooltipRegion(index.row(),
+                                QRect(currentX, startY, tailWidth, fontMetrics.height()),
+                                tailList.value(tailIndex));
+        }
+        drawSecondLineText(painter, elidedTail, font, fontMetrics, color, currentX, startY);
     }
 
     return currentX;
@@ -477,7 +515,7 @@ QMap<int, QString> GrandSearchListDelegate::calcTailShowDataByMaxWidth(QStringLi
 
     for (int i = 0; i < tailCount; i++) {
         tailString = strings.takeFirst();
-        elidedTailText = fontMetrics.elidedText(tailString, Qt::ElideLeft, averageWidth);
+        elidedTailText = fontMetrics.elidedText(tailString, Qt::ElideMiddle, averageWidth);
         if (!elidedTailText.isEmpty())
             tailMap.insert(i, elidedTailText);
     }
@@ -525,7 +563,7 @@ QMap<int, QString> GrandSearchListDelegate::calcTailShowDataByOptimalWidth(QStri
         }
 
         pendString = pendMap.value(index);
-        elidedTailText = fontMetrics.elidedText(pendString, Qt::ElideLeft, availableWidth);
+        elidedTailText = fontMetrics.elidedText(pendString, Qt::ElideMiddle, availableWidth);
         if (elidedTailText == pendString) {
             // 未截断显示，说明设置的可用空间还有剩余，需要退还给未使用空间
             int elidedTailWidth = fontMetrics.size(Qt::TextSingleLine, pendString).width();

--- a/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistdelegate.h
+++ b/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistdelegate.h
@@ -13,12 +13,22 @@
 
 namespace GrandSearch {
 
+// tooltip 省略区域：记录绘制时被省略的文本区域和完整内容
+struct TooltipRegion
+{
+    QRect rect;   // 该区域在 item 中的绘制矩形
+    QString fullText;   // 被省略前的完整文本
+};
+
 class GrandSearchListDelegate : public Dtk::Widget::DStyledItemDelegate
 {
     Q_OBJECT
 public:
     explicit GrandSearchListDelegate(QAbstractItemView *parent = Q_NULLPTR);
     ~GrandSearchListDelegate() override;
+
+    // 清除 tooltip 区域缓存（在列表清空时调用）
+    void clearTooltipCache();
 
 protected:
     virtual void initStyleOption(QStyleOptionViewItem *option, const QModelIndex &index) const override;
@@ -33,23 +43,27 @@ protected:
 
 private:
     void drawSelectState(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+
+    // 在绘制时记录省略的 tooltip 区域
+    void recordTooltipRegion(int row, const QRect &rect, const QString &fullText) const;
+
+    mutable QHash<int, QList<TooltipRegion>> m_tooltipRegionCache;
     void drawIcon(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     void drawSearchResultText(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-    void drawItemName(QPainter *painter, const QStyleOptionViewItem &option,
-                      const QString &name, const QString &searcher,
-                      const QStringList &keywords, const QFont &font,
-                      const QFontMetrics &fontMetrics, const QColor &textColor,
+    void drawItemName(QPainter *painter, const QModelIndex &index, const QStyleOptionViewItem &option,
+                      const QString &name, const QString &searcher, const QStringList &keywords,
+                      const QFont &font, const QFontMetrics &fontMetrics, const QColor &textColor,
                       bool isDark, int startY) const;
-    void drawMatchedContext(QPainter *painter, const QStyleOptionViewItem &option,
+    void drawMatchedContext(QPainter *painter, const QModelIndex &index, const QStyleOptionViewItem &option,
                             const QString &matchedContext, const QStringList &keywords,
                             const QFont &font, const QFontMetrics &fontMetrics,
                             bool isDark, int startY, int startX = 0) const;
-    int drawTailText(QPainter *painter, const QStringList &tailList, const QFont &font,
-                     const QFontMetrics &fontMetrics, const QColor &color,
+    int drawTailText(QPainter *painter, const QModelIndex &index, const QStringList &tailList,
+                     const QFont &font, const QFontMetrics &fontMetrics, const QColor &color,
                      int maxWidth, int startX, int startY) const;
     void drawSecondLineText(QPainter *painter, const QString &text, const QFont &font,
-                              const QFontMetrics &fontMetrics, const QColor &color,
-                              int &startX, int startY) const;
+                            const QFontMetrics &fontMetrics, const QColor &color,
+                            int &startX, int startY) const;
 
     void calcTailShowInfo(const int totalTailWidth, int &tailCount, int &averageWidth) const;
     QMap<int, QString> calcTailShowData(QStringList &strings, const int &tailCount, int averageWidth, const QFontMetrics &fontMetrics) const;

--- a/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistview.cpp
+++ b/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistview.cpp
@@ -28,7 +28,6 @@ DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
 #define ICON_SIZE 24
-#define ListItemTextMaxWidth 240   // 文本元素最大显示宽度
 
 GrandSearchListView::GrandSearchListView(QWidget *parent)
     : DListView(parent)
@@ -170,6 +169,8 @@ int GrandSearchListView::getThemeType() const
 
 void GrandSearchListView::clear()
 {
+    if (m_delegate)
+        m_delegate->clearTooltipCache();
     if (m_model)
         m_model->clear();
 }
@@ -259,13 +260,6 @@ void GrandSearchListView::setData(const QModelIndex &index, const MatchedItem &i
     QVariant searchMeta;
     searchMeta.setValue(item);
     m_model->setData(index, searchMeta, DATA_ROLE);
-
-    // 添加悬浮提示
-    QFontMetricsF fontWidth(DFontSizeManager::instance()->get(DFontSizeManager::T6));
-    QString mtext = fontWidth.elidedText(item.name, Qt::ElideRight, ListItemTextMaxWidth);
-    if (mtext != item.name) {
-        m_model->setData(index, item.name, Qt::ToolTipRole);
-    }
 
     // 设置icon - 先显示默认图标
     QIcon itemIcon = Utils::defaultIcon(item);


### PR DESCRIPTION
1. Remove calls to searchHelper->tropeInputSymbol() in file and OCR
search, using original user input directly
2. In file search, change info.keyword from regex pattern to original
content to avoid filtering
3. Move clearing of text/icon from paint() to initStyleOption() in list
delegate for proper state drawing
4. Adjust viewOption rect by -10px right margin before painting select
state to prevent clipping
5. Minor code formatting cleanup

Log: Improved keyword matching accuracy; fixed list item display under
select state

Influence:
1. Test file search with various input symbols (Chinese/English
brackets, spaces, etc.)
2. Verify OCR search results with special characters
3. Check list item appearance when selected – text and icon should not
be cut off
4. Confirm delegate paint behavior with different view styles
5. Ensure right margin is consistent and select state highlight is
correctly aligned

fix: 移除符号预处理并修复列表代理绘制区域

1. 移除文件和OCR搜索中对searchHelper->tropeInputSymbol()的调用，直接使用
原始用户输入
2. 文件搜索中，将info.keyword从正则表达式改为原始内容，避免不必要的过滤
3. 将清空文本和图标的操作从paint()移到initStyleOption()中，确保选中状态
绘制正确
4. 在绘制选中状态前，将viewOption的右边距增加10px，防止内容被裁剪
5. 清理部分代码格式

Log: 改进的关键词匹配准确性；修复选中状态下列表项显示问题

Influence:
1. 测试文件搜索，输入各种符号（中英文括号、空格等）
2. 验证OCR搜索带有特殊字符的结果
3. 检查列表项选中时的显示效果——文本和图标不应被裁剪
4. 确认不同视图样式下委托绘制行为正常
5. 验证右边距一致，选中状态高亮正确对齐

BUG: https://pms.uniontech.com/bug-view-363989.html
