### PR TITLE
feat: parse .desktop files for localized app name and icon

### DIFF
--- a/src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp
+++ b/src/dde-grand-search-daemon/searcher/file/filesearchutils.cpp
@@ -12,24 +12,51 @@
 
 #include <dfm-search/dsearch_global.h>
 
+#include <DDesktopEntry>
+
 #include <QLoggingCategory>
 
 Q_DECLARE_LOGGING_CATEGORY(logDaemon)
 
 using namespace GrandSearch;
+DCORE_USE_NAMESPACE
 
 MatchedItem FileSearchUtils::packItem(const QString &fileName, const QString &searcher, const QStringList &keywords)
 {
     qCDebug(logDaemon) << "Packing file item - File:" << fileName << "Searcher:" << searcher;
     QFileInfo fileInfo(fileName);
-    QMimeType mimeType = SpecialTools::getMimeType(fileInfo);
     GrandSearch::MatchedItem item;
     item.item = fileName;
+    item.searcher = searcher;
+    item.extra = QVariant::fromValue(extraData(fileInfo, keywords));
+
+    // .desktop 文件（含符号链接指向 .desktop）：解析出本地化应用名称和应用图标
+    QString desktopPath = fileName;
+    if (fileInfo.suffix().compare("desktop", Qt::CaseInsensitive) != 0 && fileInfo.isSymLink()) {
+        QString target = fileInfo.symLinkTarget();
+        if (QFileInfo(target).suffix().compare("desktop", Qt::CaseInsensitive) == 0)
+            desktopPath = target;
+    }
+
+    if (desktopPath != fileName || fileInfo.suffix().compare("desktop", Qt::CaseInsensitive) == 0) {
+        DDesktopEntry desktopEntry(desktopPath);
+        QString displayName = desktopEntry.ddeDisplayName();
+        if (!displayName.isEmpty()) {
+            item.name = displayName;
+            item.icon = desktopEntry.stringValue("Icon", "Desktop Entry", "application-x-desktop");
+            item.type = "application/x-desktop";
+
+            qCDebug(logDaemon) << "Desktop file parsed - Name:" << item.name
+                               << "Type:" << item.type << "Icon:" << item.icon;
+            return item;
+        }
+    }
+
+    // 普通文件：使用 MIME 类型信息
+    QMimeType mimeType = SpecialTools::getMimeType(fileInfo);
     item.name = fileInfo.fileName();
     item.type = mimeType.name();
     item.icon = mimeType.iconName();
-    item.searcher = searcher;
-    item.extra = QVariant::fromValue(extraData(fileInfo, keywords));
 
     qCDebug(logDaemon) << "Item packed successfully - Name:" << item.name
                        << "Type:" << item.type << "Icon:" << item.icon;


### PR DESCRIPTION
1. Add DDesktopEntry parsing for .desktop files (including symlinks
pointing to .desktop)
2. When a .desktop file is matched, use its ddeDisplayName as the
display name instead of the file name
3. Set the icon from the desktop entry's "Icon" field and type as
"application/x-desktop"
4. Fall back to original MIME-based logic for non-desktop files
5. Improve user experience by showing human-readable application names
in search results

Log: Search results now show application names and icons for .desktop
files instead of raw file names

Influence:
1. Search for a .desktop file (e.g., "firefox.desktop") and verify the
display name is the local application name, not the file name
2. Test with .desktop symlinks (e.g., /usr/share/applications/
Firefox.desktop pointing to firefox.desktop)
3. Test with non-.desktop files to ensure no regression (MIME-based
display still works)
4. Test with .desktop files that have an empty ddeDisplayName (should
fall back to file name)
5. Check that the icon field is correctly populated for .desktop files
6. Verify that the extra data (keywords, etc.) is still correctly
attached

feat: 解析 .desktop 文件以获取本地化应用名称和图标

1. 为 .desktop 文件（包括指向 .desktop 的符号链接）添加 DDesktopEntry
解析
2. 当匹配到 .desktop 文件时，使用其 ddeDisplayName 作为显示名称，而不是
文件名
3. 从桌面入口的 "Icon" 字段设置图标，类型设置为 "application/x-desktop"
4. 对于非 .desktop 文件，回退到原来的基于 MIME 的逻辑
5. 提升用户体验，在搜索结果中显示人类可读的应用名称

Log: 搜索结果现在对 .desktop 文件显示应用名称和图标，而非原始文件名

Influence:
1. 搜索一个 .desktop 文件（如 "firefox.desktop"），验证显示名称是本地化
应用名称而非文件名
2. 测试 .desktop 符号链接（如 /usr/share/applications/Firefox.desktop 指
向 firefox.desktop）
3. 测试非 .desktop 文件，确保无回归（MIME 显示仍然正常）
4. 测试 ddeDisplayName 为空的 .desktop 文件（应回退到文件名）
5. 检查 .desktop 文件的图标字段是否正确填充
6. 验证附加数据（关键词等）仍然正确附加

BUG: https://pms.uniontech.com/bug-view-371187.html
