### PR TITLE
fix(quick-panel): add hover opacity effect

### DIFF
--- a/src/grand-search-dock-plugin/gui/grandsearchwidget.cpp
+++ b/src/grand-search-dock-plugin/gui/grandsearchwidget.cpp
@@ -22,6 +22,7 @@
 #include <QDebug>
 #include <QVBoxLayout>
 #include <QLoggingCategory>
+#include <QGraphicsOpacityEffect>
 
 Q_DECLARE_LOGGING_CATEGORY(logDock)
 
@@ -230,6 +231,10 @@ QuickPanel::QuickPanel(const QString &desc, QWidget *parent)
 
     setLayout(lay);
 
+    QGraphicsOpacityEffect *effect = new QGraphicsOpacityEffect(this);
+    effect->setOpacity(kOpacityNormal);
+    setGraphicsEffect(effect);
+
     updateIcon();
 
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, &QuickPanel::updateIcon);
@@ -245,4 +250,28 @@ void QuickPanel::updateIcon()
     iconLabel->setPixmap(pixmap);
 
     update();
+}
+
+void QuickPanel::updateOpacity()
+{
+    if (auto *effect = qobject_cast<QGraphicsOpacityEffect *>(graphicsEffect()))
+        effect->setOpacity(m_hover ? kOpacityHover : kOpacityNormal);
+}
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+void QuickPanel::enterEvent(QEvent *event)
+#else
+void QuickPanel::enterEvent(QEnterEvent *event)
+#endif
+{
+    m_hover = true;
+    updateOpacity();
+    QWidget::enterEvent(event);
+}
+
+void QuickPanel::leaveEvent(QEvent *event)
+{
+    m_hover = false;
+    updateOpacity();
+    QWidget::leaveEvent(event);
 }

--- a/src/grand-search-dock-plugin/gui/grandsearchwidget.h
+++ b/src/grand-search-dock-plugin/gui/grandsearchwidget.h
@@ -52,8 +52,22 @@ public:
 public slots:
     void updateIcon();
 
+protected:
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    void enterEvent(QEnterEvent *event) override;
+#else
+    void enterEvent(QEvent *event) override;
+#endif
+    void leaveEvent(QEvent *event) override;
+
 private:
+    void updateOpacity();
+
+    static constexpr qreal kOpacityNormal = 0.7;
+    static constexpr qreal kOpacityHover = 1.0;
+
     DTK_WIDGET_NAMESPACE::DLabel *iconLabel = nullptr;
+    bool m_hover = false;
 };
 }
 


### PR DESCRIPTION
1. Add QGraphicsOpacityEffect to QuickPanel for opacity control
2. Implement enterEvent/leaveEvent with Qt5/Qt6 compatibility
3. Add updateOpacity() to adjust opacity on hover state
4. Define opacity constants (normal=0.7, hover=1.0)

Log: Add hover visual feedback for QuickPanel via opacity effect

fix(quick-panel): 添加鼠标悬浮透明度效果

1. 为 QuickPanel 添加 QGraphicsOpacityEffect 以控制透明度
2. 实现 enterEvent/leaveEvent 并兼容 Qt5/Qt6
3. 新增 updateOpacity() 根据悬浮状态调整透明度
4. 定义透明度常量（普通 0.7，悬浮 1.0）

Log: 为 QuickPanel 添加鼠标悬浮时的透明度视觉反馈
PMS: BUG-314503