### PR TITLE
fix: respect blacklist paths in semantic search

### DIFF
--- a/src/dde-grand-search-daemon/searcher/semantic/semanticworker.cpp
+++ b/src/dde-grand-search-daemon/searcher/semantic/semanticworker.cpp
@@ -4,6 +4,7 @@
 
 #include "semanticworker_p.h"
 #include "global/builtinsearch.h"
+#include "configuration/configer.h"
 
 #include <QDebug>
 #include <QFileInfo>
@@ -44,6 +45,11 @@ bool SemanticWorkerPrivate::doSearch()
         qCDebug(logDaemon) << "Input is not a semantic query, skipping semantic search";
         return false;
     }
+
+    // 排除黑名单路径，避免搜索出黑名单目录下的文件
+    auto blacklistConfig = Configer::instance()->group(GRANDSEARCH_BLACKLIST_GROUP);
+    auto blacklist = blacklistConfig->value(GRANDSEARCH_BLACKLIST_PATH, QStringList());
+    dfmSearcher.setSearchExcludedPaths(blacklist);
 
     // 通过 intentParsed 信号提取关键词
     // searchSync 内部会发出 intentParsed 信号，但使用 searchSync 时


### PR DESCRIPTION
## 根因分析

全局搜索将某目录加入黑名单后，使用智能语义搜索输入"今天打开过文件"仍能搜出黑名单目录下的文件。根因为两层缺陷：

1. **dde-grand-search 语义 worker 未传黑名单**：`SemanticWorkerPrivate::doSearch()` 构造 `SemanticSearcher` 后只设了 `setMaxResults`/`setSearchTimeout`，从未读取黑名单配置、也未调用 `setSearchExcludedPaths`。同后端的文件名/全文/OCR 三个 worker 都做了这一步，唯独语义 worker 漏了。
2. **util-dfm RecentSearchStrategy 不过滤黑名单**：dfm-search 的其它子引擎都尊重 `searchExcludedPaths()`，唯独 `RecentSearchStrategy` 全文无该引用。而"今天打开过文件"经 `action_rules.json` 命中 `action_recent` → `recentOnly=true` → 独占走 Recent 子引擎，黑名单目录下的最近使用文件不会被过滤。

关键证据：`semanticworker.cpp` 缺 `setSearchExcludedPaths`（对比 fulltext/filename/ocr worker）；`recentsearchstrategy.cpp` 全文无 `searchExcludedPaths` 引用。

## 修复方案

- dde-grand-search：语义 worker 在 `isSemanticQuery` 判定通过后、`searchSync` 之前，读取 `GRANDSEARCH_BLACKLIST_PATH` 并调用 `dfmSearcher.setSearchExcludedPaths(blacklist)`，与其它 worker 对齐。
- util-dfm：为 `RecentSearchStrategy` 新增 `filterByExcludedPaths` 方法（按 `searchExcludedPaths()` 用 `startsWith` 过滤，与 `FileNameRealTimeStrategy` 约定一致），并在 `search()` 过滤管道中尽早调用。补充 3 个单元测试覆盖黑名单过滤、空黑名单、黑名单+关键词组合场景。

两层必须同修：仅修第一层，由于 Recent 策略不消费 excluded paths，"今天打开过文件"的精确场景仍不修复。

## 改动安全评估

低风险。两处改动均为纯增量：
- dde-grand-search：仅新增 1 个 include + 3 行调用（在局部对象上调用已有的 setter），不改变任何函数签名，无外部调用者受影响。
- util-dfm：新增 1 个 private 过滤方法 + 在 `search()` 中调用，不改变任何公开 API 签名；`startsWith` 约定与现有 `FileNameRealTimeStrategy` 完全一致。

关联 PMS：https://pms.uniontech.com/bug-view-371177.html

## Summary by Sourcery

Bug Fixes:
- Prevent semantic search results from including files under blacklisted directories by honoring configured excluded paths.