### PR TITLE
fix: enlarge and make search settings dialog resizable

### DIFF
--- a/src/grand-search/gui/searchconfig/configwidget.cpp
+++ b/src/grand-search/gui/searchconfig/configwidget.cpp
@@ -21,8 +21,8 @@
 
 Q_DECLARE_LOGGING_CATEGORY(logGrandSearch)
 
-#define MAINWINDOW_WIDTH    696
-#define MAINWINDOW_HEIGHT   529
+#define MAINWINDOW_WIDTH    780
+#define MAINWINDOW_HEIGHT   600
 
 using namespace GrandSearch;
 DWIDGET_USE_NAMESPACE
@@ -43,7 +43,9 @@ ConfigWidget::~ConfigWidget()
 
 void ConfigWidget::initUI()
 {
-    setFixedSize(MAINWINDOW_WIDTH, MAINWINDOW_HEIGHT);
+    // 设置窗口最小尺寸并允许用户拖拽缩放，初始尺寸为主窗口尺寸
+    setMinimumSize(MAINWINDOW_WIDTH, MAINWINDOW_HEIGHT);
+    resize(MAINWINDOW_WIDTH, MAINWINDOW_HEIGHT);
 
     // 禁用最小、最大化按钮
     setWindowFlag(Qt::WindowMinMaxButtonsHint, false);
@@ -72,7 +74,7 @@ void ConfigWidget::initUI()
 
     m_scrollAreaContent = new QWidget(m_scrollArea);
     m_scrollLayout = new QVBoxLayout(m_scrollAreaContent);
-    m_scrollLayout->setContentsMargins(109, 20, 109, 20);
+    m_scrollLayout->setContentsMargins(40, 20, 40, 20);
     m_scrollLayout->setSpacing(20);
     m_scrollAreaContent->setLayout(m_scrollLayout);
 


### PR DESCRIPTION
## 根因分析

搜索设置对话框 `ConfigWidget` 在构造时以硬编码固定值 `setFixedSize(696, 529)` 锁定窗口，尺寸常量自 master 根提交（2025-05-08）起未随设置内容增长而更新，且禁用了最小/最大化按钮导致不可缩放、无 DPI/分辨率自适应；叠加固定 109px×2 横向边距使有效内容区仅 478px（内部控件固定 476px，仅 2px 余量），最终表现为对话框样式偏小、内容拥挤。

关键证据（master 基线 `66b64726`，社区版 V25 / dde-grand-search 6.1.0）：
- `src/grand-search/gui/searchconfig/configwidget.cpp:24-25` 定义 `MAINWINDOW_WIDTH=696`/`MAINWINDOW_HEIGHT=529`；`:46` `setFixedSize(...)`；`:49` 禁用最小/最大化；`:75` 横向边距 109px×2。
- 触发路径：`grandsearchsettingservice.cpp:59 --setting` → `main.cpp:85` 构造 `ConfigWidget` → `:46` `setFixedSize(696,529)` → 固定偏小呈现。
- 版本对比：尺寸常量源自 master 根提交 `b8d5c92`（2025-05-08）至今 git blame 显示零改动，master 历史中无尺寸修复提交，未发现后续修复。

## 修复方案

方向 1+2（低风险缓解 + 常规收敛）：将窗口尺寸调大为 780×600，并把 `setFixedSize` 改为 `setMinimumSize` + `resize` 以允许用户拖拽缩放（保留禁用最小/最大化按钮）；同时收窄滚动内容横向边距 109px→40px 扩大有效内容区，改善布局呼吸感。改动仅限 `ConfigWidget::initUI()` 的 UI 尺寸属性，不涉业务/数据流。

## 改动安全评估

低风险。`initUI` 为私有方法，无外部调用者；无函数签名/公开 API 变更；单元测试 `ut_configwidget.cpp` 不断言窗口尺寸，改动不破坏其断言。master 根提交以来尺寸逻辑从未改动，本次为首次调整，无历史修复可冲突。

## Summary by Sourcery

Improve the search settings dialog usability by enlarging its default layout, widening the available content area, and supporting user resizing.

Bug Fixes:
- Increase the search settings dialog size and improve its layout to prevent cramped content.

Enhancements:
- Allow the search settings dialog to be resized while retaining a larger minimum size and disabling window maximize/minimize controls.