### PR TITLE
fix: optimize search text change handling to avoid redundant operations

### DIFF
--- a/src/grand-search/business/query/querycontroller.cpp
+++ b/src/grand-search/business/query/querycontroller.cpp
@@ -102,13 +102,8 @@ void QueryController::onSearchTextChanged(const QString &txt)
     QString normalizedText = txt;
     normalizedText.replace('\n', ' ').replace('\r', ' ');
 
-    // 如果文本没有变化，直接返回
-    if (normalizedText == d_p->m_searchText && normalizedText == d_p->m_pendingSearchText)
-        return;
-
     // 停止已有的定时器
     d_p->m_debounceTimer->stop();
-
     if (normalizedText.isEmpty()) {
         // 停止搜索相关的所有活动
         onTerminateSearch();
@@ -123,6 +118,10 @@ void QueryController::onSearchTextChanged(const QString &txt)
 
         return;
     }
+
+    // 如果文本没有变化（与当前搜索文本相同），直接返回
+    if (normalizedText == d_p->m_searchText)
+        return;
 
     // 存储待处理的搜索文本
     d_p->m_pendingSearchText = normalizedText;

--- a/src/grand-search/gui/entrance/entrancewidget.cpp
+++ b/src/grand-search/gui/entrance/entrancewidget.cpp
@@ -74,7 +74,11 @@ void EntranceWidget::initConnections()
     Q_ASSERT(d_p->m_searchEdit);
 
     connect(d_p->m_searchEdit, &SearchEdit::debouncedTextChanged, this, &EntranceWidget::searchTextChanged);
-    connect(d_p->m_searchEdit, &SearchEdit::debouncedTextChanged, this, [this](const QString &) {
+    connect(d_p->m_searchEdit, &SearchEdit::debouncedTextChanged, this, [this](const QString &text) {
+        if (text == d_p->m_currentSearchText)
+            return;
+
+        d_p->m_currentSearchText = text;
         MatchedItem item;
         onAppIconChanged(QString(), item);
     });

--- a/src/grand-search/gui/entrance/entrancewidget_p.h
+++ b/src/grand-search/gui/entrance/entrancewidget_p.h
@@ -25,6 +25,7 @@ public:
     QHBoxLayout *m_mainLayout = nullptr;
 
     QString m_appIconName;
+    QString m_currentSearchText;
 };
 
 }


### PR DESCRIPTION
1. Remove early return condition that checked both current and pending
search text in QueryController
2. After handling empty and whitespace-only text, only skip if text
matches current search text
3. In EntranceWidget, skip resetting app icon if search text hasn't
changed
4. Add m_currentSearchText member to track the last processed search
text

Log: No user-facing changes.

Influence:
1. Test search with rapid typing and ensure no missing or duplicate
searches
2. Verify that clearing the search box resets results correctly
3. Check that app icon does not flicker when typing the same text again
4. Ensure pending search text is still properly queued for debounce
5. Test with special characters, whitespace, and long strings
6. Verify no regression in search responsiveness or accuracy

fix: 优化搜索文本变化处理，避免冗余操作

1. 移除 QueryController 中同时检查当前搜索文本和待处理搜索文本的提前返回
条件
2. 在处理空文本和纯空白文本后，仅当文本与当前搜索文本相同时才跳过
3. 在 EntranceWidget 中，如果搜索文本未变化则跳过重置应用图标
4. 添加 m_currentSearchText 成员变量以跟踪上次处理的搜索文本

Influence:
1. 测试快速输入时是否出现搜索缺失或重复
2. 验证清空搜索框后结果是否正确重置
3. 确认输入相同文本时应用图标不会闪烁
4. 确保待处理搜索文本仍能正确排队进行防抖处理
5. 测试特殊字符、空白字符和长字符串
6. 验证搜索响应速度和准确性没有退化
