### PR TITLE
chore: bump version to 6.0.50

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-grand-search (6.0.50) unstable; urgency=medium
+
+  * refactor: replace QLabel with DIconButton for app icon
+  * fix: add X-Deepin-Singleton flag to desktop file
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 24 Jul 2026 13:36:38 +0800
+
 dde-grand-search (6.0.39) unstable; urgency=medium
 
   * fix: fix app icon scaling on high DPI displays


### PR DESCRIPTION
6.0.50

Log:

## Summary by Sourcery

Chores:
- Bump recorded package version to 6.0.50 in the Debian changelog.