### PR TITLE
fix(icon): install app icon into bloom theme to fix manual app list icon

### DIFF
--- a/src/grand-search/CMakeLists.txt
+++ b/src/grand-search/CMakeLists.txt
@@ -305,3 +305,14 @@ install(DIRECTORY ${CMAKE_SOURCE_DIR}/assets/manual/dde-grand-search
 
 # desktop
 install(FILES dde-grand-search.desktop DESTINATION share/applications)
+
+# app icon into the icon theme so that dde-manual's app list (and other theme
+# icon lookups) can resolve "dde-grand-search".
+# bloom is the UOS default theme and the one deepin-manual actually loads icons
+# from (its Inherits=Papirus does not fall back to hicolor), so install there to
+# match how dde/dde-file-manager ship their icons. hicolor is kept as the generic
+# fallback for other themes/environments.
+install(FILES ${CMAKE_SOURCE_DIR}/assets/manual/dde-grand-search/grand-search/common/dde-grand-search.svg
+    DESTINATION share/icons/bloom/apps/96)
+install(FILES ${CMAKE_SOURCE_DIR}/assets/manual/dde-grand-search/grand-search/common/dde-grand-search.svg
+    DESTINATION share/icons/hicolor/scalable/apps)


### PR DESCRIPTION
- Install the dde-grand-search app icon into bloom/apps/96, the UOS default theme that deepin-manual loads icons from, matching how dde/dde-file-manager ship their icons
- Keep installing the icon into hicolor/scalable/apps as a generic fallback for other themes/environments

修复(图标): 将应用图标安装到 bloom 主题，修复帮助手册应用列表图标显示异常

- 将全局搜索应用图标安装到 bloom/apps/96，即 deepin-manual 实际加载图标的 UOS 默认主题，与 dde、dde-file-manager 的图标安装方式保持一致
- 同时保留将图标安装到 hicolor/scalable/apps，作为其它主题/环境的通用兜底

Log: 修复帮助手册首页全局搜索应用图标显示异常。原应用图标仅安装在 hicolor，而 deepin-manual 在 bloom 主题下加载图标（bloom 的 Inherits 为 Papirus，不回退 hicolor）导致加载失败，现将图标同时安装到 bloom/apps/96 与 hicolor/scalable/apps
Bug: https://pms.uniontech.com/bug-view-365721.html

## Summary by Sourcery

Install the dde-grand-search application icon into the Bloom icon theme while retaining the existing hicolor fallback to ensure the icon resolves correctly in deepin-manual and other environments.

Bug Fixes:
- Ensure the dde-grand-search app icon is visible in deepin-manual by installing it into the Bloom theme used for icon lookup.

Enhancements:
- Align dde-grand-search icon installation paths with other Deepin applications by installing into Bloom and keeping hicolor as a generic fallback.