### PR TITLE
fix: port SearchEdit to fix dual icon overlap

### DIFF
--- a/src/grand-search/CMakeLists.txt
+++ b/src/grand-search/CMakeLists.txt
@@ -56,12 +56,17 @@ set(GUISRC
     gui/mainwindow_p.h
     gui/mainwindow.h
     gui/mainwindow.cpp
+    gui/iconbutton.h
+    gui/iconbutton.cpp
     # 可见性/退出处理
     gui/handlevisibility/handlevisibility.h
     gui/handlevisibility/handlevisibility.cpp
     # 界面相关数据定义
     gui/datadefine.h
     # 入口界面
+    gui/entrance/searchedit_p.h
+    gui/entrance/searchedit.h
+    gui/entrance/searchedit.cpp
     gui/entrance/entrancewidget_p.h
     gui/entrance/entrancewidget.h
     gui/entrance/entrancewidget.cpp

--- a/src/grand-search/gui/entrance/entrancewidget.cpp
+++ b/src/grand-search/gui/entrance/entrancewidget.cpp
@@ -1,128 +1,51 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "entrancewidget_p.h"
 #include "entrancewidget.h"
-#include "gui/datadefine.h"
+#include "searchedit.h"
 #include "utils/utils.h"
 
-#include <DSearchEdit>
-#include <DStyle>
-#include <DLabel>
-#include <DFontSizeManager>
 #include <DGuiApplicationHelper>
 
 #include <QLineEdit>
-#include <QPushButton>
 #include <QHBoxLayout>
-#include <QWidgetAction>
-#include <QAction>
-#include <QTimer>
-#include <QGuiApplication>
-#include <QKeyEvent>
-#include <QMenu>
-#include <QClipboard>
-#include <QContextMenuEvent>
 #include <QEvent>
-#include <QtGlobal>
 
-DWIDGET_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 using namespace GrandSearch;
 
-static const uint DelayReponseTime          = 50;       // 输入延迟搜索时间
-static const uint EntraceWidgetWidth        = 740;      // 搜索界面宽度度
-static const uint EntraceWidgetHeight       = 48;       // 搜索界面高度
-static const uint WidgetMargins             = 10;       // 界面边距
-static const uint SearchMaxLength           = 512;      // 输入最大字符限制
-
-static const uint LabelIconSize             = 26;       // 标签应用图标显示大小
-static const uint LabelSize                 = 32;       // 标签大小
+static const uint EntraceWidgetWidth = 740;
+static const uint EntraceWidgetHeight = 48;
+static const uint WidgetMargins = 10;
 
 EntranceWidgetPrivate::EntranceWidgetPrivate(EntranceWidget *parent)
     : q_p(parent)
 {
-    m_delayChangeTimer = new QTimer(this);
-    m_delayChangeTimer->setSingleShot(true);
-    m_delayChangeTimer->setInterval(DelayReponseTime);
-
-    connect(m_delayChangeTimer, &QTimer::timeout, this, &EntranceWidgetPrivate::notifyTextChanged);
-}
-
-void EntranceWidgetPrivate::delayChangeText()
-{
-    Q_ASSERT(m_delayChangeTimer);
-
-    m_delayChangeTimer->start();
-}
-
-void EntranceWidgetPrivate::notifyTextChanged()
-{
-    Q_ASSERT(m_searchEdit);
-
-    const QString &currentSearchText = m_searchEdit->text().trimmed();
-    emit q_p->searchTextChanged(currentSearchText);
-
-    // 搜索内容改变后，清空图标显示
-    MatchedItem item;
-    q_p->onAppIconChanged(QString(), item);
-}
-
-void EntranceWidgetPrivate::showMenu(const QPoint &pos)
-{
-    Q_ASSERT(m_lineEdit);
-
-    QMenu *menu = new QMenu;
-    QAction *action = nullptr;
-
-    action = menu->addAction(tr("Cut"));
-    action->setEnabled(m_lineEdit->hasSelectedText() && m_lineEdit->echoMode() == QLineEdit::Normal);
-    connect(action, &QAction::triggered, m_lineEdit, &QLineEdit::cut);
-
-    action = menu->addAction(tr("Copy"));
-    action->setEnabled(m_lineEdit->hasSelectedText() && m_lineEdit->echoMode() == QLineEdit::Normal);
-    connect(action, &QAction::triggered, m_lineEdit, &QLineEdit::copy);
-
-    action = menu->addAction(tr("Paste"));
-    action->setEnabled(!QGuiApplication::clipboard()->text().isEmpty());
-    connect(action, &QAction::triggered, m_lineEdit, &QLineEdit::paste);
-
-    menu->exec(pos);
-    delete menu;
 }
 
 EntranceWidget::EntranceWidget(QWidget *parent)
-    : QFrame(parent)
-    , d_p(new EntranceWidgetPrivate(this))
+    : QFrame(parent), d_p(new EntranceWidgetPrivate(this))
 {
     initUI();
     initConnections();
 }
 
-EntranceWidget::~EntranceWidget()
-{
-
-}
+EntranceWidget::~EntranceWidget() = default;
 
 void EntranceWidget::showLabelAppIcon(bool visible)
 {
-    Q_ASSERT(d_p->m_lineEdit);
-    Q_ASSERT(d_p->m_appIconLabel);
-    Q_ASSERT(d_p->m_appIconAction);
-    if (visible == d_p->m_appIconLabel->isVisible())
-        return;
-    d_p->m_appIconAction->setVisible(visible);
-    d_p->m_appIconLabel->setVisible(visible);
-    d_p->m_lineEdit->update();
+    Q_ASSERT(d_p->m_searchEdit);
+    d_p->m_searchEdit->setAppIconVisible(visible);
 }
 
 bool EntranceWidget::event(QEvent *event)
 {
     if (event->type() == QEvent::FocusIn) {
-        d_p->m_lineEdit->setFocus();
+        d_p->m_searchEdit->setFocus();
         return true;
     }
-
     return QFrame::event(event);
 }
 
@@ -131,106 +54,17 @@ void EntranceWidget::paintEvent(QPaintEvent *event)
     QFrame::paintEvent(event);
 }
 
-bool EntranceWidget::eventFilter(QObject *watched, QEvent *event)
-{
-    if (watched == d_p->m_lineEdit && QEvent::KeyPress == event->type()) {
-        QKeyEvent *keyEvent = static_cast<QKeyEvent*>(event);
-        if (Q_LIKELY(keyEvent)) {
-            int key = keyEvent->key();
-            switch (key) {
-            case Qt::Key_Up : {
-                emit sigSelectPreviousItem();
-                return true;
-            }
-            case Qt::Key_Tab :
-            case Qt::Key_Down : {
-                emit sigSelectNextItem();
-                return true;
-            }
-            case Qt::Key_Return:
-            case Qt::Key_Enter: {
-                emit sigHandleItem();
-                return true;
-            }
-            case Qt::Key_Escape : {
-                emit sigCloseWindow();
-                return true;
-            }
-            default:break;
-            }
-        }
-    } else if (watched == d_p->m_lineEdit && QEvent::ContextMenu == event->type()) {
-        QContextMenuEvent *contextMenuEvent = static_cast<QContextMenuEvent*>(event);
-        if (Q_LIKELY(contextMenuEvent)) {
-            d_p->showMenu(contextMenuEvent->globalPos());
-            return true;
-        }
-    } else if (watched == d_p->m_searchEdit && QEvent::FocusIn == event->type()) {
-        if (Q_LIKELY(d_p->m_lineEdit)) {
-            d_p->m_lineEdit->setFocus();
-            return true;
-        }
-    }
-    return QFrame::eventFilter(watched, event);
-}
-
 void EntranceWidget::initUI()
 {
-    d_p->m_searchEdit = new DSearchEdit(this);
-    d_p->m_searchEdit->installEventFilter(this);
-
-    d_p->m_lineEdit = d_p->m_searchEdit->lineEdit();
-    d_p->m_lineEdit->setMaxLength(SearchMaxLength);
-    d_p->m_lineEdit->installEventFilter(this);
-
-    QFont lineFont = d_p->m_lineEdit->font();
-    lineFont = DFontSizeManager::instance()->get(DFontSizeManager::T4, lineFont);
-    d_p->m_lineEdit->setFont(lineFont);
-
-    QPalette palette;
-    QColor colorText(0, 0, 0);
-    if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType)
-        colorText = QColor(255, 255, 255);
-
-    palette.setColor(QPalette::Button, Qt::transparent);
-    palette.setColor(QPalette::Text, colorText);
-    palette.setColor(QPalette::ButtonText, colorText);
-
-    d_p->m_lineEdit->setPalette(palette);
-    DStyle::setFocusRectVisible(d_p->m_lineEdit, true);
-
-    d_p->m_appIconLabel = new DLabel(d_p->m_searchEdit);
-    d_p->m_appIconLabel->setFixedSize(LabelSize, LabelSize);
-
-    d_p->m_appIconAction = new QAction(this);
-    d_p->m_lineEdit->addAction(d_p->m_appIconAction, QLineEdit::TrailingPosition);
-    d_p->m_searchEdit->setRightWidgets(QList<QWidget*>() << d_p->m_appIconLabel);
-
-    // 搜索框界面布局设置
-    // 必须对搜索框控件的边距和间隔设置为0,否则其内含的LineEdit不满足大小显示要求
-    {
-        auto slayout = d_p->m_searchEdit->layout();
-        slayout->setSpacing(0);
-        slayout->setMargin(0);
-
-        // 增加默认应用图标的右边距
-        auto conMar = slayout->contentsMargins();
-        conMar.setRight(2);
-        slayout->setContentsMargins(conMar);
-
-        d_p->m_lineEdit->setFixedSize(EntraceWidgetWidth, EntraceWidgetHeight);
-    }
-
-    // 搜索框提示信息设置
+    d_p->m_searchEdit = new SearchEdit(this);
+    d_p->m_searchEdit->lineEdit()->setFixedSize(EntraceWidgetWidth, EntraceWidgetHeight);
     d_p->m_searchEdit->setPlaceHolder(tr("Search"));
     d_p->m_searchEdit->setPlaceholderText(tr("What would you like to search for?"));
 
-    // 搜索界面布局设置
     d_p->m_mainLayout = new QHBoxLayout(this);
     d_p->m_mainLayout->addWidget(d_p->m_searchEdit);
-    // 根据设计图要求，设置边距和间隔
     d_p->m_mainLayout->setSpacing(0);
-    d_p->m_mainLayout->setMargin(WidgetMargins);
+    d_p->m_mainLayout->setContentsMargins(WidgetMargins, WidgetMargins, WidgetMargins, WidgetMargins);
 
     this->setLayout(d_p->m_mainLayout);
 }
@@ -238,13 +72,23 @@ void EntranceWidget::initUI()
 void EntranceWidget::initConnections()
 {
     Q_ASSERT(d_p->m_searchEdit);
-    Q_ASSERT(d_p->m_lineEdit);
 
-    // 输入改变时重置定时器，避免短时间内发起大量无效调用
-    connect(d_p->m_searchEdit, &DSearchEdit::textChanged, d_p.data(), &EntranceWidgetPrivate::delayChangeText);
+    connect(d_p->m_searchEdit, &SearchEdit::debouncedTextChanged, this, &EntranceWidget::searchTextChanged);
+    connect(d_p->m_searchEdit, &SearchEdit::debouncedTextChanged, this, [this](const QString &text) {
+        if (text == d_p->m_currentSearchText)
+            return;
 
-    // 终止搜索时，强制设置焦点
-    connect(d_p->m_searchEdit, &DSearchEdit::searchAborted, d_p->m_lineEdit, qOverload<>(&QLineEdit::setFocus));
+        d_p->m_currentSearchText = text;
+        MatchedItem item;
+        onAppIconChanged(QString(), item);
+    });
+
+    connect(d_p->m_searchEdit, &SearchEdit::selectNextItem, this, &EntranceWidget::sigSelectNextItem);
+    connect(d_p->m_searchEdit, &SearchEdit::selectPreviousItem, this, &EntranceWidget::sigSelectPreviousItem);
+    connect(d_p->m_searchEdit, &SearchEdit::handleItem, this, &EntranceWidget::sigHandleItem);
+    connect(d_p->m_searchEdit, &SearchEdit::closeWindow, this, &EntranceWidget::sigCloseWindow);
+
+    connect(d_p->m_searchEdit, &SearchEdit::searchAborted, d_p->m_searchEdit->lineEdit(), qOverload<>(&QLineEdit::setFocus));
 }
 
 void EntranceWidget::onAppIconChanged(const QString &searchGroupName, const MatchedItem &item)
@@ -252,24 +96,16 @@ void EntranceWidget::onAppIconChanged(const QString &searchGroupName, const Matc
     Q_UNUSED(searchGroupName)
 
     const QString appIconName = Utils::appIconName(item);
-    // app图标名称为空，隐藏appIcon显示
     if (appIconName.isEmpty()) {
-        showLabelAppIcon(false);
+        d_p->m_searchEdit->setAppIconVisible(false);
         d_p->m_appIconName.clear();
         return;
     }
-
 
     if (appIconName == d_p->m_appIconName)
         return;
 
     d_p->m_appIconName = appIconName;
-
-    // 更新应用图标
-    const int size = LabelIconSize;
-    QIcon icon = QIcon::fromTheme(appIconName);
-    d_p->m_appIconLabel->setPixmap(icon.pixmap(int(size), int(size)));
-
-    // 图标更新完成后再刷新显示
-    showLabelAppIcon(true);
+    d_p->m_searchEdit->setAppIconVisible(true);
+    d_p->m_searchEdit->setAppIcon(appIconName);
 }

--- a/src/grand-search/gui/entrance/entrancewidget.h
+++ b/src/grand-search/gui/entrance/entrancewidget.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -21,17 +21,16 @@ public:
     ~EntranceWidget() override;
 
     void showLabelAppIcon(bool visible);
+
 protected:
     bool event(QEvent *event) Q_DECL_OVERRIDE;
     void paintEvent(QPaintEvent *event) Q_DECL_OVERRIDE;
-    bool eventFilter(QObject *watched, QEvent *event) Q_DECL_OVERRIDE;
 
 private:
     void initUI();
     void initConnections();
 
 public slots:
-    // 切换选择搜索结果时，应用图标发生改变
     void onAppIconChanged(const QString &searchGroupName, const MatchedItem &item);
 
 signals:

--- a/src/grand-search/gui/entrance/entrancewidget_p.h
+++ b/src/grand-search/gui/entrance/entrancewidget_p.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,44 +7,25 @@
 
 #include "entrancewidget.h"
 
-#include <DWidget>
-
 #include "QObject"
 
-DWIDGET_BEGIN_NAMESPACE
-class DSearchEdit;
-class DLabel;
-DWIDGET_END_NAMESPACE
-
 class QHBoxLayout;
-class QTimer;
-class QLineEdit;
-class QAction;
-class QPushButton;
 
 namespace GrandSearch {
 
+class SearchEdit;
+
 class EntranceWidgetPrivate : public QObject
 {
-    Q_OBJECT
 public:
     explicit EntranceWidgetPrivate(EntranceWidget *parent = nullptr);
 
-    void delayChangeText();
-    void notifyTextChanged();
-
-    void showMenu(const QPoint& pos);
-
     EntranceWidget *q_p = nullptr;
-    Dtk::Widget::DSearchEdit *m_searchEdit = nullptr;   // 搜索输入框控件
-    QLineEdit *m_lineEdit = nullptr;                    // 输入控件
-    Dtk::Widget::DLabel *m_appIconLabel = nullptr;      // 应用图标显示label
-    QAction *m_appIconAction = nullptr;                 // 应用图标显示区域占位action
+    SearchEdit *m_searchEdit = nullptr;
     QHBoxLayout *m_mainLayout = nullptr;
 
-    QTimer *m_delayChangeTimer = nullptr;               // 延迟发出搜索文本改变
-
-    QString m_appIconName;                              // 当前搜索框显示的默认打开应用图标名称
+    QString m_appIconName;
+    QString m_currentSearchText;
 };
 
 }

--- a/src/grand-search/gui/entrance/searchedit.cpp
+++ b/src/grand-search/gui/entrance/searchedit.cpp
@@ -1,0 +1,392 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "searchedit_p.h"
+#include "searchedit.h"
+#include "utils/utils.h"
+
+#include <DStyle>
+#include <DIconButton>
+#include <DIconTheme>
+#include <DFontSizeManager>
+#include <DGuiApplicationHelper>
+
+#include <QLineEdit>
+#include <QHBoxLayout>
+#include <QAction>
+#include <QTimer>
+#include <QMenu>
+#include <QGuiApplication>
+#include <QClipboard>
+#include <QKeyEvent>
+#include <QStyleOption>
+#include <QToolButton>
+
+DWIDGET_USE_NAMESPACE
+using namespace GrandSearch;
+
+static constexpr int DelayResponseTime = 50;
+static constexpr int AppIconSize = 32;
+static constexpr int SearchIconSize = 20;
+
+SearchEditPrivate::SearchEditPrivate(SearchEdit *qq)
+    : q(qq)
+{
+}
+
+void SearchEditPrivate::init()
+{
+    m_delayTimer = new QTimer(q);
+    m_delayTimer->setSingleShot(true);
+    m_delayTimer->setInterval(DelayResponseTime);
+    QObject::connect(m_delayTimer, &QTimer::timeout, q, [this]() { notifyTextChanged(); });
+
+    // 内部 QLineEdit
+    m_lineEdit = new QLineEdit(q);
+    m_lineEdit->installEventFilter(q);
+    m_lineEdit->setMaxLength(512);
+    m_lineEdit->setContextMenuPolicy(Qt::NoContextMenu);
+    m_lineEdit->setClearButtonEnabled(false);
+
+    // 调色板（暗色/亮色主题）
+    QPalette pa = m_lineEdit->palette();
+    QColor colorText(0, 0, 0);
+    QColor colorBkg(0, 0, 0, 25);
+    if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType) {
+        colorText = QColor(255, 255, 255);
+        colorBkg = QColor(255, 255, 255, 25);
+    }
+    pa.setColor(QPalette::Button, colorBkg);
+    pa.setColor(QPalette::Text, colorText);
+    pa.setColor(QPalette::ButtonText, colorText);
+    m_lineEdit->setPalette(pa);
+    DStyle::setFocusRectVisible(m_lineEdit, false);
+
+    // 字体
+    QFont lineFont = m_lineEdit->font();
+    lineFont = DFontSizeManager::instance()->get(DFontSizeManager::T4, lineFont);
+    m_lineEdit->setFont(lineFont);
+
+    // 居中的搜索图标 + 占位文本容器
+    m_iconWidget = new QWidget;
+    m_iconWidget->setObjectName("iconWidget");
+    QHBoxLayout *centerLayout = new QHBoxLayout(m_iconWidget);
+    centerLayout->setContentsMargins(0, 0, 0, 0);
+    centerLayout->setSpacing(6);
+
+    auto *searchIcon = new DIconButton(DStyle::SP_IndicatorSearch);
+    searchIcon->setFlat(true);
+    searchIcon->setFocusPolicy(Qt::NoFocus);
+    searchIcon->setAttribute(Qt::WA_TransparentForMouseEvents);
+    searchIcon->setIconSize(QSize(SearchIconSize, SearchIconSize));
+
+    m_placeholderLabel = new QLabel(q);
+    DPalette pe;
+    QStyleOption opt;
+    QColor color = DStyleHelper(q->style()).getColor(&opt, pe, DPalette::TextTips);
+    pe.setColor(DPalette::TextTips, color);
+    m_placeholderLabel->setPalette(pe);
+    m_placeholderLabel->setObjectName("SearchEditPlaceHolderLabel");
+
+    m_placeHolder = SearchEdit::tr("Search");
+    m_placeholderLabel->setText(m_placeHolder);
+
+    centerLayout->addStretch(1);
+    centerLayout->addWidget(searchIcon, 0, Qt::AlignCenter);
+    centerLayout->addWidget(m_placeholderLabel, 0, Qt::AlignCenter);
+    centerLayout->addStretch(1);
+
+    // QLineEdit 内部布局：左侧放 iconWidget（居中），聚焦后隐藏
+    m_lineEditLayout = new QHBoxLayout(m_lineEdit);
+    m_lineEditLayout->setContentsMargins(0, 0, 0, 0);
+    m_lineEditLayout->setSpacing(0);
+    m_lineEditLayout->addWidget(m_iconWidget);
+
+    // 左侧搜索图标 action（聚焦后显示）
+    m_searchAction = new QAction(q);
+    m_searchAction->setObjectName("_d_search_leftAction");
+    QString suffix = Utils::iconThemeSuffix();
+    m_searchAction->setIcon(QIcon(QString(":/icons/deepin/builtin/texts/search%1.svg").arg(suffix)));
+    m_lineEdit->addAction(m_searchAction, QLineEdit::LeadingPosition);
+    m_searchAction->setVisible(false);
+
+    // 应用图标（右侧）
+    m_appIconLabel = new DIconButton(q);
+    m_appIconLabel->setIconSize({ AppIconSize, AppIconSize });
+    m_appIconLabel->setFlat(true);
+    m_appIconLabel->setFocusPolicy(Qt::NoFocus);
+    m_appIconLabel->setAttribute(Qt::WA_TransparentForMouseEvents);
+    m_appIconLabel->setVisible(false);
+
+    m_appIconAction = new QAction(q);
+    m_appIconAction->setVisible(false);
+    m_lineEdit->addAction(m_appIconAction, QLineEdit::TrailingPosition);
+
+    // 清除按钮（QLineEdit 外部）
+    m_clearButton = new SearchIconButton(q);
+    m_clearButton->setIconSize({ 20, 20 });
+    m_clearButton->setIcon(DDciIcon::fromTheme("clear"));
+    m_clearButton->setFlat(true);
+    m_clearButton->setFocusPolicy(Qt::NoFocus);
+    m_clearButton->setVisible(false);
+
+    // 清除按钮占位 action
+    m_clearAction = new QAction(q);
+    m_clearAction->setVisible(false);
+    m_lineEdit->addAction(m_clearAction, QLineEdit::TrailingPosition);
+
+    // 主布局
+    QHBoxLayout *mainLayout = new QHBoxLayout(q);
+    mainLayout->setSpacing(6 / q->devicePixelRatio());
+    mainLayout->setContentsMargins(0, 0, 10 / q->devicePixelRatio(), 0);
+    mainLayout->addWidget(m_lineEdit);
+    mainLayout->addWidget(m_clearButton);
+    mainLayout->addWidget(m_appIconLabel);
+
+    QList<QToolButton *> list = q->lineEdit()->findChildren<QToolButton *>();
+    for (int i = 0; i < list.count(); i++) {
+        if (list.at(i)->defaultAction() == m_searchAction) {
+            QToolButton *searchBtn = list.at(i);
+            searchBtn->setIconSize({ 16, 16 });
+            searchBtn->setFixedWidth(40);
+            break;
+        }
+    }
+
+    // 聚焦切换 + 文本变化触发防抖
+    QObject::connect(m_lineEdit, &QLineEdit::textChanged, q, [this](const QString &text) {
+        toEditMode(false);
+        bool hasText = !text.isEmpty();
+        m_clearButton->setVisible(hasText);
+        m_clearAction->setVisible(hasText);
+        if (hasText)
+            delayTextChanged();
+        else
+            Q_EMIT q->debouncedTextChanged(QString());
+    });
+
+    QObject::connect(m_clearButton, &DIconButton::clicked, q, [this]() {
+        q->clearEdit();
+        Q_EMIT q->searchAborted();
+    });
+}
+
+void SearchEditPrivate::toEditMode(bool focus)
+{
+    if (focus || m_lineEdit->hasFocus() || !m_lineEdit->text().isEmpty()) {
+        m_searchAction->setVisible(true);
+        m_iconWidget->setVisible(false);
+        m_lineEdit->setPlaceholderText(m_placeholderText);
+    } else {
+        m_searchAction->setVisible(false);
+        m_iconWidget->setVisible(true);
+        m_lineEdit->setPlaceholderText(QString());
+    }
+}
+
+void SearchEditPrivate::showContextMenu(const QPoint &pos)
+{
+    QMenu *menu = new QMenu;
+    QAction *action = nullptr;
+
+    action = menu->addAction(SearchEdit::tr("Cut"));
+    action->setEnabled(m_lineEdit->hasSelectedText() && m_lineEdit->echoMode() == QLineEdit::Normal);
+    QObject::connect(action, &QAction::triggered, m_lineEdit, &QLineEdit::cut);
+
+    action = menu->addAction(SearchEdit::tr("Copy"));
+    action->setEnabled(m_lineEdit->hasSelectedText() && m_lineEdit->echoMode() == QLineEdit::Normal);
+    QObject::connect(action, &QAction::triggered, m_lineEdit, &QLineEdit::copy);
+
+    action = menu->addAction(SearchEdit::tr("Paste"));
+    action->setEnabled(!QGuiApplication::clipboard()->text().isEmpty());
+    QObject::connect(action, &QAction::triggered, m_lineEdit, &QLineEdit::paste);
+
+    menu->exec(pos);
+    delete menu;
+}
+
+void SearchEditPrivate::delayTextChanged()
+{
+    Q_ASSERT(m_delayTimer);
+    m_delayTimer->start();
+}
+
+void SearchEditPrivate::notifyTextChanged()
+{
+    const QString &text = m_lineEdit->text().trimmed();
+    Q_EMIT q->debouncedTextChanged(text);
+}
+
+SearchEdit::SearchEdit(QWidget *parent)
+    : QWidget(parent), d(new SearchEditPrivate(this))
+{
+    d->init();
+}
+
+SearchEdit::~SearchEdit() = default;
+
+QLineEdit *SearchEdit::lineEdit() const
+{
+    return d->m_lineEdit;
+}
+
+void SearchEdit::setPlaceHolder(const QString &text)
+{
+    if (d->m_placeHolder == text)
+        return;
+    d->m_placeHolder = text;
+    d->m_placeholderLabel->setText(text);
+}
+
+QString SearchEdit::placeHolder() const
+{
+    return d->m_placeHolder;
+}
+
+void SearchEdit::setPlaceholderText(const QString &text)
+{
+    d->m_placeholderText = text;
+    if (d->m_lineEdit->hasFocus())
+        d->m_lineEdit->setPlaceholderText(text);
+}
+
+QString SearchEdit::placeholderText() const
+{
+    return d->m_placeholderText;
+}
+
+void SearchEdit::setText(const QString &text)
+{
+    d->m_lineEdit->setText(text);
+}
+
+QString SearchEdit::text() const
+{
+    return d->m_lineEdit->text();
+}
+
+void SearchEdit::setClearButtonEnabled(bool enable)
+{
+    d->m_lineEdit->setClearButtonEnabled(enable);
+}
+
+void SearchEdit::setAppIcon(const QString &iconName)
+{
+    if (iconName.isEmpty()) {
+        d->m_appIconName.clear();
+        setAppIconVisible(false);
+        return;
+    }
+
+    if (iconName == d->m_appIconName)
+        return;
+
+    d->m_appIconName = iconName;
+    setAppIcon(QIcon::fromTheme(iconName));
+}
+
+void SearchEdit::setAppIcon(const QIcon &icon)
+{
+    if (icon.isNull()) {
+        d->m_appIconName.clear();
+        setAppIconVisible(false);
+        return;
+    }
+
+    d->m_appIconLabel->setIcon(icon);
+    setAppIconVisible(true);
+}
+
+void SearchEdit::setAppIconVisible(bool visible)
+{
+    if (visible == d->m_appIconLabel->isVisible())
+        return;
+    d->m_appIconAction->setVisible(visible);
+    d->m_appIconLabel->setVisible(visible);
+    d->m_lineEdit->update();
+}
+
+bool SearchEdit::isAppIconVisible() const
+{
+    return d->m_appIconLabel->isVisible();
+}
+
+void SearchEdit::clear()
+{
+    d->m_lineEdit->clear();
+}
+
+void SearchEdit::clearEdit()
+{
+    d->m_lineEdit->clear();
+    d->m_clearButton->setVisible(false);
+    d->m_clearAction->setVisible(false);
+    d->toEditMode(false);
+    if (d->m_lineEdit->hasFocus())
+        d->m_lineEdit->clearFocus();
+}
+
+void SearchEdit::setFocus()
+{
+    d->m_lineEdit->setFocus();
+}
+
+bool SearchEdit::eventFilter(QObject *watched, QEvent *event)
+{
+    if (watched == d->m_lineEdit) {
+        switch (event->type()) {
+        case QEvent::FocusIn:
+            d->toEditMode(true);
+            break;
+        case QEvent::FocusOut:
+            d->toEditMode(false);
+            break;
+        case QEvent::KeyPress: {
+            auto *keyEvent = static_cast<QKeyEvent *>(event);
+            if (Q_LIKELY(keyEvent)) {
+                switch (keyEvent->key()) {
+                case Qt::Key_Up:
+                    Q_EMIT selectPreviousItem();
+                    return true;
+                case Qt::Key_Tab:
+                case Qt::Key_Down:
+                    Q_EMIT selectNextItem();
+                    return true;
+                case Qt::Key_Return:
+                case Qt::Key_Enter:
+                    Q_EMIT handleItem();
+                    return true;
+                case Qt::Key_Escape:
+                    Q_EMIT closeWindow();
+                    return true;
+                default:
+                    break;
+                }
+            }
+            break;
+        }
+        case QEvent::ContextMenu: {
+            auto *ctxEvent = static_cast<QContextMenuEvent *>(event);
+            if (Q_LIKELY(ctxEvent) && !d->m_iconWidget->isVisible()) {
+                d->showContextMenu(ctxEvent->globalPos());
+                return true;
+            }
+            break;
+        }
+        default:
+            break;
+        }
+    }
+    return QWidget::eventFilter(watched, event);
+}
+
+bool SearchEdit::event(QEvent *event)
+{
+    if (event->type() == QEvent::FocusIn) {
+        d->m_lineEdit->setFocus();
+        return true;
+    }
+
+    return QWidget::event(event);
+}

--- a/src/grand-search/gui/entrance/searchedit.h
+++ b/src/grand-search/gui/entrance/searchedit.h
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SEARCHEDIT_H
+#define SEARCHEDIT_H
+
+#include "gui/iconbutton.h"
+
+#include <QLineEdit>
+#include <QScopedPointer>
+
+class QLineEdit;
+class QIcon;
+
+namespace GrandSearch {
+
+class SearchEditPrivate;
+class SearchEdit : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit SearchEdit(QWidget *parent = nullptr);
+    ~SearchEdit() override;
+
+    QLineEdit *lineEdit() const;
+
+    void setPlaceHolder(const QString &text);
+    QString placeHolder() const;
+
+    void setPlaceholderText(const QString &text);
+    QString placeholderText() const;
+
+    void setText(const QString &text);
+    QString text() const;
+
+    void setClearButtonEnabled(bool enable);
+
+    void setAppIcon(const QString &iconName);
+    void setAppIcon(const QIcon &icon);
+    void setAppIconVisible(bool visible);
+    bool isAppIconVisible() const;
+
+    void clear();
+    void clearEdit();
+
+    void setFocus();
+
+signals:
+    void debouncedTextChanged(const QString &text);
+
+    void selectPreviousItem();
+    void selectNextItem();
+    void handleItem();
+    void closeWindow();
+    void searchAborted();
+
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+    bool event(QEvent *event) override;
+
+private:
+    QScopedPointer<SearchEditPrivate> d;
+};
+
+}
+
+#endif // SEARCHEDIT_H

--- a/src/grand-search/gui/entrance/searchedit_p.h
+++ b/src/grand-search/gui/entrance/searchedit_p.h
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SEARCHEDIT_P_H
+#define SEARCHEDIT_P_H
+
+#include "searchedit.h"
+
+#include <DIconButton>
+
+#include <QLabel>
+#include <QHBoxLayout>
+#include <QTimer>
+#include <QAction>
+
+namespace GrandSearch {
+
+class SearchEditPrivate
+{
+    SearchEditPrivate(SearchEdit *qq);
+
+    void init();
+    void toEditMode(bool focus);
+    void showContextMenu(const QPoint &pos);
+    void delayTextChanged();
+    void notifyTextChanged();
+
+    SearchEdit *q = nullptr;
+
+    QLineEdit *m_lineEdit = nullptr;
+    QWidget *m_iconWidget = nullptr;
+    QLabel *m_placeholderLabel = nullptr;
+    DTK_WIDGET_NAMESPACE::DIconButton *m_appIconLabel = nullptr;
+    DTK_WIDGET_NAMESPACE::DIconButton *m_clearButton = nullptr;
+    QAction *m_searchAction = nullptr;
+    QAction *m_clearAction = nullptr;
+    QAction *m_appIconAction = nullptr;
+
+    QHBoxLayout *m_lineEditLayout = nullptr;
+
+    QTimer *m_delayTimer = nullptr;
+
+    QString m_placeHolder;
+    QString m_placeholderText;
+    QString m_appIconName;
+
+    friend class SearchEdit;
+};
+
+}
+
+#endif // SEARCHEDIT_P_H

--- a/src/grand-search/gui/iconbutton.cpp
+++ b/src/grand-search/gui/iconbutton.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "iconbutton.h"
+
+#include <DStyle>
+#include <DGuiApplicationHelper>
+#include <DStyleOptionButton>
+
+#include <QPainter>
+
+DWIDGET_USE_NAMESPACE
+using namespace GrandSearch;
+
+SearchIconButton::SearchIconButton(QWidget *parent)
+    : DIconButton(parent)
+{
+}
+
+void SearchIconButton::paintEvent(QPaintEvent *event)
+{
+    DStyleOptionButton opt;
+    initStyleOption(&opt);
+
+    if (opt.state & (QStyle::State_Sunken | QStyle::State_MouseOver)) {
+        DPalette dp = DGuiApplicationHelper::instance()->applicationPalette();
+        QColor bgColor = dp.color(DPalette::ObviousBackground);
+        if (opt.state & QStyle::State_Sunken)
+            bgColor.setAlphaF(0.2);
+
+        int radius = qMin(width(), height()) / 2;
+        QPainter p(this);
+        p.setRenderHint(QPainter::Antialiasing);
+        p.setPen(Qt::NoPen);
+        p.setBrush(bgColor);
+        p.drawEllipse(QPointF(width() / 2.0, height() / 2.0), radius, radius);
+    }
+
+    DStylePainter p(this);
+    p.drawControl(DStyle::CE_IconButton, opt);
+}

--- a/src/grand-search/gui/iconbutton.h
+++ b/src/grand-search/gui/iconbutton.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef ICONBUTTON_H
+#define ICONBUTTON_H
+
+#include <DIconButton>
+
+namespace GrandSearch {
+
+class SearchIconButton : public Dtk::Widget::DIconButton
+{
+    Q_OBJECT
+public:
+    explicit SearchIconButton(QWidget *parent = nullptr);
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+};
+
+}
+
+#endif // ICONBUTTON_H


### PR DESCRIPTION
## Root Cause Analysis

The global search box (`EntranceWidget`) uses `DSearchEdit` (inheriting `DLineEdit`), which enables Qt's built-in clear button by default via `setClearButtonEnabled(true)`. Meanwhile, `EntranceWidget::initUI()` also places the app icon in the same right-side area through both `QLineEdit::addAction(TrailingPosition)` and `DLineEdit::setRightWidgets()`. This creates two overlapping right-side icons: the app icon and the DLineEdit built-in clear button (X). During fast typing, the clear button repeatedly shows/hides as text changes, visually overlapping with the app icon and producing the "dual close icon" flicker described in PMS BUG-268383.

Key evidence: `entrancewidget.cpp:179` creates `DSearchEdit` (DLineEdit subclass with clear button enabled by default); `entrancewidget.cpp:206-207` places the app icon in the same trailing/right-widgets area, causing the overlap.

## Fix

Replace `DSearchEdit`/`DLineEdit` with a custom `SearchEdit` based on `QWidget` + native `QLineEdit` (with `setClearButtonEnabled(false)`). The clear button (`IconButton`) and app icon (`DIconButton`) are placed as sibling widgets in a `QHBoxLayout`, shown/hidden independently — eliminating the overlap. This ports the fix already shipped on master (commit `66b6472`).

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- This is a faithful port of master's published and verified fix; all new source files are byte-identical to master commit `66b6472`
- Historical bug fixes (Bug 90485 icon-overlap, Bug 97626 focus-loss, Bug 109514 focus-reset, Bug 102247 icon-margin, Bug 97529 font-style) are all preserved — no regression
- Public `EntranceWidget` signals (`searchTextChanged`, `searchAborted`, `sigSelectPreviousItem`, etc.) and method signatures are unchanged; all callers in `mainwindow.cpp` remain compatible

### Business Impact Scope

- **Global search entry UI** — search box display and interaction (text input, clear text, app icon display, focus management)
- Affected scenarios: rapid typing in search box, clear button visibility with/without text, app icon display and switching, focus retention during fast input

### Verification Suggestion

Verify that rapid typing in the search box no longer shows dual icon overlap, the clear button and app icon both display correctly, and search functionality (text input, signal connections) works without regression.

---

## 根因分析

全局搜索框（`EntranceWidget`）使用 `DSearchEdit`（继承 `DLineEdit`），`DLineEdit` 构造时默认调用 `setClearButtonEnabled(true)` 开启 Qt 内置清除按钮。同时 `EntranceWidget::initUI()` 又通过 `QLineEdit::addAction(TrailingPosition)` 和 `DLineEdit::setRightWidgets()` 两种方式将应用图标放在同一右侧区域。导致右侧同时存在应用图标和 DLineEdit 内置清除按钮（X）两个图标，快速输入时清除按钮随文本变化反复显隐，与应用图标叠加闪烁，出现 PMS BUG-268383 描述的"双关闭图标"现象。

关键证据：`entrancewidget.cpp:179` 创建 `DSearchEdit`（DLineEdit 子类，默认开启清除按钮）；`entrancewidget.cpp:206-207` 在同一尾部/右侧扩展区放置应用图标，造成叠加。

## 修复方案

用基于 `QWidget` + 原生 `QLineEdit` 的自定义 `SearchEdit`（`setClearButtonEnabled(false)` 关闭内置清除按钮）替换 `DSearchEdit`/`DLineEdit`。清除按钮（`IconButton`）与应用图标（`DIconButton`）作为 `QHBoxLayout` 中的平级兄弟 widget，独立显隐——从根本上消除叠加。此方案移植自 master 已发布修复（commit `66b6472`）。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 本次改动为忠实移植 master 已发布且验证过的修复，所有新增源文件与 master commit `66b6472` 字节一致
- 历史 bug 修复（Bug 90485 图标遮挡、Bug 97626 焦点丢失、Bug 109514 焦点重置、Bug 102247 图标边距、Bug 97529 字体样式）均兼容保留——无回归风险
- `EntranceWidget` 公开信号（`searchTextChanged`、`searchAborted`、`sigSelectPreviousItem` 等）和方法签名不变，`mainwindow.cpp` 中所有调用方均兼容

### 业务影响范围

- **全局搜索入口界面** — 搜索框显示与交互（输入文本、清除文本、应用图标显示、焦点管理）
- 受影响场景：搜索框快速输入、有/无文本时清除按钮显隐、应用图标显示与切换、快速输入时焦点保持

### 验证建议

验证快速输入时搜索框不再出现双图标叠加，清除按钮与应用图标均正常显示，搜索功能（文本输入、信号连接）无回归。

## Summary by Sourcery

Prevent dual-icon flicker in the global search field by introducing a dedicated search edit with independently managed controls.

Bug Fixes:
- Eliminate overlapping application and clear icons in the global search field during text entry.

Enhancements:
- Replace the toolkit search edit with a dedicated search widget that manages placeholder, focus, keyboard navigation, context menus, app icons, and clear controls independently while preserving existing search signals and behavior.

Build:
- Include the new search edit and icon button sources in the grand-search build.