### PR TITLE
fix: hide app icon on text change to prevent duplicate clear icons

### DIFF
--- a/src/grand-search/gui/entrance/entrancewidget.cpp
+++ b/src/grand-search/gui/entrance/entrancewidget.cpp
@@ -57,6 +57,12 @@ void EntranceWidgetPrivate::delayChangeText()
     Q_ASSERT(m_delayChangeTimer);
 
     qCDebug(logGrandSearch) << "Search text input changed - Starting delay timer";
+
+    // 文本变化时立即隐藏应用图标，使其与 QLineEdit 内置清除按钮的可见性同步切换，
+    // 消除 50ms 防抖定时器延迟导致的清除按钮与应用图标并存的时序窗口
+    MatchedItem item;
+    q_p->onAppIconChanged(QString(), item);
+
     m_delayChangeTimer->start();
 }
 


### PR DESCRIPTION
## 修复：持续输入时出现 2 个关闭图标（PMS 268383）

### Bug 信息
- **PMS 单号**：268383
- **Bug 标题**：持续输入时出现 2 个关闭图标
- **产品**：全局搜索

### 根因
QLineEdit 内置清除按钮在文本变化时即时可见，而应用图标经 50ms 防抖定时器（`delayChangeText` → `notifyTextChanged`）延迟隐藏，两者可见性切换存在时序差。持续输入时定时器持续重置，使时序窗口延长，导致清除按钮与应用图标并存，尾部同时出现两个关闭图标。

### 修复方案
在 `EntranceWidgetPrivate::delayChangeText()` 即时回调（`textChanged` 信号触发）中，于启动 50ms 防抖定时器之前，新增一次 `onAppIconChanged(QString(), 空 item)` 调用，立即隐藏应用图标，使其与清除按钮的即时可见性同步切换，消除时序窗口。

### 安全性
- `onAppIconChanged` 隐藏分支已被 `notifyTextChanged()` 正常使用，`Utils::appIconName(空 item)` 返回空串无 I/O。
- `showLabelAppIcon` 内部 guard 防止重复隐藏，定时器到期后调用为 no-op。
- 改动范围极小，不触及焦点处理、搜索逻辑、事件过滤等其他模块。
- 风险等级：低。

### 改动文件
- `src/grand-search/gui/entrance/entrancewidget.cpp`

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate clear icons during continuous search input by hiding the application icon immediately when text changes.