### PR TITLE
refactor: replace QLabel with DIconButton for app icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ dist/
 AGENTS.md
 .claude
 .trellis
+.opencode

--- a/src/grand-search/gui/entrance/searchedit.cpp
+++ b/src/grand-search/gui/entrance/searchedit.cpp
@@ -141,8 +141,11 @@ void SearchEditPrivate::init()
     m_searchAction->setVisible(false);
 
     // 应用图标（右侧）
-    m_appIconLabel = new QLabel(q);
-    m_appIconLabel->setFixedSize(AppIconSize, AppIconSize);
+    m_appIconLabel = new DIconButton(q);
+    m_appIconLabel->setIconSize({ AppIconSize, AppIconSize });
+    m_appIconLabel->setFlat(true);
+    m_appIconLabel->setFocusPolicy(Qt::NoFocus);
+    m_appIconLabel->setAttribute(Qt::WA_TransparentForMouseEvents);
     m_appIconLabel->setVisible(false);
 
     m_appIconAction = new QAction(q);
@@ -320,10 +323,7 @@ void SearchEdit::setAppIcon(const QIcon &icon)
         return;
     }
 
-    auto iconSize = QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps) ? AppIconSize : (AppIconSize * devicePixelRatioF());
-    auto pixmap = icon.pixmap(iconSize);
-    pixmap.setDevicePixelRatio(devicePixelRatioF());
-    d->m_appIconLabel->setPixmap(pixmap);
+    d->m_appIconLabel->setIcon(icon);
     setAppIconVisible(true);
 }
 

--- a/src/grand-search/gui/entrance/searchedit_p.h
+++ b/src/grand-search/gui/entrance/searchedit_p.h
@@ -31,7 +31,7 @@ class SearchEditPrivate
     QLineEdit *m_lineEdit = nullptr;
     QWidget *m_iconWidget = nullptr;
     QLabel *m_placeholderLabel = nullptr;
-    QLabel *m_appIconLabel = nullptr;
+    DTK_WIDGET_NAMESPACE::DIconButton *m_appIconLabel = nullptr;
     DTK_WIDGET_NAMESPACE::DIconButton *m_clearButton = nullptr;
     QAction *m_searchAction = nullptr;
     QAction *m_clearAction = nullptr;


### PR DESCRIPTION
1. Change the app icon widget from QLabel to DIconButton to better
integrate with DTK framework
2. Simplify icon setting logic by using setIcon() instead of manual
pixmap handling with high-DPI adjustments
3. Remove device pixel ratio calculations and explicit pixmap creation
4. Set DIconButton as flat and transparent to mouse events to preserve
UI behavior

Influence:
1. Verify app icon displays correctly in search edit field
2. Test with different DPI scaling settings (1x, 1.25x, 1.5x, 2x)
3. Ensure icon is click-through (should not interfere with search input)
4. Confirm no regression in icon appearance compared to previous QLabel
implementation
5. Verify icon updates dynamically when setAppIcon is called

refactor: 将应用图标控件从 QLabel 替换为 DIconButton

1. 将应用图标控件从 QLabel 改为 DIconButton，以更好地集成 DTK 框架
2. 简化图标设置逻辑，使用 setIcon() 替代手动处理 pixmap 和高 DPI 适配
3. 移除设备像素比计算和显式 pixmap 创建
4. 设置 DIconButton 为扁平且透明鼠标事件，保持原有 UI 行为

Influence:
1. 验证搜索编辑框中应用图标显示正常
2. 在不同 DPI 缩放比例下测试（1x、1.25x、1.5x、2x）
3. 确保图标可穿透点击（不影响搜索输入）
4. 确认与之前 QLabel 实现相比图标外观无回归
5. 验证调用 setAppIcon 时图标动态更新

BUG: https://pms.uniontech.com/bug-view-368613.html

## Summary by Sourcery

Refactor the search edit app icon widget to use DTK’s DIconButton instead of QLabel, simplifying icon handling and improving DPI and interaction behavior.

Bug Fixes:
- Improve app icon rendering across different DPI settings by delegating scaling to DIconButton’s icon handling.

Enhancements:
- Replace the QLabel-based app icon with a flat, non-focusable, mouse-transparent DIconButton to better integrate with the DTK framework and preserve click-through behavior.