### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file

### DIFF
--- a/src/grand-search/dde-grand-search.desktop
+++ b/src/grand-search/dde-grand-search.desktop
@@ -7,6 +7,7 @@ NoDisplay=true
 StartupNotify=true
 Terminal=false
 Type=Application
+X-Deepin-Singleton=true
 
 # Translations:
 GenericName[lo]=ການຄົ້ນຫາຂະໜາດໃຫຍ່


### PR DESCRIPTION
Add X-Deepin-Singleton=true to desktop file to mark the application as a singleton app.

为单例应用的desktop文件添加X-Deepin-Singleton=true标识。

Log: 添加单例应用标识
PMS: TASK-392841
Influence: AM能识别单例应用，Treeland不再为单例应用显示快速启动画面