### PR TITLE
fix: remove duplicate app launch in launchAppByGio

### DIFF
--- a/src/grand-search/utils/utils.cpp
+++ b/src/grand-search/utils/utils.cpp
@@ -979,13 +979,6 @@ bool Utils::launchAppByGio(const QString &desktopFile, const QStringList &filePa
     g_object_unref(appInfo);
     g_list_free(g_files);
 
-    for (auto filePath : filePaths) {
-        if (!filePath.isEmpty()) {
-            qCDebug(logGrandSearch) << "Opening file with gio:" << filePath;
-            QProcess::startDetached("gio", QStringList() << "open" << filePath);
-        }
-    }
-
     return ok;
 }
 

--- a/tests/grand-search/utils/ut_utils.cpp
+++ b/tests/grand-search/utils/ut_utils.cpp
@@ -1333,7 +1333,9 @@ TEST(UtilsTest, launchAppByGio)
     result = Utils::launchAppByGio(desktopFile, filePaths);
     EXPECT_FALSE(result);
     EXPECT_TRUE(ut_gio_launch);
-    EXPECT_TRUE(ut_startDetached);
+    // The redundant `gio open` fallback loop was removed from launchAppByGio;
+    // only g_app_info_launch starts the app now, so startDetached must NOT be called.
+    EXPECT_FALSE(ut_startDetached);
 }
 
 TEST(UtilsTest, openWithBrowser)


### PR DESCRIPTION
## Root Cause Analysis

In `Utils::launchAppByGio` (`src/grand-search/utils/utils.cpp`), the same file was launched twice: once via `g_app_info_launch` and again, **unconditionally and decoupled from the first launch's result**, via a `QProcess::startDetached("gio", {"open", ...})` loop over the same file list. Both launches resolve and start the MIME default application, so opening a compressed file from global search spawned **two** archive-manager windows. This path is only reached as a fallback when `launchAppByDBus` fails; the redundant `gio open` loop has existed since the function was introduced (commit `b86ea85b`) and never checked the `g_app_info_launch` outcome.

Key evidence: `utils.cpp:966` `g_app_info_launch` + `utils.cpp:982-987` redundant `gio open` loop; trigger path `openMatchedItem → openFile → launchApp → launchAppByDBus` fails → fallback `launchAppByGio` (`utils.cpp:873`).

## Fix

Remove the redundant `QProcess::startDetached("gio", {"open", ...})` loop (`utils.cpp:982-987`) so `g_app_info_launch` is the **single** launch entry; the function returns its `ok` result directly after cleanup. Adjust the `launchAppByGio` unit test (`tests/grand-search/utils/ut_utils.cpp`), which had asserted `EXPECT_TRUE(ut_startDetached)` — encoding the double-launch as expected behavior — to `EXPECT_FALSE(ut_startDetached)`, and keep the `startDetached` stub as a regression guard.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- The function signature is unchanged; the sole production caller `Utils::launchApp` (`utils.cpp:873`) only consumes the boolean return value `ok`, which is preserved. The removed block was a 2021 leftover (git blame `b86ea85b`) never coupled to the launch result; removing it does **not** revert the later `1584d68`/`a326254` DBus/AppManager1 path fixes.
- No other callers are affected.

### Business Impact Scope

Affects global-search file-open via the GIO fallback path (reached only when the DBus/AppManager1 launch fails). User scenario: Shift+Space global search → enter `.7z`/`.rar` → open a compressed file → now opens a **single** archive-manager window instead of two. The normal DBus launch path is unaffected.

### Verification Suggestion

On V23 beta3, place a `.7z`/`.rar` on the desktop, trigger global search, open the compressed file, and confirm exactly one archive-manager window opens. Also re-open several file types (image/text) that go through the DBus path to confirm normal open behavior is unaffected.

---

## 根因分析

`Utils::launchAppByGio`（`src/grand-search/utils/utils.cpp`）对同一文件做了两次启动：`g_app_info_launch` 之后又**无条件、与首次启动结果解耦**地对同一文件列表执行 `QProcess::startDetached("gio", {"open", ...})` 循环。两次启动都解析并拉起 MIME 默认应用，导致全局搜索打开压缩文件时弹出**两个**归档管理器窗口。该路径仅在 `launchAppByDBus` 失败回退时触发；冗余 `gio open` 循环自函数创建（commit `b86ea85b`）即存在，且从不检查 `g_app_info_launch` 的结果。

关键证据：`utils.cpp:966` `g_app_info_launch` + `utils.cpp:982-987` 冗余 `gio open` 循环；触发链路 `openMatchedItem → openFile → launchApp → launchAppByDBus` 失败 → 回退 `launchAppByGio`（`utils.cpp:873`）。

## 修复方案

移除冗余的 `QProcess::startDetached("gio", {"open", ...})` 循环（`utils.cpp:982-987`），仅保留 `g_app_info_launch` 作为**唯一**启动入口，函数清理后直接 `return ok`。同步修正 `launchAppByGio` 单元测试（`tests/grand-search/utils/ut_utils.cpp`）中曾将双重启动固化为预期的 `EXPECT_TRUE(ut_startDetached)` 断言为 `EXPECT_FALSE(ut_startDetached)`，并保留 `startDetached` stub 作为回归防护。

## 改动安全评估

### 代码安全评估

- **风险等级**：低风险
- 函数签名不变，唯一生产调用者 `Utils::launchApp`（`utils.cpp:873`）仅依赖布尔返回值 `ok`（保持不变）。被删代码块为 2021 年遗留（git blame `b86ea85b`），与启动结果解耦，移除**不**撤销后续 `1584d68`/`a326254` 的 DBus/AppManager1 路径修复。
- 无其他调用者受影响。

### 业务影响范围

仅影响全局搜索经 GIO 回退路径打开文件的场景（仅在 DBus/AppManager1 启动失败时触发）。用户场景：Shift+Space 唤出全局搜索 → 输入 `.7z`/`.rar` → 打开压缩文件 → 现仅弹出一个归档管理器窗口（原先两个）。正常 DBus 启动路径不受影响。

### 验证建议

在 V23 beta3 桌面放置 `.7z`/`.rar`，唤出全局搜索打开该压缩文件，确认仅打开一个归档管理器窗口；另对走 DBus 路径的图片/文本等文件类型回归打开行为，确认正常打开不受影响。

---

**Refs**: Multica issue WS-1253; PMS bug 241939 — https://pms.uniontech.com/bug-view-241939.html

## Summary by Sourcery

Remove the redundant GIO fallback launch so files opened from global search start their default application only once.

Bug Fixes:
- Prevent duplicate application launches when opening files through the GIO fallback path.

Tests:
- Update the GIO launch test to verify that no redundant detached `gio` process is started.