### PR TITLE
feat: refine semantic search activation and auth prompt logic

### DIFF
--- a/src/dde-grand-search-daemon/searcher/ocr/ocrtextsearcher.cpp
+++ b/src/dde-grand-search-daemon/searcher/ocr/ocrtextsearcher.cpp
@@ -33,6 +33,9 @@ bool OcrTextSearcher::isActive() const
 {
     // Check if OCR search is enabled via DConfig
     DConfig *dcfg = DConfig::create("org.deepin.dde.file-manager", "org.deepin.dde.file-manager.search");
+    if (!dcfg)
+        return false;
+
     bool enabled = dcfg->value("enableOcrTextSearch").toBool() && DFMSEARCH::Global::isOcrTextIndexAvailable();
     delete dcfg;
 

--- a/src/dde-grand-search-daemon/searcher/semantic/semanticsearcher.cpp
+++ b/src/dde-grand-search-daemon/searcher/semantic/semanticsearcher.cpp
@@ -9,11 +9,14 @@
 
 #include <dfm-search/dsearch_global.h>
 
+#include <DConfig>
+
 #include <QLoggingCategory>
 
 Q_DECLARE_LOGGING_CATEGORY(logDaemon)
 
 DFM_SEARCH_USE_NS
+DCORE_USE_NAMESPACE
 
 using namespace GrandSearch;
 
@@ -30,8 +33,16 @@ QString SemanticSearcher::name() const
 
 bool SemanticSearcher::isActive() const
 {
-    if (!Global::isFileNameIndexReadyForSearch()) {
-        qCDebug(logDaemon) << "SemanticSearcher inactive: filename index not ready";
+    DConfig *dcfg = DConfig::create("org.deepin.dde.file-manager", "org.deepin.dde.file-manager.search");
+    if (!dcfg) {
+        qCDebug(logDaemon) << "SemanticSearcher inactive: failed to create DConfig";
+        return false;
+    }
+
+    bool enabled = dcfg->value("enableFileIndexSearch").toBool() && DFMSEARCH::Global::isFileNameIndexReadyForSearch();
+    delete dcfg;
+    if (!enabled) {
+        qCDebug(logDaemon) << "SemanticSearcher inactive: file index search not enabled or index not ready";
         return false;
     }
 

--- a/src/grand-search/gui/exhibition/matchresult/authpromptwidget.cpp
+++ b/src/grand-search/gui/exhibition/matchresult/authpromptwidget.cpp
@@ -6,15 +6,20 @@
 #include "gui/iconbutton.h"
 #include "business/config/searchconfig.h"
 #include "global/searchconfigdefine.h"
+#include "utils/utils.h"
 
 #include <dfm-search/dsearch_global.h>
 
 #include <DConfig>
 #include <DDciIcon>
 #include <DFontSizeManager>
+#include <DHorizontalLine>
 
 #include <QFontMetrics>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QLoggingCategory>
+#include <QScopedPointer>
 
 Q_DECLARE_LOGGING_CATEGORY(logGrandSearch)
 
@@ -27,6 +32,7 @@ inline constexpr char kSearchCfgPath[] { "org.deepin.dde.file-manager.search" };
 inline constexpr char kEnableFileIndexSearch[] { "enableFileIndexSearch" };
 inline constexpr char kEnableFullTextSearch[] { "enableFullTextSearch" };
 inline constexpr char kEnableOcrTextSearch[] { "enableOcrTextSearch" };
+inline constexpr char kSearchSettingGroup[] { "10_advance.00_search" };
 inline constexpr int kMargin { 20 };
 
 AuthPromptWidget::AuthPromptWidget(QWidget *parent)
@@ -41,27 +47,6 @@ AuthPromptWidget::~AuthPromptWidget()
 {
 }
 
-QStringList AuthPromptWidget::checkUnavailableFeatures()
-{
-    QStringList features;
-
-    // 全文搜索索引
-    if (!contentSearchAvailable())
-        features << tr("full-text search");
-
-    // 图片文本内容搜索（OCR）索引
-    if (!ocrTextSearchAvailable())
-        features << tr("image text content search");
-
-    // 智能搜索
-    if (!semanticSearchAvailable())
-        features << tr("smart search");
-
-    qCDebug(logGrandSearch) << "Unavailable features:" << features;
-
-    return features;
-}
-
 void AuthPromptWidget::updatePromptContent()
 {
     // 用户已关闭过，不再显示
@@ -71,100 +56,82 @@ void AuthPromptWidget::updatePromptContent()
         return;
     }
 
-    // 检查索引可用性
-    QStringList unavailable = checkUnavailableFeatures();
-    if (unavailable.isEmpty()) {
+    QStringList disabledModes = disabledSearchModes();
+    if (disabledModes.isEmpty()) {
         hide();
         return;
     }
 
-    // 构建功能列表文本（中文引号包裹，逗号分隔）
-    QStringList quoted;
-    for (const QString &f : unavailable)
-        quoted << QString("\"%1\"").arg(f);
-    m_featuresText = quoted.join(tr(", "));
-
+    // 构建功能列表文本
+    m_featuresText = QLocale().createSeparatedList(disabledModes);
     show();
+}
+
+// 创建文件管理器搜索 DConfig，失败时返回 nullptr 并记录日志
+static QScopedPointer<DConfig> createSearchDConfig()
+{
+    DConfig *raw = DConfig::create(kCfgAppId, kSearchCfgPath);
+    if (!raw)
+        qCWarning(logGrandSearch) << "Failed to create DConfig for file manager search";
+    return QScopedPointer<DConfig>(raw);
 }
 
 void AuthPromptWidget::enableSearchindexes()
 {
-    DConfig *dcfg = DConfig::create(kCfgAppId, kSearchCfgPath);
-    if (!dcfg) {
-        qCWarning(logGrandSearch) << "Failed to create DConfig for file manager search";
+    auto dcfg = createSearchDConfig();
+    if (!dcfg)
         return;
-    }
 
-    bool enabled = dcfg->value(kEnableFileIndexSearch, false).toBool();
-    if (!enabled) {
-        dcfg->setValue(kEnableFileIndexSearch, true);
-        qCDebug(logGrandSearch) << "Enabled file search index";
-    }
+    // 非智能搜索未开启时，需要进行通知
+    bool needNotified = !dcfg->value(kEnableFullTextSearch, false).toBool()
+            && !dcfg->value(kEnableOcrTextSearch, false).toBool();
 
-    enabled = dcfg->value(kEnableFullTextSearch, false).toBool();
-    if (!enabled) {
-        dcfg->setValue(kEnableFullTextSearch, true);
-        qCDebug(logGrandSearch) << "Enabled full-text search index";
-    }
+    dcfg->setValue(kEnableFileIndexSearch, true);
+    dcfg->setValue(kEnableFullTextSearch, true);
+    dcfg->setValue(kEnableOcrTextSearch, true);
 
-    enabled = dcfg->value(kEnableOcrTextSearch, false).toBool();
-    if (!enabled) {
-        dcfg->setValue(kEnableOcrTextSearch, true);
-        qCDebug(logGrandSearch) << "Enabled OCR text search index";
-    }
+    SearchConfig::instance()->setConfig(GRANDSEARCH_SEMANTIC_GROUP, GRANDSEARCH_SEMANTIC_ENABLED, true);
 
-    delete dcfg;
+    if (needNotified) {
+        const QStringList actions = { "view-index-status", tr("View index status") };
+        QJsonObject paramObj;
+        paramObj.insert("group", kSearchSettingGroup);
+        QJsonObject argsObj;
+        argsObj.insert("action", "settings");
+        argsObj.insert("params", paramObj);
+        const QStringList cmdShowSettings { "file-manager.sh",
+                                            "--event",
+                                            QJsonDocument(argsObj).toJson(QJsonDocument::Compact) };
+        QVariantMap hints = { { "x-deepin-action-view-index-status", cmdShowSettings } };
+        Utils::notifyMessage(tr("Smart search"),
+                             tr("Indexing is in progress. You can check the index status in file manager settings."),
+                             actions, hints);
+    }
 }
 
-bool AuthPromptWidget::contentSearchAvailable()
+QStringList AuthPromptWidget::disabledSearchModes()
 {
-    return false;
-    DConfig *dcfg = DConfig::create(kCfgAppId, kSearchCfgPath);
-    if (!dcfg) {
-        qCWarning(logGrandSearch) << "Failed to create DConfig for file manager search";
-        return false;
-    }
+    auto dcfg = createSearchDConfig();
+    if (!dcfg)
+        return {};
 
-    bool enabled = dcfg->value(kEnableFullTextSearch, false).toBool();
-    delete dcfg;
-    return enabled && DFMSEARCH::Global::isContentIndexAvailable();
-}
-
-bool AuthPromptWidget::ocrTextSearchAvailable()
-{
-    return false;
-    DConfig *dcfg = DConfig::create(kCfgAppId, kSearchCfgPath);
-    if (!dcfg) {
-        qCWarning(logGrandSearch) << "Failed to create DConfig for file manager search";
-        return false;
-    }
-
-    bool enabled = dcfg->value(kEnableOcrTextSearch, false).toBool();
-    delete dcfg;
-    return enabled && DFMSEARCH::Global::isOcrTextIndexAvailable();
-}
-
-bool AuthPromptWidget::semanticSearchAvailable()
-{
-    return false;
-    DConfig *dcfg = DConfig::create(kCfgAppId, kSearchCfgPath);
-    if (!dcfg) {
-        qCWarning(logGrandSearch) << "Failed to create DConfig for file manager search";
-        return false;
-    }
-
-    bool enabled = dcfg->value(kEnableFileIndexSearch, false).toBool();
-    delete dcfg;
-
+    QStringList modes;
+    if (!dcfg->value(kEnableFullTextSearch, false).toBool())
+        modes << tr("\"Full-Text search\"");
+    if (!dcfg->value(kEnableOcrTextSearch, false).toBool())
+        modes << tr("\"Image-Content search\"");
     bool cfgEnabled = SearchConfig::instance()->getConfig(GRANDSEARCH_SEMANTIC_GROUP, GRANDSEARCH_SEMANTIC_ENABLED, true).toBool();
-    return enabled && cfgEnabled && DFMSEARCH::Global::isFileNameIndexReadyForSearch();
+    if (!cfgEnabled || !dcfg->value(kEnableFileIndexSearch, false).toBool())
+        modes << tr("\"Smart search\"");
+
+    return modes;
 }
 
 void AuthPromptWidget::initUi()
 {
-    m_vLayout = new QVBoxLayout(this);
-    m_vLayout->setContentsMargins(kMargin, 0, kMargin, 0);
-    m_vLayout->setSpacing(10);
+    QVBoxLayout *vLayout = new QVBoxLayout(this);
+    vLayout->setContentsMargins(kMargin, 0, kMargin, 0);
+    vLayout->setSpacing(10);
 
     m_hLayout = new QHBoxLayout();
     m_hLayout->setContentsMargins(0, 0, 0, 0);
@@ -189,10 +156,10 @@ void AuthPromptWidget::initUi()
     m_hLayout->addWidget(m_closeButton, 0);
 
     // 底部分隔线
-    m_separator = new DHorizontalLine(this);
+    DHorizontalLine *separator = new DHorizontalLine(this);
 
-    m_vLayout->addLayout(m_hLayout);
-    m_vLayout->addWidget(m_separator);
+    vLayout->addLayout(m_hLayout);
+    vLayout->addWidget(separator);
 }
 
 void AuthPromptWidget::initConnect()
@@ -201,7 +168,6 @@ void AuthPromptWidget::initConnect()
     connect(m_contentLabel, &DLabel::linkActivated, this, [this](const QString &link) {
         if (link == QLatin1String("authorize")) {
             enableSearchindexes();
-            SearchConfig::instance()->setConfig(GRANDSEARCH_SEMANTIC_GROUP, GRANDSEARCH_SEMANTIC_ENABLED, true);
             hide();
         }
     });
@@ -221,7 +187,7 @@ QString AuthPromptWidget::buildElidedText(int availableWidth) const
 
     // 构建链接（始终完整显示，不省略）
     const auto &linkColor = palette().color(QPalette::Highlight);
-    const QString linkText = tr("Authorize with one click");
+    const QString linkText = tr("one-click authorization");
     const QString linkTag = QString("<a href=\"authorize\" style=\"color:%1; text-decoration: none;\">%2</a>")
                                     .arg(linkColor.name(), linkText);
 

--- a/src/grand-search/gui/exhibition/matchresult/authpromptwidget.h
+++ b/src/grand-search/gui/exhibition/matchresult/authpromptwidget.h
@@ -7,10 +7,8 @@
 
 #include <DWidget>
 #include <DLabel>
-#include <DHorizontalLine>
 
 #include <QHBoxLayout>
-#include <QVBoxLayout>
 
 namespace GrandSearch {
 
@@ -46,28 +44,18 @@ private:
     void adjustElidedText();
     void updatePromptContent();
     void enableSearchindexes();
-    bool contentSearchAvailable();
-    bool ocrTextSearchAvailable();
-    bool semanticSearchAvailable();
-
-    // 索引可用性检查
-    QStringList checkUnavailableFeatures();
+    QStringList disabledSearchModes();
 
     // 文本省略计算
     QString buildElidedText(int availableWidth) const;
 
 private:
-    // 布局
-    QVBoxLayout *m_vLayout = nullptr;
     QHBoxLayout *m_hLayout = nullptr;
     Dtk::Widget::DLabel *m_contentLabel = nullptr;
-    Dtk::Widget::DHorizontalLine *m_separator = nullptr;
     IconButton *m_closeButton = nullptr;
-
-    // 内容缓存
-    QString m_featuresText;  // 不可用功能列表文本
+    QString m_featuresText;   // 不可用功能列表文本
 };
 
 }
 
-#endif // AUTHPROMPTWIDGET_H
+#endif   // AUTHPROMPTWIDGET_H

--- a/src/grand-search/gui/searchconfig/semanticsearchwidget.cpp
+++ b/src/grand-search/gui/searchconfig/semanticsearchwidget.cpp
@@ -7,14 +7,20 @@
 #include "global/searchconfigdefine.h"
 #include "business/config/searchconfig.h"
 
+#include <DConfig>
+
 #include <QVBoxLayout>
 #include <QLoggingCategory>
 
 Q_DECLARE_LOGGING_CATEGORY(logGrandSearch)
 
 DWIDGET_USE_NAMESPACE
-
+DCORE_USE_NAMESPACE
 using namespace GrandSearch;
+
+inline constexpr char kCfgAppId[] { "org.deepin.dde.file-manager" };
+inline constexpr char kSearchCfgPath[] { "org.deepin.dde.file-manager.search" };
+inline constexpr char kEnableFileIndexSearch[] { "enableFileIndexSearch" };
 
 SemanticSearchWidget::SemanticSearchWidget(QWidget *parent)
     : DWidget(parent)
@@ -41,12 +47,15 @@ void SemanticSearchWidget::initUi()
     switchLayout->addWidget(groupLabel, 1);
     switchLayout->addWidget(m_switchBtn);
 
-    // 从配置加载初始状态
-    bool enabled = SearchConfig::instance()->getConfig(GRANDSEARCH_SEMANTIC_GROUP, GRANDSEARCH_SEMANTIC_ENABLED, true).toBool();
-    m_switchBtn->setChecked(enabled);
+    // 从配置加载初始状态：语义搜索开关需同时满足自身配置和文件索引 DConfig 开启
+    bool semanticEnabled = SearchConfig::instance()->getConfig(GRANDSEARCH_SEMANTIC_GROUP, GRANDSEARCH_SEMANTIC_ENABLED, true).toBool();
+    bool fileIndexEnabled = isFileIndexSearchEnabled();
+    m_switchBtn->setChecked(semanticEnabled && fileIndexEnabled);
 
     // 描述信息
-    TipsLabel *tipsLabel = new TipsLabel(tr("When enabled, natural language search is supported in grand search, e.g., \"PPT documents edited yesterday\""), this);
+    TipsLabel *tipsLabel = new TipsLabel(tr("When enabled, natural language search is supported in grand search, e.g., "
+                                            "\"PPT documents edited yesterday\".Using this feature requires "
+                                            "file indexing to be enabled."), this);
     tipsLabel->setWordWrap(true);
 
     mainLayout->addLayout(switchLayout);
@@ -62,4 +71,34 @@ void SemanticSearchWidget::onSwitchToggled(bool checked)
 {
     qCDebug(logGrandSearch) << "Smart search configuration changed - Enabled:" << checked;
     SearchConfig::instance()->setConfig(GRANDSEARCH_SEMANTIC_GROUP, GRANDSEARCH_SEMANTIC_ENABLED, checked);
+
+    // 开启智能搜索时需同时开启文件索引；关闭时不操作文件索引配置
+    if (checked) {
+        setFileIndexSearchEnabled(true);
+    }
+}
+
+bool SemanticSearchWidget::isFileIndexSearchEnabled() const
+{
+    DConfig *dcfg = DConfig::create(kCfgAppId, kSearchCfgPath);
+    if (!dcfg) {
+        qCWarning(logGrandSearch) << "Failed to create DConfig for file manager search";
+        return false;
+    }
+
+    bool enabled = dcfg->value(kEnableFileIndexSearch, false).toBool();
+    delete dcfg;
+    return enabled;
+}
+
+void SemanticSearchWidget::setFileIndexSearchEnabled(bool enabled)
+{
+    DConfig *dcfg = DConfig::create(kCfgAppId, kSearchCfgPath);
+    if (!dcfg) {
+        qCWarning(logGrandSearch) << "Failed to create DConfig for file manager search";
+        return;
+    }
+
+    dcfg->setValue(kEnableFileIndexSearch, enabled);
+    delete dcfg;
 }

--- a/src/grand-search/gui/searchconfig/semanticsearchwidget.h
+++ b/src/grand-search/gui/searchconfig/semanticsearchwidget.h
@@ -25,6 +25,8 @@ private slots:
 private:
     void initUi();
     void initConnect();
+    bool isFileIndexSearchEnabled() const;
+    void setFileIndexSearchEnabled(bool enabled);
 
 private:
     DTK_WIDGET_NAMESPACE::DSwitchButton *m_switchBtn = nullptr;

--- a/src/grand-search/utils/utils.cpp
+++ b/src/grand-search/utils/utils.cpp
@@ -24,6 +24,7 @@ extern "C" {
 #include <DDesktopServices>
 #include <DUtil>
 #include <DSysInfo>
+#include <DDBusSender>
 
 #include <QCollator>
 #include <QFileInfo>
@@ -1106,4 +1107,23 @@ bool Utils::isWayland()
     static bool wayland = QApplication::platformName() == "wayland";
 
     return wayland;
+}
+
+void Utils::notifyMessage(const QString &title, const QString &msg,
+                          const QStringList &actions, const QVariantMap &hints)
+{
+    DDBusSender()
+            .service("org.freedesktop.Notifications")
+            .path("/org/freedesktop/Notifications")
+            .interface("org.freedesktop.Notifications")
+            .method(QString("Notify"))
+            .arg(QObject::tr("dde-grand-search"))
+            .arg(static_cast<uint>(0))
+            .arg(QString("dde-grand-search"))
+            .arg(title)
+            .arg(msg)
+            .arg(actions)
+            .arg(hints)
+            .arg(5000)
+            .call();
 }

--- a/src/grand-search/utils/utils.h
+++ b/src/grand-search/utils/utils.h
@@ -117,6 +117,9 @@ public:
 
     static bool isWayland();
 
+    static void notifyMessage(const QString &title, const QString &msg,
+                              const QStringList &actions, const QVariantMap &hints);
+
 private:
     static QMap<QString, QString> m_appIconNameMap;// 存放应用desktop文件对应的图标名称，用于搜索框应用图标刷新
     static QMimeDatabase m_mimeDb;


### PR DESCRIPTION
1. SemanticSearcher now checks DConfig "enableFileIndexSearch" before
becoming active, requiring both file index config and index readiness.
2. AuthPromptWidget reworked: removed hardcoded false returns for
availability checks, unified into disableSearchModes(), and added
notification via DDBusSender when enabling search indexes.
3. SemanticSearchWidget toggle now synchronizes with file index DConfig;
enabling smart search also enables file index.
4. Layout members moved to local variables in AuthPromptWidget to reduce
class state.

Log: Improved semantic search activation conditions; replaced auth
prompt's hardcoded unavailable features with dynamic DConfig checks;
added notification when enabling search indexes.

Influence:
1. Verify that SemanticSearcher is active only when DConfig
enableFileIndexSearch is true and file name index is ready.
2. Test AuthPromptWidget with different combinations of search configs
(full-text, OCR, file index, smart search) to ensure correct disabled
modes are listed.
3. Check that enabling search indexes via the link triggers a desktop
notification with actions.
4. Test SemanticSearchWidget toggle: turning on smart search should
enable file index DConfig; turning off should not disable it.
5. Verify that the notification's "View index status" action opens file
manager settings correctly.
6. Confirm that the layout remains correct when resizing the auth prompt
widget.

feat: 优化智能搜索激活条件和授权提示逻辑

1. SemanticSearcher 现在需要检查 DConfig 配置 "enableFileIndexSearch" 为
true 且索引就绪才激活。
2. 重构 AuthPromptWidget：移除原先硬编码返回 false 的可用性检查，统一为
disableSearchModes()，并在启用搜索索引时通过 DDBusSender 发送通知。
3. SemanticSearchWidget 开关现在与文件索引 DConfig 同步：开启智能搜索时
自动启用文件索引。
4. 将 AuthPromptWidget 中的布局成员改为局部变量以减少类状态。

Log: 优化智能搜索激活条件；将授权提示中硬编码的不可用功能替换为动态
DConfig 检查；添加启用搜索索引时的通知功能。

Influence:
1. 验证 SemanticSearcher 仅在 DConfig enableFileIndexSearch 为 true 且文
件名索引就绪时激活。
2. 测试 AuthPromptWidget 在不同搜索配置组合（全文、OCR、文件索引、智能搜
索）下是否正确列出禁用模式。
3. 检查通过链接启用搜索索引后是否触发桌面通知，并包含操作按钮。
4. 测试 SemanticSearchWidget 开关：打开智能搜索应启用文件索引 DConfig，
关闭时不应禁用。
5. 验证通知中的“查看索引状态”操作能否正确打开文件管理器设置。
6. 确认调整授权提示窗口大小时布局正常。
