### PR TITLE
fix: adjust group icon size and title layout spacing

### DIFF
--- a/src/grand-search/gui/exhibition/matchresult/groupwidget.cpp
+++ b/src/grand-search/gui/exhibition/matchresult/groupwidget.cpp
@@ -328,7 +328,7 @@ void GroupWidget::initUi()
 
     // 组名图标
     m_groupIcon = new DIconButton(this);
-    m_groupIcon->setIconSize({ 18, 18 });
+    m_groupIcon->setIconSize({ 16, 16 });
     m_groupIcon->setFlat(true);
     m_groupIcon->setAttribute(Qt::WA_TransparentForMouseEvents);
     m_groupLabel->setContentsMargins(0, 5, 5, 5);
@@ -364,7 +364,7 @@ void GroupWidget::initUi()
     // 组列表标题栏布局
     m_hTitelLayout = new QHBoxLayout();
     m_hTitelLayout->setContentsMargins(LayoutMagrinSize, 0, 0, 0);
-    m_hTitelLayout->setSpacing(0);
+    m_hTitelLayout->setSpacing(2);
     m_hTitelLayout->addWidget(m_groupIcon);
     m_hTitelLayout->addWidget(m_groupLabel);
     m_hTitelLayout->addSpacerItem(new QSpacerItem(SpacerWidth, SpacerHeight, QSizePolicy::Expanding, QSizePolicy::Minimum));


### PR DESCRIPTION
1. Change group widget icon size from 18x18 to 16x16 for better visual
alignment
2. Increase title layout spacing from 0 to 2 pixels to prevent
overlapping elements
3. These adjustments improve overall UI consistency and prevent layout
issues

Log: Adjusted group icon size and title spacing in match results

Influence:
1. Verify group icon displays correctly at new size
2. Check title layout spacing no longer overlaps text/icons
3. Test with different screen resolutions and scaling factors
4. Ensure no visual regression in other parts of the match results view

fix: 调整分组图标尺寸和标题布局间距

1. 将分组图标尺寸从 18x18 改为 16x16，改善视觉对齐
2. 将标题布局间距从 0 调整为 2 像素，防止元素重叠
3. 这些调整提升整体 UI 一致性，避免布局问题

Log: 调整了匹配结果中的分组图标尺寸和标题间距

Influence:
1. 验证分组图标在新尺寸下显示正常
2. 检查标题布局间距不再导致文本/图标重叠
3. 在不同屏幕分辨率和缩放比例下测试
4. 确保匹配结果视图的其他部分无视觉回归

## Summary by Sourcery

Adjust group widget header layout for better visual alignment in match results.

Enhancements:
- Reduce the group icon size to 16x16 for improved visual alignment.
- Increase horizontal spacing in the group title layout to prevent overlap between the icon and label.