### PR TITLE
fix: adjust list item height calculation for dynamic rows

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+dde-grand-search (6.0.37) unstable; urgency=medium
+
+  * refactor: move highlight content extraction from daemon to client-side
+  * fix: remove symbol preprocessing and fix list delegate rect
+  * feat: refine tooltip to only show on omitted text regions
+  * refactor: restructure search item event handling and loader
+  * fix: toggleGrandSearch now toggles visibility
+  * fix: adjust list item height calculation for dynamic rows
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Thu, 04 Jun 2026 20:06:50 +0800
+
 dde-grand-search (6.0.36) unstable; urgency=medium
 
   * feat: optimize search UI icons and layout spacing

--- a/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistdelegate.cpp
+++ b/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistdelegate.cpp
@@ -20,7 +20,6 @@
 #include <QApplication>
 #include <QToolTip>
 
-#define ListItemHeight 36   // 列表行高（单行）
 #define ListIconSize 24   // 列表图标大小
 #define ListRowWidth 740   // 列表行宽
 #define ItemDataSpacing 10   // 信息显示间隔
@@ -101,13 +100,13 @@ QSize GrandSearchListDelegate::sizeHint(const QStyleOptionViewItem &option, cons
         }
     }
 
-    if (!hasSecondLine)
-        return QSize(ListRowWidth, ListItemHeight);
-
     QFontMetrics nameFm(DFontSizeManager::instance()->get(DFontSizeManager::T6));
-    QFontMetrics contextFm(DFontSizeManager::instance()->get(DFontSizeManager::T8));
-    int totalHeight = ListLineMargin + nameFm.height() + ContextLineSpacing + contextFm.height() + ListLineMargin;
-    totalHeight = qMax(totalHeight, ListItemHeight);
+    int totalHeight = ListLineMargin * 2 + nameFm.height();
+
+    if (hasSecondLine) {
+        QFontMetrics contextFm(DFontSizeManager::instance()->get(DFontSizeManager::T8));
+        totalHeight += ContextLineSpacing + contextFm.height();
+    }
 
     return QSize(ListRowWidth, totalHeight);
 }
@@ -309,7 +308,8 @@ void GrandSearchListDelegate::drawItemName(QPainter *painter, const QModelIndex 
     if (elidedName != name && GRANDSEARCH_CLASS_WEB_STATICTEXT == searcher) {
         static const QString markStr = name.right(1);
         static const int markWidth = fontMetrics.size(Qt::TextSingleLine, markStr).width();
-        elidedName = fontMetrics.elidedText(name.left(name.size() - 1), Qt::ElideRight, nameTextMaxWidth - markWidth);
+        nameTextMaxWidth -= markWidth;
+        elidedName = fontMetrics.elidedText(name.left(name.size() - 1), Qt::ElideRight, nameTextMaxWidth);
         elidedName.append(markStr);
     }
 
@@ -346,8 +346,7 @@ void GrandSearchListDelegate::drawItemName(QPainter *painter, const QModelIndex 
     nameCursor.endEditBlock();
 
     QAbstractTextDocumentLayout::PaintContext paintContext;
-    int actualNameWidth = fontMetrics.size(Qt::TextSingleLine, elidedName).width();
-    QRect drawRect(textStartX, startY, actualNameWidth, fontMetrics.height());
+    QRect drawRect(textStartX, startY, nameTextMaxWidth, fontMetrics.height());
 
     // 文件名被省略时，记录 tooltip 区域
     if (elidedName != name) {


### PR DESCRIPTION
Previously the list item height was fixed to 36px, redefined as
the macro `ListItemHeight`. This change removes the fixed height
and calculates the row height dynamically based on font metrics,
allowing the list to properly display items with multi-line content.
Additionally, the drawing rectangle for the item name now uses
`nameTextMaxWidth` instead of the actual text width, ensuring consistent
alignment. The web static text ellipsis handling is also fixed to
correctly subtract the marker width.

Log: Adjusted list item height for dynamic rows in grand search results

Influence:
1. Test single-line and multi-line item display in grand search results
list
2. Verify that row height adapts correctly for items with and without
second line
3. Check alignment of item name text when ellipsis is applied
4. Confirm web static text items show correct marker and ellipsis
behavior
5. Test under different font sizes and DPI settings

fix: 调整列表项行高为动态计算

之前列表项高度固定为 36px，定义为宏 `ListItemHeight`。此更改移除了固定高
度，基于字体度量动态计算行高，使列表能够正常显示多行内容。同时修改了名称
绘制矩形区域，使用 `nameTextMaxWidth` 确保对齐一致。修复了 web 静态文本
省略号处理中标记宽度的减法逻辑。

Log: 调整全局搜索结果列表行高为动态高度

Influence:
1. 测试全局搜索结果列表中单行和多行项目的显示效果
2. 验证有/无第二行时行高是否正确自适应
3. 检查名称文本省略时的对齐情况
4. 确认 web 静态文本项目标记和省略行为正确
5. 在不同字体大小和 DPI 设置下测试
