### PR TITLE
fix: update French translations for grand search UI

### DIFF
--- a/translations/dde-grand-search_fr.ts
+++ b/translations/dde-grand-search_fr.ts
@@ -6,17 +6,17 @@
     <message>
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="48"/>
         <source>Unable to use %1, please go to the App Store to update the UOS AI version first.</source>
-        <translation>غير قادر على استخدام %1، من فضلك انتقل إلى متجر التطبيقات لتحديث إصدار UOS AI أولاً.</translation>
+        <translation>Impossible d&apos;utiliser %1, veuillez vous rendre dans l&apos;App Store pour mettre à jour la version UOS AI.</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="49"/>
         <source>Cancel</source>
-        <translation type="unfinished">Annuler</translation>
+        <translation>Annuler</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="50"/>
         <source>Open App Store</source>
-        <translation type="unfinished"></translation>
+        <translation>Ouvrir l&apos;App Store</translation>
     </message>
 </context>
 <context>
@@ -25,60 +25,60 @@
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="112"/>
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="162"/>
         <source>Summary</source>
-        <translation>ملخص</translation>
+        <translation>Résumé</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="113"/>
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="163"/>
         <source>Translation</source>
-        <translation>ترجمة</translation>
+        <translation>Traduction</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="114"/>
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="164"/>
         <source>Extension</source>
-        <translation>توسيع</translation>
+        <translation>Extension</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="115"/>
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="165"/>
         <source>Add to knowledge base</source>
-        <translation>إضافة إلى قاعدة المعرفة</translation>
+        <translation>Ajouter à la base de connaissances</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="126"/>
         <source>Summarize document content with UOS AI</source>
-        <translation>قم بملخص محتوى الوثيقة باستخدام UOS AI</translation>
+        <translation>Résumer le contenu du document avec UOS AI</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="127"/>
         <source>Translate document content with UOS AI</source>
-        <translation>قم بترجمة محتوى الوثيقة باستخدام UOS AI</translation>
+        <translation>Traduire le contenu du document avec UOS AI</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="128"/>
         <source>Extend document content with UOS AI</source>
-        <translation>قم بتوسيع محتوى الوثيقة باستخدام UOS AI</translation>
+        <translation>Étendre le contenu du document avec UOS AI</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="129"/>
         <source>Add document to UOS AI knowledge base</source>
-        <translation>أضف الوثيقة إلى قاعدة المعرفة الخاصة بـ UOS AI</translation>
+        <translation>Ajouter le document à la base de connaissances UOS AI</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="299"/>
         <source>Summarize this document for me and provide me with a clear result directly, without any unnecessary content.</source>
-        <translation>قم بملخص هذه الوثيقة لي وقدم لي نتيجة واضحة مباشرة، دون أي محتوى غير ضروري.</translation>
+        <translation>Résumez ce document et fournissez-moi un résultat clair directement, sans aucun contenu inutile.</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="315"/>
         <source>Translate this document for me and provide me with a clear result directly, without any unnecessary content.</source>
-        <translation>قم بترجمة هذه الوثيقة لي وقدم لي نتيجة واضحة مباشرة، دون أي محتوى غير ضروري.</translation>
+        <translation>Traduisez ce document et fournissez-moi un résultat clair directement, sans aucun contenu inutile.</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="331"/>
         <source>Expand this document for me and provide me with a clear and expanded result directly, without any unnecessary content.</source>
-        <translation>قم بتوسيع هذه الوثيقة لي وقدم لي نتيجة واضحة وموسعة مباشرة، دون أي محتوى غير ضروري.</translation>
+        <translation>Développez ce document et fournissez-moi un résultat clair et détaillé directement, sans aucun contenu inutile.</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="447"/>
@@ -88,12 +88,12 @@
     <message>
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="450"/>
         <source>Unable to use %1, please go to the App Store to update the UOS AI version first.</source>
-        <translation>غير قادر على استخدام %1، من فضلك انتقل إلى متجر التطبيقات لتحديث إصدار UOS AI أولاً.</translation>
+        <translation>Impossible d&apos;utiliser %1, veuillez vous rendre dans l&apos;App Store pour mettre à jour la version UOS AI.</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/exhibition/preview/generalwidget/aitoolbar.cpp" line="451"/>
         <source>Open App Store</source>
-        <translation type="unfinished"></translation>
+        <translation>Ouvrir l&apos;App Store</translation>
     </message>
 </context>
 <context>
@@ -164,18 +164,18 @@
     <message>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/embeddingpluginwidget.cpp" line="52"/>
         <source>Installed</source>
-        <translation>مثبت</translation>
+        <translation>Installé</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/embeddingpluginwidget.cpp" line="52"/>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/embeddingpluginwidget.cpp" line="91"/>
         <source>Not Installed</source>
-        <translation>غير مثبت</translation>
+        <translation>Non installé</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/embeddingpluginwidget.cpp" line="107"/>
         <source>Install</source>
-        <translation>تثبيت</translation>
+        <translation>Installer</translation>
     </message>
 </context>
 <context>
@@ -202,7 +202,7 @@
         <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="260"/>
         <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="327"/>
         <source>Size:</source>
-        <translation type="unfinished">Taille :</translation>
+        <translation>Taille :</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/exhibition/preview/generalpreviewplugin.cpp" line="272"/>
@@ -233,7 +233,7 @@
     <message>
         <location filename="../src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistdelegate.cpp" line="250"/>
         <source>Modified at </source>
-        <translation type="unfinished"></translation>
+        <translation>Modifié le </translation>
     </message>
 </context>
 <context>
@@ -241,29 +241,29 @@
     <message>
         <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="298"/>
         <source>Please go to %1 to install the ULLM, and %2 Automatic index update.</source>
-        <translation>من فضلك انتقل إلى %1 لتثبيت ULLM، و%2 تحديث المؤشر تلقائيًا.</translation>
+        <translation>Veuillez vous rendre à %1 pour installer ULLM, et %2 la mise à jour automatique de l&apos;index.</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="299"/>
         <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="308"/>
         <source>Search configuration</source>
-        <translation type="unfinished"></translation>
+        <translation>Configuration de recherche</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="300"/>
         <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="304"/>
         <source>turn on</source>
-        <translation>تمكين</translation>
+        <translation>Activer</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="303"/>
         <source>Please %1 Automatic index update.</source>
-        <translation>من فضلك %1 تحديث المؤشر تلقائيًا.</translation>
+        <translation>Veuillez %1 la mise à jour automatique de l&apos;index.</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="307"/>
         <source>Please go to %1 to install the ULLM.</source>
-        <translation>من فضلك انتقل إلى %1 لتثبيت ULLM.</translation>
+        <translation>Veuillez vous rendre à %1 pour installer ULLM.</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="360"/>
@@ -274,7 +274,7 @@
         <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="310"/>
         <location filename="../src/grand-search/gui/exhibition/matchresult/groupwidget.cpp" line="396"/>
         <source>No search results</source>
-        <translation type="unfinished">Aucun résultat trouvé</translation>
+        <translation>Aucun résultat trouvé</translation>
     </message>
 </context>
 <context>
@@ -290,37 +290,37 @@
     <message>
         <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="66"/>
         <source>AI Smart Search</source>
-        <translation>البحث الذكي بالذكاء الاصطناعي</translation>
+        <translation>Recherche intelligente par IA</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="79"/>
         <source>When turned on, you can try to search for local documents using natural language descriptions, such as &quot;last week&apos;s documents&quot;.</source>
-        <translation>عند تمكينها، يمكنك محاولة البحث عن الوثائق المحلية باستخدام وصف اللغة الطبيعية، مثل &quot;وثائق الأسبوع الماضي&quot;.</translation>
+        <translation>Lorsqu&apos;elle est activée, vous pouvez essayer de rechercher des documents locaux en utilisant des descriptions en langage naturel, comme « les documents de la semaine dernière ».</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="101"/>
         <source>Automatic index update</source>
-        <translation>تحديث المؤشر تلقائيًا</translation>
+        <translation>Mise à jour automatique de l&apos;index</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="120"/>
         <source>Full Text Search</source>
-        <translation>البحث بالنص الكامل</translation>
+        <translation>Recherche en texte intégral</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="137"/>
         <source>When turned on, full text search can be used in the file manager and grand search.</source>
-        <translation>عند تمكينها، يمكن استخدام البحث بالنص الكامل في مدير الملفات والبحث العام.</translation>
+        <translation>Lorsqu&apos;elle est activée, la recherche en texte intégral peut être utilisée dans le gestionnaire de fichiers et la recherche générale.</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="157"/>
         <source>Embedding Plugins</source>
-        <translation>إضافات التضمين</translation>
+        <translation>Plugins d&apos;intégration</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="157"/>
         <source>After installing the model, you can use services such as AI Search and UOS AI Assistant..</source>
-        <translation>بعد تثبيت النموذج، يمكنك استخدام خدمات مثل البحث الذكي والمساعد الذكي لـ UOS.</translation>
+        <translation>Après avoir installé le modèle, vous pouvez utiliser des services tels que la recherche par IA et l&apos;assistant UOS AI.</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="175"/>
@@ -330,49 +330,49 @@
     <message>
         <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="175"/>
         <source>After installing the ULLM, you can use the AI intelligent search function without an internet connection.</source>
-        <translation>بعد تثبيت ULLM، يمكنك استخدام وظيفة البحث الذكي من دون اتصال بالإنترنت.</translation>
+        <translation>Après avoir installé ULLM, vous pouvez utiliser la fonction de recherche intelligente par IA sans connexion Internet.</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="188"/>
         <source>Intelligent full text search</source>
-        <translation>البحث الكامل في النص الذكي</translation>
+        <translation>Recherche intelligente en texte intégral</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="224"/>
         <source>When enabled, you can search the text of articles using disjointed and incomplete keywords.</source>
-        <translation>عند تمكين هذه الميزة، يمكنك البحث في نص المقالات باستخدام كلمات مفتتة وغير كاملة.</translation>
+        <translation>Lorsqu&apos;elle est activée, vous pouvez rechercher le texte des articles en utilisant des mots-clés fragmentés et incomplets.</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="246"/>
         <source>Please install %0 in &lt;a href=&quot;%0&quot;&gt;the app store&lt;/a&gt; before turning on this configuration.</source>
-        <translation>يرجى تثبيت %0 في &lt;a href=&quot;%0&quot;&gt;متجر التطبيق&lt;/a&gt; قبل تفعيل هذه الإعداد.</translation>
+        <translation>Veuillez installer %0 dans &lt;a href=&quot;%0&quot;&gt;l&apos;App Store&lt;/a&gt; avant d&apos;activer ce paramètre.</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="286"/>
         <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="412"/>
         <source>Intelligent search indexing is being updated, which may take up more resources, please keep the power access.</source>
-        <translation>جارى تحديث تفهرس البحث الذكي، وقد يستهلك موارد أكثر، من فضلك حافظ على إمكانية الوصول إلى الطاقة.</translation>
+        <translation>Mise à jour de l&apos;indexation de la recherche intelligente en cours, cela peut consommer plus de ressources, veuillez maintenir l&apos;accès à l&apos;alimentation.</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="290"/>
         <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="416"/>
         <source>Smart Search indexing update is complete. Last update time: %0</source>
-        <translation>تحديث تفهرس البحث الذكي قد اكتمل. وقت آخر تحديث: %0</translation>
+        <translation>Mise à jour de l&apos;indexation de la recherche intelligente terminée. Dernière mise à jour : %0</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="293"/>
         <source>Indexing error!</source>
-        <translation>خطأ في التفهرس!</translation>
+        <translation>Erreur d&apos;indexation !</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="342"/>
         <source>To use AI Smart Search, you need to install the Embedding Plugins and ULLM first.</source>
-        <translation>للاستخدام البحث الذكي الذكي، من الضروري تثبيت إضافات التضمين وULLM أولاً.</translation>
+        <translation>Pour utiliser la recherche intelligente par IA, vous devez d&apos;abord installer les plugins d&apos;intégration et ULLM.</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/intelligentretrieval/intelligentretrievalwidget.cpp" line="343"/>
         <source>OK</source>
-        <translation>موافق</translation>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
@@ -381,92 +381,92 @@
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="62"/>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="387"/>
         <source>Not Installed</source>
-        <translation>غير مثبت</translation>
+        <translation>Non installé</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="79"/>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="386"/>
         <source>Install Model</source>
-        <translation>تثبيت النموذج</translation>
+        <translation>Installer le modèle</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="95"/>
         <source>Update model</source>
-        <translation>تحديث النموذج</translation>
+        <translation>Mettre à jour le modèle</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="96"/>
         <source>Uninstall model</source>
-        <translation>إزالة النموذج</translation>
+        <translation>Désinstaller le modèle</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="148"/>
         <source>Installing</source>
-        <translation>جارى التثبيت</translation>
+        <translation>Installation en cours</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="214"/>
         <source>Are you sure you want to delete this model?</source>
-        <translation>هل أنت متأكد من رغبتك في حذف هذا النموذج؟</translation>
+        <translation>Êtes-vous sûr de vouloir supprimer ce modèle ?</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="215"/>
         <source>After uninstallation, functions such as AI Search and UOS AI Assistant will not work properly.</source>
-        <translation>بعد إزالة النموذج، لن تعمل وظائف مثل البحث الذكي والمساعد الذكي لـ UOS بشكل صحيح.</translation>
+        <translation>Après la désinstallation, des fonctions telles que la recherche par IA et l&apos;assistant UOS AI ne fonctionneront pas correctement.</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="216"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished">Annuler</translation>
+        <translation>Annuler</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="217"/>
         <source>Confirm</source>
         <comment>button</comment>
-        <translation type="unfinished">Confirmer</translation>
+        <translation>Confirmer</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="326"/>
         <source>Installing </source>
-        <translation>جارى التثبيت </translation>
+        <translation>Installation en cours </translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="346"/>
         <source>Installing the ULLM</source>
-        <translation>جارى تثبيت ULLM</translation>
+        <translation>Installation de ULLM</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="347"/>
         <source>Exiting will cause the installation to fail, do you still want to exit?</source>
-        <translation>الخروج سيؤدي إلى فشل التثبيت، هل ما زلت ترغب في الخروج؟</translation>
+        <translation>Quitter entraînera l&apos;échec de l&apos;installation, souhaitez-vous toujours quitter ?</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="348"/>
         <source>Exit</source>
         <comment>button</comment>
-        <translation>الخروج</translation>
+        <translation>Quitter</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="349"/>
         <source>Continue</source>
         <comment>button</comment>
-        <translation>المتابعة</translation>
+        <translation>Continuer</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="380"/>
         <source>UnInstall Model</source>
-        <translation>إزالة النموذج</translation>
+        <translation>Désinstaller le modèle</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="381"/>
         <source>Installed</source>
-        <translation>مثبت</translation>
+        <translation>Installé</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/llmwidget/llmwidget.cpp" line="392"/>
         <source>Please install the &quot;Embedding Plugins&quot; first before installing this model.</source>
-        <translation>يرجى تثبيت &quot;إضافات التضمين&quot; أولاً قبل تثبيت هذا النموذج.</translation>
+        <translation>Veuillez d&apos;abord installer les « Plugins d&apos;intégration » avant d&apos;installer ce modèle.</translation>
     </message>
 </context>
 <context>
@@ -482,7 +482,7 @@
     <message>
         <location filename="../src/grand-search/gui/exhibition/matchresult/matchwidget.cpp" line="90"/>
         <source>Guess you want to search the following</source>
-        <translation>ربما ترغب في البحث في ما يلي</translation>
+        <translation>Vous souhaitez peut-être rechercher ce qui suit</translation>
     </message>
 </context>
 <context>
@@ -500,7 +500,7 @@
     <message>
         <location filename="../src/grand-search/gui/searchconfig/planwidget.cpp" line="53"/>
         <source>Joining the search experience program means that you grant and authorize us to collect the information of your device and system, file icons, content and properties, applications and their configurations, the contents you search while using the Application, the time of search, the type of requested large model.If you refuse our collection and use of the aforementioned information, do not join the program.</source>
-        <translation>الانضمام إلى برنامج تجربة البحث يعني أنك تمنحنا وتُفوضنا جمع معلومات جهازك ونظامك، وأيقونات الملفات، والمواد والمحتوى، والتطبيقات وملقماتها، والمواد التي تبحثها أثناء استخدام التطبيق، وقت البحث، نوع النموذج الكبير المطلوب. إذا رفضت جمعنا واستخدامنا المعلومات المذكورة أعلاه، فلا تنضم إلى البرنامج.</translation>
+        <translation>Rejoindre le programme d&apos;expérience de recherche signifie que vous nous accordez et nous autorisez à collecter les informations de votre appareil et système, les icônes de fichiers, le contenu et les propriétés, les applications et leurs configurations, les contenus que vous recherchez lors de l&apos;utilisation de l&apos;application, l&apos;heure de la recherche, le type de grand modèle demandé. Si vous refusez notre collecte et utilisation des informations susmentionnées, ne rejoignez pas le programme.</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/planwidget.cpp" line="64"/>
@@ -536,22 +536,22 @@
     <message>
         <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="121"/>
         <source>Search</source>
-        <translation type="unfinished">Rechercher</translation>
+        <translation>Rechercher</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="219"/>
         <source>Cut</source>
-        <translation type="unfinished">Couper</translation>
+        <translation>Couper</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="223"/>
         <source>Copy</source>
-        <translation type="unfinished">Copier</translation>
+        <translation>Copier</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/entrance/searchedit.cpp" line="227"/>
         <source>Paste</source>
-        <translation type="unfinished">Coller</translation>
+        <translation>Coller</translation>
     </message>
 </context>
 <context>
@@ -599,7 +599,7 @@
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="76"/>
         <source>360 AI Search</source>
-        <translation>360 البحث الذكي</translation>
+        <translation>Recherche IA 360</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="77"/>
@@ -609,7 +609,7 @@
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="78"/>
         <source>Custom</source>
-        <translation>مخصص</translation>
+        <translation>Personnalisé</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/searchenginewidget.cpp" line="99"/>
@@ -635,7 +635,7 @@
     <message>
         <location filename="../src/grand-search/gui/searchconfig/tailerwidget.cpp" line="19"/>
         <source>Tailer settings</source>
-        <translation>Paramètres de tailleur</translation>
+        <translation>Paramètres de suffixe</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/searchconfig/tailerwidget.cpp" line="29"/>
@@ -759,7 +759,7 @@
     <message>
         <location filename="../src/grand-search/gui/datadefine.h" line="34"/>
         <source>Web</source>
-        <translation>la toile</translation>
+        <translation>Web</translation>
     </message>
     <message>
         <location filename="../src/grand-search/gui/datadefine.h" line="35"/>
@@ -769,7 +769,7 @@
     <message>
         <location filename="../src/grand-search/gui/datadefine.h" line="36"/>
         <source>Text found in the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Texte trouvé dans l&apos;image</translation>
     </message>
     <message>
         <location filename="../src/preview-plugin/video-preview/videopreviewplugin.cpp" line="28"/>


### PR DESCRIPTION
1. Corrected multiple French translations in the grand search module
2. Fixed incomplete (unfinished) translations for UI elements like
"Cancel", "Open App Store", "Size:", "Search", etc.
3. Updated all AI-related tooltip texts and configuration descriptions
to proper French
4. Ensured consistency in terminology across the translation file

Log: Updated French translations for UI elements in search settings, AI
toolbar, and preview widgets

Influence:
1. Verify that all translated strings display correctly in the French
locale
2. Check that previously untranslated strings now show proper French
text
3. Test AI toolbar functions with French language setting
4. Verify search configuration dialog translations
5. Check preview plugin tooltips and labels in French

fix: 更新全局搜索的法语翻译

1. 修正了全局搜索中的多个法语翻译
2. 修复了UI元素（如"取消"、"打开应用商店"、"大小："、"搜索"等）的未完成
翻译
3. 将所有AI相关工具提示文本和配置描述更新为正确的法语
4. 确保整个翻译文件中术语的一致性

Log: 更新了搜索设置、AI工具栏和预览小部件中UI元素的法语翻译

Influence:
1. 验证所有翻译字符串在法语语言环境下正确显示
2. 检查之前未翻译的字符串现在是否显示正确的法语文本
3. 用法语语言设置测试AI工具栏功能
4. 验证搜索配置对话框的翻译
5. 检查预览插件工具提示和标签的法语显示

BUG: https://pms.uniontech.com/bug-view-355447.html
