### PR TITLE
refactor: replace QFontMetrics with QFontMetricsF and consolidate text elision

### DIFF
--- a/src/global/widgets/highlightutils.cpp
+++ b/src/global/widgets/highlightutils.cpp
@@ -5,29 +5,22 @@
 #include "highlightutils.h"
 
 #include <QPainter>
-#include <QFontMetrics>
+#include <QFontMetricsF>
 #include <QRegularExpression>
 #include <QPalette>
+#include <QFont>
 #include <algorithm>
 
 namespace HighlightUtils {
 
-static int charWidth(const QFontMetrics &fm, QChar ch)
+static double charWidth(const QFontMetricsF &fm, QChar ch)
 {
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    return fm.width(ch);
-#else
     return fm.horizontalAdvance(ch);
-#endif
 }
 
-static int textWidth(const QFontMetrics &fm, const QString &text)
+static double textWidth(const QFontMetricsF &fm, const QString &text)
 {
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    return fm.width(text);
-#else
     return fm.horizontalAdvance(text);
-#endif
 }
 
 QVector<MatchRange> findMatchRanges(const QString &text, const QStringList &keywords)
@@ -58,16 +51,16 @@ QVector<MatchRange> findMatchRanges(const QString &text, const QStringList &keyw
 }
 
 static ElideResult buildWindowElide(const QString &text, int keepStart, int keepEnd,
-                                    int maxWidth, const QFontMetrics &fm)
+                                    int maxWidth, const QFontMetricsF &fm)
 {
     ElideResult result;
     const QString ellipsis = QStringLiteral("…");
-    int ellipsisWidth = charWidth(fm, QChar(0x2026));
+    double ellipsisWidth = charWidth(fm, QChar(0x2026));
 
     bool needLeft = (keepStart > 0);
     bool needRight = (keepEnd < text.length());
     int numEllipsis = (needLeft ? 1 : 0) + (needRight ? 1 : 0);
-    int budget = maxWidth - numEllipsis * ellipsisWidth;
+    double budget = maxWidth - numEllipsis * ellipsisWidth;
     if (budget <= 0) {
         result.text = ellipsis;
         result.origPositions = { -1 };
@@ -76,10 +69,10 @@ static ElideResult buildWindowElide(const QString &text, int keepStart, int keep
 
     int keepLen = keepEnd - keepStart;
     int trimLeft = 0, trimRight = 0;
-    int w = textWidth(fm, text.mid(keepStart, keepLen));
+    double w = textWidth(fm, text.mid(keepStart, keepLen));
     while (w > budget && keepLen > 0) {
-        int lNext = charWidth(fm, text[keepStart + trimLeft]);
-        int rNext = charWidth(fm, text[keepEnd - 1 - trimRight]);
+        double lNext = charWidth(fm, text[keepStart + trimLeft]);
+        double rNext = charWidth(fm, text[keepEnd - 1 - trimRight]);
         if (trimRight >= keepLen - trimLeft - 1) {
             w -= lNext;
             ++trimLeft;
@@ -116,11 +109,11 @@ static ElideResult buildWindowElide(const QString &text, int keepStart, int keep
 }
 
 ElideResult smartElideWithTracking(const QString &text, int maxWidth,
-                                   const QFontMetrics &fm,
+                                   const QFontMetricsF &fm,
                                    const QVector<MatchRange> &matchRanges)
 {
     const QString ellipsis = QStringLiteral("…");
-    int ellipsisWidth = charWidth(fm, QChar(0x2026));
+    double ellipsisWidth = charWidth(fm, QChar(0x2026));
 
     if (textWidth(fm, text) <= maxWidth) {
         ElideResult result;
@@ -152,9 +145,9 @@ ElideResult smartElideWithTracking(const QString &text, int maxWidth,
         bool needLeft = (keepStart > 0);
         bool needRight = (keepEnd < text.length());
         int numEllipsis = (needLeft ? 1 : 0) + (needRight ? 1 : 0);
-        int budget = maxWidth - numEllipsis * ellipsisWidth;
+        double budget = maxWidth - numEllipsis * ellipsisWidth;
 
-        int keptWidth = textWidth(fm, text.mid(keepStart, keepEnd - keepStart));
+        double keptWidth = textWidth(fm, text.mid(keepStart, keepEnd - keepStart));
         if (keptWidth > budget)
             break;
 
@@ -163,20 +156,20 @@ ElideResult smartElideWithTracking(const QString &text, int maxWidth,
 
         bool expanded = false;
         if (keepStart > 0) {
-            int cw = charWidth(fm, text[keepStart - 1]);
+            double cw = charWidth(fm, text[keepStart - 1]);
             int newNeedLeft = (keepStart - 1 > 0);
             int newNumEllipsis = (newNeedLeft ? 1 : 0) + (needRight ? 1 : 0);
-            int newBudget = maxWidth - newNumEllipsis * ellipsisWidth;
+            double newBudget = maxWidth - newNumEllipsis * ellipsisWidth;
             if (keptWidth + cw <= newBudget) {
                 --keepStart;
                 expanded = true;
             }
         }
         if (!expanded && keepEnd < text.length()) {
-            int cw = charWidth(fm, text[keepEnd]);
+            double cw = charWidth(fm, text[keepEnd]);
             int newNeedRight = (keepEnd + 1 < text.length());
             int newNumEllipsis = (needLeft ? 1 : 0) + (newNeedRight ? 1 : 0);
-            int newBudget = maxWidth - newNumEllipsis * ellipsisWidth;
+            double newBudget = maxWidth - newNumEllipsis * ellipsisWidth;
             if (keptWidth + cw <= newBudget) {
                 ++keepEnd;
                 expanded = true;
@@ -190,14 +183,14 @@ ElideResult smartElideWithTracking(const QString &text, int maxWidth,
 }
 
 ElideResult elideWithTracking(const QString &text, Qt::TextElideMode mode,
-                              int maxWidth, const QFontMetrics &fm)
+                              int maxWidth, const QFontMetricsF &fm)
 {
     ElideResult result;
     if (text.isEmpty())
         return result;
 
     const QString ellipsis = QStringLiteral("…");
-    int ellipsisWidth = charWidth(fm, QChar(0x2026));
+    double ellipsisWidth = charWidth(fm, QChar(0x2026));
 
     if (textWidth(fm, text) <= maxWidth) {
         result.text = text;
@@ -213,14 +206,14 @@ ElideResult elideWithTracking(const QString &text, Qt::TextElideMode mode,
         return result;
     }
 
-    int availWidth = maxWidth - ellipsisWidth;
+    double availWidth = maxWidth - ellipsisWidth;
 
     switch (mode) {
     case Qt::ElideRight: {
-        int w = 0;
+        double w = 0;
         int keep = 0;
         for (int i = 0; i < text.length(); ++i) {
-            int cw = charWidth(fm, text[i]);
+            double cw = charWidth(fm, text[i]);
             if (w + cw > availWidth)
                 break;
             w += cw;
@@ -241,7 +234,7 @@ ElideResult elideWithTracking(const QString &text, Qt::TextElideMode mode,
             int tail = tryChars - head;
             if (head < 0 || tail < 0 || head + tail > total)
                 continue;
-            int w = textWidth(fm, text.left(head)) + textWidth(fm, text.right(tail));
+            double w = textWidth(fm, text.left(head)) + textWidth(fm, text.right(tail));
             if (w <= availWidth) {
                 bestKeep = tryChars;
                 break;
@@ -264,10 +257,10 @@ ElideResult elideWithTracking(const QString &text, Qt::TextElideMode mode,
         break;
     }
     case Qt::ElideLeft: {
-        int w = 0;
+        double w = 0;
         int keep = 0;
         for (int i = text.length() - 1; i >= 0; --i) {
-            int cw = charWidth(fm, text[i]);
+            double cw = charWidth(fm, text[i]);
             if (w + cw > availWidth)
                 break;
             w += cw;
@@ -293,11 +286,11 @@ ElideResult elideWithTracking(const QString &text, Qt::TextElideMode mode,
 }
 
 QVector<QTextLayout::FormatRange> buildFormatRanges(
-    const QString &displayText,
-    const QVector<int> &origPosMapping,
-    const QString &originalText,
-    const QStringList &keywords,
-    const QTextCharFormat &format)
+        const QString &displayText,
+        const QVector<int> &origPosMapping,
+        const QString &originalText,
+        const QStringList &keywords,
+        const QTextCharFormat &format)
 {
     QVector<QTextLayout::FormatRange> ranges;
 
@@ -371,74 +364,6 @@ QTextCharFormat defaultHighlightFormat(const QFont &baseFont, const QPalette &pa
     fmt.setFontWeight(QFont::DemiBold);
     fmt.setForeground(palette.color(QPalette::BrightText));
     return fmt;
-}
-
-void drawHighlightedText(QPainter *painter, const QString &text,
-                         const QStringList &keywords,
-                         const QFont &font, const QColor &textColor,
-                         const QColor &highlightColor,
-                         const QRect &rect, Qt::Alignment alignment)
-{
-    if (text.isEmpty())
-        return;
-
-    QFontMetrics fm(font);
-    int maxWidth = rect.width();
-
-    // Elide
-    QVector<MatchRange> matchRanges = findMatchRanges(text, keywords);
-    ElideResult elideResult;
-
-    if (!matchRanges.isEmpty()) {
-        elideResult = smartElideWithTracking(text, maxWidth, fm, matchRanges);
-    }
-    if (elideResult.text.isEmpty()) {
-        elideResult = elideWithTracking(text, Qt::ElideRight, maxWidth, fm);
-    }
-
-    const QString &displayText = elideResult.text;
-    const QVector<int> &origPosMapping = elideResult.origPositions;
-
-    // Build format ranges for keywords
-    QVector<QTextLayout::FormatRange> formats;
-    if (!keywords.isEmpty()) {
-        QTextCharFormat fmt;
-        fmt.setFont(font);
-        fmt.setFontWeight(QFont::DemiBold);
-        fmt.setForeground(highlightColor);
-
-        // Create a temporary palette with our desired highlight color
-        QPalette tempPalette;
-        tempPalette.setColor(QPalette::BrightText, highlightColor);
-
-        formats = buildFormatRanges(displayText, origPosMapping, text, keywords, fmt);
-    }
-
-    // Setup QTextLayout
-    QTextLayout layout;
-    layout.setText(displayText);
-    layout.setFont(font);
-    layout.setFormats(formats);
-
-    layout.beginLayout();
-    QTextLine line = layout.createLine();
-    if (line.isValid())
-        line.setLineWidth(maxWidth);
-    layout.endLayout();
-
-    // Vertical alignment
-    int textHeight = fm.height();
-    int y = rect.y();
-    if (alignment & Qt::AlignVCenter)
-        y += (rect.height() - textHeight) / 2;
-    else if (alignment & Qt::AlignBottom)
-        y += rect.height() - textHeight;
-
-    painter->save();
-    painter->setPen(textColor);
-    painter->translate(rect.x(), y);
-    layout.draw(painter, QPointF(0, 0));
-    painter->restore();
 }
 
 }   // namespace HighlightUtils

--- a/src/global/widgets/highlightutils.h
+++ b/src/global/widgets/highlightutils.h
@@ -5,7 +5,7 @@
 #ifndef HIGHLIGHTUTILS_H
 #define HIGHLIGHTUTILS_H
 
-#include <QFontMetrics>
+#include <QFontMetricsF>
 #include <QTextLayout>
 #include <QString>
 #include <QStringList>
@@ -15,12 +15,14 @@ class QTextCharFormat;
 
 namespace HighlightUtils {
 
-struct MatchRange {
+struct MatchRange
+{
     int start;
     int end;   // exclusive
 };
 
-struct ElideResult {
+struct ElideResult
+{
     QString text;
     QVector<int> origPositions;   // text[i] -> original char position, -1 for ellipsis char
 };
@@ -30,33 +32,25 @@ QVector<MatchRange> findMatchRanges(const QString &text, const QStringList &keyw
 
 // Standard elide with position tracking
 ElideResult elideWithTracking(const QString &text, Qt::TextElideMode mode,
-                              int maxWidth, const QFontMetrics &fm);
+                              int maxWidth, const QFontMetricsF &fm);
 
 // Smart elide that keeps keyword matches visible
 ElideResult smartElideWithTracking(const QString &text, int maxWidth,
-                                   const QFontMetrics &fm,
+                                   const QFontMetricsF &fm,
                                    const QVector<MatchRange> &matchRanges);
 
 // Build QTextLayout format ranges for keyword highlighting
 // If origPosMapping is empty, matches are found directly in displayText
 // Otherwise, matches are found in originalText and mapped to display positions via origPosMapping
 QVector<QTextLayout::FormatRange> buildFormatRanges(
-    const QString &displayText,
-    const QVector<int> &origPosMapping,
-    const QString &originalText,
-    const QStringList &keywords,
-    const QTextCharFormat &format);
+        const QString &displayText,
+        const QVector<int> &origPosMapping,
+        const QString &originalText,
+        const QStringList &keywords,
+        const QTextCharFormat &format);
 
 // Convenience: create a default highlight format (DemiBold + BrightText foreground)
 QTextCharFormat defaultHighlightFormat(const QFont &baseFont, const QPalette &palette);
-
-// Render a highlighted, elided text using QTextLayout at a given rect
-void drawHighlightedText(QPainter *painter, const QString &text,
-                         const QStringList &keywords,
-                         const QFont &font, const QColor &textColor,
-                         const QColor &highlightColor,
-                         const QRect &rect, Qt::Alignment alignment = Qt::AlignVCenter | Qt::AlignLeft);
-
 }   // namespace HighlightUtils
 
-#endif // HIGHLIGHTUTILS_H
+#endif   // HIGHLIGHTUTILS_H

--- a/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistdelegate.cpp
+++ b/src/grand-search/gui/exhibition/matchresult/listview/grandsearchlistdelegate.cpp
@@ -19,6 +19,7 @@
 #include <QAbstractTextDocumentLayout>
 #include <QApplication>
 #include <QToolTip>
+#include <QFontMetricsF>
 
 #define ListIconSize 24   // 列表图标大小
 #define ListRowWidth 740   // 列表行宽
@@ -304,59 +305,61 @@ void GrandSearchListDelegate::drawItemName(QPainter *painter, const QModelIndex 
     int textStartX = ItemDataSpacing + ListIconSize + ItemDataSpacing;
     int nameTextMaxWidth = option.rect.width() - textStartX;
 
-    QString elidedName = fontMetrics.elidedText(name, Qt::ElideRight, nameTextMaxWidth);
-    if (elidedName != name && GRANDSEARCH_CLASS_WEB_STATICTEXT == searcher) {
-        static const QString markStr = name.right(1);
-        static const int markWidth = fontMetrics.size(Qt::TextSingleLine, markStr).width();
-        nameTextMaxWidth -= markWidth;
-        elidedName = fontMetrics.elidedText(name.left(name.size() - 1), Qt::ElideRight, nameTextMaxWidth);
-        elidedName.append(markStr);
-    }
+    // 使用 QFontMetricsF 进行精确的字体宽度计算
+    QFontMetricsF fontMetricsF(fontMetrics);
 
-    QTextDocument nameDocument;
-    nameDocument.setDocumentMargin(0);
-    nameDocument.setPlainText(elidedName);
-    QTextCursor nameCursor(&nameDocument);
-
-    nameCursor.beginEditBlock();
-    nameCursor.select(QTextCursor::LineUnderCursor);
-    QTextCharFormat nameFmt;
-    nameFmt.setForeground(textColor);
-    nameFmt.setFont(font);
-    nameCursor.mergeCharFormat(nameFmt);
+    // 使用智能省略，确保高亮关键词优先显示
+    HighlightUtils::ElideResult elideResult;
 
     if (!keywords.isEmpty()) {
-        QTextCharFormat hlFmt;
-        hlFmt.setFontWeight(QFont::DemiBold);
-        hlFmt.setForeground(isDark ? QColor("#FFFFFF") : QColor("#000000"));
-        for (const QString &kw : keywords) {
-            if (kw.isEmpty()) continue;
-            QTextCursor searchCursor(&nameDocument);
-            while (!searchCursor.isNull() && !searchCursor.atEnd()) {
-                searchCursor = nameDocument.find(kw, searchCursor,
-                                                 QTextDocument::FindCaseSensitively);
-                if (!searchCursor.isNull())
-                    searchCursor.mergeCharFormat(hlFmt);
-            }
+        auto matchRanges = HighlightUtils::findMatchRanges(name, keywords);
+        if (!matchRanges.isEmpty()) {
+            elideResult = HighlightUtils::smartElideWithTracking(name, nameTextMaxWidth, fontMetricsF, matchRanges);
+        }
+    }
+    if (elideResult.text.isEmpty())
+        elideResult = HighlightUtils::elideWithTracking(name, Qt::ElideRight, nameTextMaxWidth, fontMetricsF);
+
+    QString displayText = elideResult.text;
+
+    // Web 搜索器特殊处理：保留末尾的标记字符
+    if (elideResult.text != name && GRANDSEARCH_CLASS_WEB_STATICTEXT == searcher) {
+        QString lastChar = name.right(1);
+        int lastCharWidth = static_cast<int>(fontMetricsF.horizontalAdvance(lastChar));
+        nameTextMaxWidth -= lastCharWidth;
+        if (nameTextMaxWidth > 0) {
+            elideResult = HighlightUtils::elideWithTracking(name.left(name.size() - 1), Qt::ElideRight, nameTextMaxWidth, fontMetricsF);
+            displayText = elideResult.text + lastChar;
         }
     }
 
-    nameCursor.clearSelection();
-    nameCursor.movePosition(QTextCursor::EndOfLine);
-    nameCursor.endEditBlock();
+    // 构建高亮格式（映射到省略后的文本位置）
+    QTextCharFormat hlFmt;
+    hlFmt.setFontWeight(QFont::DemiBold);
+    hlFmt.setForeground(isDark ? QColor("#FFFFFF") : QColor("#000000"));
+    auto formats = HighlightUtils::buildFormatRanges(
+            displayText, elideResult.origPositions, name, keywords, hlFmt);
 
-    QAbstractTextDocumentLayout::PaintContext paintContext;
+    // 使用 QTextLayout 绘制
+    QTextLayout layout;
+    layout.setText(displayText);
+    layout.setFont(font);
+    layout.setFormats(formats);
+    layout.beginLayout();
+    layout.createLine();
+    layout.endLayout();
+
     QRect drawRect(textStartX, startY, nameTextMaxWidth, fontMetrics.height());
 
     // 文件名被省略时，记录 tooltip 区域
-    if (elidedName != name) {
+    if (elideResult.text != name) {
         recordTooltipRegion(index.row(), drawRect, name);
     }
 
     painter->save();
-    painter->translate(drawRect.topLeft());
-    painter->setClipRect(drawRect.translated(-drawRect.topLeft()));
-    nameDocument.documentLayout()->draw(painter, paintContext);
+    painter->translate(textStartX, startY);
+    painter->setPen(textColor);
+    layout.draw(painter, QPointF(0, 0));
     painter->restore();
 }
 
@@ -369,6 +372,9 @@ void GrandSearchListDelegate::drawMatchedContext(QPainter *painter, const QModel
         startX = ItemDataSpacing + ListIconSize + ItemDataSpacing;
     int maxWidth = option.rect.width() - startX;
 
+    // 使用 QFontMetricsF 进行精确的字体宽度计算
+    QFontMetricsF fontMetricsF(fontMetrics);
+
     QColor textColor = isDark ? QColor(255, 255, 255, int(255 * 0.5)) : QColor(0, 0, 0, int(255 * 0.5));
     QColor highlightColor = isDark ? QColor(255, 255, 255, int(255 * 0.8)) : QColor(0, 0, 0, int(255 * 0.85));
 
@@ -380,9 +386,9 @@ void GrandSearchListDelegate::drawMatchedContext(QPainter *painter, const QModel
 
     HighlightUtils::ElideResult elideResult;
     if (!leftmostOnly.isEmpty())
-        elideResult = HighlightUtils::smartElideWithTracking(matchedContext, maxWidth, fontMetrics, leftmostOnly);
+        elideResult = HighlightUtils::smartElideWithTracking(matchedContext, maxWidth, fontMetricsF, leftmostOnly);
     if (elideResult.text.isEmpty())
-        elideResult = HighlightUtils::elideWithTracking(matchedContext, Qt::ElideRight, maxWidth, fontMetrics);
+        elideResult = HighlightUtils::elideWithTracking(matchedContext, Qt::ElideRight, maxWidth, fontMetricsF);
 
     // 构建高亮格式
     QTextCharFormat hlFmt;
@@ -398,9 +404,7 @@ void GrandSearchListDelegate::drawMatchedContext(QPainter *painter, const QModel
     layout.setFont(font);
     layout.setFormats(formats);
     layout.beginLayout();
-    QTextLine line = layout.createLine();
-    if (line.isValid())
-        line.setLineWidth(maxWidth);
+    layout.createLine();
     layout.endLayout();
 
     painter->save();


### PR DESCRIPTION
1. Migrate from QFontMetrics to QFontMetricsF for higher precision in
width calculations, removing Qt5 compatibility code.
2. Remove the unused `drawHighlightedText` function from HighlightUtils,
as the delegate now directly uses `smartElideWithTracking` and
`buildFormatRanges`.
3. Refactor GrandSearchListDelegate to use HighlightUtils for text
elision and highlighting with position tracking, replacing old
QTextDocument-based approach.
4. This ensures consistent handling of font metrics across different
scaling factors and improves keyword visibility during elision.

Log: Optimized text elision and highlighting algorithm for more accurate
width calculations.

Influence:
1. Verify that list item names and matched context text are displayed
correctly with proper truncation and ellipsis.
2. Test keyword highlighting: ensure matched keywords remain visible
after text truncation.
3. Test with various font sizes and DPI scaling to confirm width
calculation accuracy.
4. Verify that the web searcher special marker character (e.g., last
character) is preserved during truncation.
5. Test dark/light theme to ensure highlight colors remain appropriate.
6. Verify that no crash or regression occurs when keywords are empty or
text is very short.

refactor: 使用 QFontMetricsF 替换 QFontMetrics，统一文本省略逻辑

1. 将宽度计算从 QFontMetrics 迁移到 QFontMetricsF，以获得更高精度，并移
除 Qt5 兼容代码。
2. 移除 HighlightUtils 中未使用的 `drawHighlightedText` 函数，因为代理现
在直接使用 `smartElideWithTracking` 和 `buildFormatRanges`。
3. 重构 GrandSearchListDelegate，使用 HighlightUtils 进行带有位置追踪的
文本省略和高亮，替换旧的基于 QTextDocument 的方法。
4. 确保在不同缩放因子下字体度量处理的统一，并提高省略时关键词的可见性。

Log: 优化文本省略和高亮算法，使得宽度计算更精确。

Influence:
1. 验证列表项名称和匹配上下文文本显示是否正确，包括正确的截断和省略号。
2. 测试关键词高亮：确保省略后匹配的关键词仍然可见。
3. 在不同字体大小和 DPI 缩放下测试，确认宽度计算准确性。
4. 验证 Web 搜索器特殊标记字符（如最后一个字符）在截断时被保留。
5. 测试暗色/亮色主题，确保高亮颜色正确。
6. 验证当关键词为空或文本很短时不会出现崩溃或回归问题。

BUG: https://pms.uniontech.com/bug-view-365101.html BUG: https://pms.uniontech.com/bug-view-365311.html
