### PR TITLE
fix: fix app icon scaling on high DPI displays

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-grand-search (6.0.39) unstable; urgency=medium
+
+  * fix: fix app icon scaling on high DPI displays
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Wed, 24 Jun 2026 13:56:27 +0800
+
 dde-grand-search (6.0.38) unstable; urgency=medium
 
   * fix: update French translations for grand search UI

--- a/src/grand-search/gui/entrance/searchedit.cpp
+++ b/src/grand-search/gui/entrance/searchedit.cpp
@@ -309,10 +309,7 @@ void SearchEdit::setAppIcon(const QString &iconName)
         return;
 
     d->m_appIconName = iconName;
-    auto pixmap = QIcon::fromTheme(iconName).pixmap(AppIconSize);
-    pixmap.setDevicePixelRatio(qApp->devicePixelRatio());
-    d->m_appIconLabel->setPixmap(pixmap);
-    setAppIconVisible(true);
+    setAppIcon(QIcon::fromTheme(iconName));
 }
 
 void SearchEdit::setAppIcon(const QIcon &icon)
@@ -323,8 +320,9 @@ void SearchEdit::setAppIcon(const QIcon &icon)
         return;
     }
 
-    auto pixmap = icon.pixmap(AppIconSize);
-    pixmap.setDevicePixelRatio(qApp->devicePixelRatio());
+    auto iconSize = QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps) ? AppIconSize : (AppIconSize * devicePixelRatioF());
+    auto pixmap = icon.pixmap(iconSize);
+    pixmap.setDevicePixelRatio(devicePixelRatioF());
     d->m_appIconLabel->setPixmap(pixmap);
     setAppIconVisible(true);
 }


### PR DESCRIPTION
Refactored `setAppIcon` methods in SearchEdit to correctly handle
high DPI scaling. The `setAppIcon(QString)` overload now delegates
to `setAppIcon(QIcon)` instead of manually scaling, eliminating
duplicate logic. The `setAppIcon(QIcon)` method now checks
`Qt::AA_UseHighDpiPixmaps` attribute: if enabled, it uses `AppIconSize`
directly (since Qt will handle DPI scaling); otherwise, it multiplies
the size by `devicePixelRatioF()` to produce a sharp pixmap at the
native resolution. The pixmap device pixel ratio is set to the widget's
ratio, ensuring proper rendering on mixed DPI setups.

Log: Improved app icon display quality on high DPI screens

Influence:
1. Test with display scaling factors 100%, 125%, 150%, 200% and verify
icon sharpness
2. Test with `AA_UseHighDpiPixmaps` both enabled and disabled (e.g., via
Qt environment variables)
3. Verify that icons in search results appear crisp on all DPI settings
4. Regression test: ensure icons still display correctly on standard (96
DPI) screens
5. Verify that custom icon themes (e.g., from `setAppIcon` with QIcon)
also benefit from the fix

fix: 修复高 DPI 下应用图标缩放问题

重构 SearchEdit 中的 `setAppIcon` 方法以正确处理高 DPI 缩放。
`setAppIcon(QString)` 重载现在委托给 `setAppIcon(QIcon)`，避免重复逻
辑。`setAppIcon(QIcon)` 方法根据 `Qt::AA_UseHighDpiPixmaps` 属性决定：
若启用，则直接使用 `AppIconSize`（Qt 会处理 DPI 缩放）；否则将尺寸乘以
`devicePixelRatioF()` 以生成原生分辨率下的清晰像素图。像素图的设备像素比
设置为控件的比例，确保在混合 DPI 环境下正确渲染。

Log: 改进高 DPI 屏幕下的应用图标显示质量

Influence:
1. 在不同缩放比例（100%、125%、150%、200%）下测试，验证图标清晰度
2. 分别测试 `AA_UseHighDpiPixmaps` 启用和禁用的情况（可通过 Qt 环境变量
控制）
3. 验证搜索结果显示的图标在所有 DPI 设置下是否清晰
4. 回归测试：确保图标在标准 DPI（96 DPI）屏幕上仍正常显示
5. 验证通过 `setAppIcon(QIcon)` 设置的自定义图标主题也能受益于该修复

BUG: https://pms.uniontech.com/bug-view-367201.html
