### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file (#392841)

### DIFF
--- a/src/grand-search/dde-grand-search.desktop
+++ b/src/grand-search/dde-grand-search.desktop
@@ -7,6 +7,7 @@ NoDisplay=true
 StartupNotify=true
 Terminal=false
 Type=Application
+X-Deepin-Singleton=true
 
 # Translations:
 GenericName[lo]=ການຄົ້ນຫາຂະໜາດໃຫຍ່


### PR DESCRIPTION
Add X-Deepin-Singleton=true to desktop file to mark the application as a singleton app. This allows AM to identify singleton apps and inform Treeland to skip the splash screen for these apps.

Refs: https://pms.uniontech.com/task-view-392841.html

## Summary by Sourcery

Enhancements:
- Add X-Deepin-Singleton=true to the dde-grand-search.desktop file to declare the application as a singleton app.