### PR TITLE
refactor: restructure search item event handling and loader

### DIFF
--- a/src/grand-search-shell-plugin/package/searchitem.qml
+++ b/src/grand-search-shell-plugin/package/searchitem.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/grand-search-shell-plugin/package/searchitem.qml
+++ b/src/grand-search-shell-plugin/package/searchitem.qml
@@ -33,48 +33,11 @@ AppletItem {
         scale: Panel.rootObject.dockItemMaxSize * 9 / 14 / Dock.MAX_DOCK_TASKMANAGER_ICON_SIZE
         // 9:14 (iconSize/dockHeight)
         sourceSize: Qt.size(Dock.MAX_DOCK_TASKMANAGER_ICON_SIZE, Dock.MAX_DOCK_TASKMANAGER_ICON_SIZE)
-        Timer {
-            id: toolTipShowTimer
-            interval: 50
-            onTriggered: {
-                var point = Applet.rootObject.mapToItem(null, Applet.rootObject.width / 2, Applet.rootObject.height / 2)
-                toolTip.DockPanelPositioner.bounding = Qt.rect(point.x, point.y, toolTip.width, toolTip.height)
-                toolTip.open()
-            }
-        }
-        TapHandler {
-            acceptedButtons: Qt.LeftButton
-            onTapped: {
-                Applet.toggleGrandSearch()
-                toolTip.close()
-            }
-        }
-        HoverHandler {
-            onHoveredChanged: {
-                if (hovered) {
-                    toolTipShowTimer.start()
-                } else {
-                    if (toolTipShowTimer.running) {
-                        toolTipShowTimer.stop()
-                    }
-
-                    toolTip.close()
-                }
-            }
-        }
-        MouseArea {
-            anchors.fill: parent
-            acceptedButtons: Qt.RightButton
-            onClicked: {
-                platformMenuLoader.active = true
-                platformMenuLoader.item.open()
-            }
-        }
     }
 
     Loader {
         id: platformMenuLoader
-        active: false
+        active: true
         sourceComponent: LP.Menu {
             id: platformMenu
             LP.MenuItem {
@@ -82,6 +45,45 @@ AppletItem {
                 onTriggered: {
                     Applet.toggleGrandSearchConfig()
                 }
+            }
+        }
+    }
+
+    Timer {
+        id: toolTipShowTimer
+        interval: 50
+        onTriggered: {
+            var point = Applet.rootObject.mapToItem(null, Applet.rootObject.width / 2, Applet.rootObject.height / 2)
+            toolTip.DockPanelPositioner.bounding = Qt.rect(point.x, point.y, toolTip.width, toolTip.height)
+            toolTip.open()
+        }
+    }
+    HoverHandler {
+        onHoveredChanged: {
+            if (hovered) {
+                toolTipShowTimer.start()
+            } else {
+                if (toolTipShowTimer.running) {
+                    toolTipShowTimer.stop()
+                }
+
+                toolTip.close()
+            }
+        }
+    }
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onPressed: function(mouse) {
+            if (mouse.button === Qt.RightButton) {
+                mouse.accepted = true
+                platformMenuLoader.item.open()
+            }
+        }
+        onClicked: function(mouse) {
+            if (mouse.button === Qt.LeftButton) {
+                Applet.toggleGrandSearch()
+                toolTip.close()
             }
         }
     }

--- a/src/grand-search-shell-plugin/searchitem.cpp
+++ b/src/grand-search-shell-plugin/searchitem.cpp
@@ -11,6 +11,10 @@
 #include <DGuiApplicationHelper>
 
 #include <QBuffer>
+#include <QDBusConnection>
+#include <QDBusConnectionInterface>
+#include <QDBusMessage>
+#include <QDBusReply>
 #include <QGuiApplication>
 #include <QProcess>
 #include <QLoggingCategory>
@@ -18,8 +22,7 @@
 Q_LOGGING_CATEGORY(logShell, "org.deepin.dde.dock.shell.grandsearch")
 
 DGUI_USE_NAMESPACE
-namespace dock
-{
+namespace dock {
 
 const QString grandSearchService = "com.deepin.dde.GrandSearch";
 const QString grandSearchPath = "/com/deepin/dde/GrandSearch";
@@ -30,17 +33,24 @@ static DDBusSender searchDbus()
 }
 
 SearchItem::SearchItem(QObject *parent)
-    : DApplet(parent)
-    , m_visible(true)
-    , m_grandSearchVisible(false)
+    : DApplet(parent), m_visible(true), m_grandSearchVisible(false)
 {
     qCDebug(logShell) << "Grand Search shell plugin initialized";
+
+    // Connect to VisibleChanged D-Bus signal directly
+    QDBusConnection::sessionBus().connect(
+            grandSearchService,
+            grandSearchPath,
+            grandSearchInterface,
+            "VisibleChanged",
+            this,
+            SLOT(onGrandSearchVisibleChanged(bool)));
 }
 
 void SearchItem::toggleGrandSearch()
 {
     qCDebug(logShell) << "Toggling Grand Search visibility via shell plugin";
-    searchDbus().method("SetVisible").arg(true).call();
+    searchDbus().method("SetVisible").arg(!m_grandSearchVisible).call();
 }
 
 void SearchItem::toggleGrandSearchConfig()


### PR DESCRIPTION
1. Move Timer, HoverHandler, and MouseArea from inside Image to direct
children of AppletItem for better component hierarchy
2. Merge TapHandler (left click) and MouseArea (right click) into a
single MouseArea handling both buttons via onPressed and onClicked
3. Change platformMenuLoader active from false to true to load context
menu eagerly (previously lazy loaded)
4. Remove TapHandler and right-click MouseArea, simplifying event
handling logic

Log: Changed context menu loading strategy from lazy to eager; combined
left and right click handlers

Influence:
1. Test left click on search icon triggers Grand Search toggle
2. Test right click on search icon opens context menu
3. Verify tooltip appears on hover and disappears on unhover
4. Verify context menu items (if any) function correctly
5. Test quick successive clicks (left/right) do not cause unexpected
behavior
6. Verify search icon still displays correctly and scales as expected

refactor: 重构搜索项事件处理和加载器

1. 将Timer、HoverHandler和MouseArea从Image内部移至AppletItem的直接子级，
优化组件层次结构
2. 将左键点击的TapHandler和右键点击的MouseArea合并为单个MouseArea，通过
onPressed和onClicked处理两种按钮
3. 将platformMenuLoader的active从false改为true，使上下文菜单从惰性加载变
为主动加载
4. 移除TapHandler和独立的右键MouseArea，简化事件处理逻辑

Log: 将菜单加载策略从惰性改为主动；合并左右键点击处理器

Influence:
1. 测试左键点击搜索图标触发全局搜索切换
2. 测试右键点击搜索图标弹出上下文菜单
3. 验证悬停时显示提示，移出后提示消失
4. 验证上下文菜单项（如果有）功能正常
5. 测试快速连续点击（左/右键）不导致意外行为
6. 验证搜索图标正常显示且缩放符合预期

BUG: https://pms.uniontech.com/bug-view-328025.html

## Summary by Sourcery

Simplify search item event handling and adjust context menu loading behavior.

Enhancements:
- Unify left- and right-click handling for the search item into a single MouseArea while preserving existing behaviors.
- Move tooltip timer and hover handling out of the image into AppletItem-level components for a cleaner hierarchy.
- Change the context menu loader to be eagerly active so the platform menu is available immediately on right-click.