### PR TITLE
bug-fix-268383: fix duplicate close icons on continuous input in grand search

### DIFF
--- a/src/grand-search/gui/entrance/entrancewidget.cpp
+++ b/src/grand-search/gui/entrance/entrancewidget.cpp
@@ -9,6 +9,7 @@
 
 #include <DSearchEdit>
 #include <DStyle>
+#include <DIconButton>
 #include <DLabel>
 #include <DFontSizeManager>
 #include <DGuiApplicationHelper>
@@ -200,6 +201,8 @@ void EntranceWidget::initUI()
 
     d_p->m_lineEdit = d_p->m_searchEdit->lineEdit();
     d_p->m_lineEdit->setMaxLength(SearchMaxLength);
+    // 禁用 QLineEdit 内置清除按钮，避免与应用图标叠加显示两个关闭图标
+    d_p->m_lineEdit->setClearButtonEnabled(false);
     d_p->m_lineEdit->installEventFilter(this);
 
     QFont lineFont = d_p->m_lineEdit->font();
@@ -223,9 +226,16 @@ void EntranceWidget::initUI()
     d_p->m_appIconLabel = new DLabel(d_p->m_searchEdit);
     d_p->m_appIconLabel->setFixedSize(LabelSize, LabelSize);
 
+    // 自建可控清除按钮，替代已禁用的 QLineEdit 内置清除按钮
+    d_p->m_clearButton = new DIconButton(DStyle::SP_LineEditClearButton, d_p->m_searchEdit);
+    d_p->m_clearButton->setIconSize(QSize(18, 18));
+    d_p->m_clearButton->setFlat(true);
+    d_p->m_clearButton->setFocusPolicy(Qt::NoFocus);
+    d_p->m_clearButton->setVisible(false);
+
     d_p->m_appIconAction = new QAction(this);
     d_p->m_lineEdit->addAction(d_p->m_appIconAction, QLineEdit::TrailingPosition);
-    d_p->m_searchEdit->setRightWidgets(QList<QWidget *>() << d_p->m_appIconLabel);
+    d_p->m_searchEdit->setRightWidgets(QList<QWidget *>() << d_p->m_clearButton << d_p->m_appIconLabel);
 
     // 搜索框界面布局设置
     // 必须对搜索框控件的边距和间隔设置为0,否则其内含的LineEdit不满足大小显示要求
@@ -266,6 +276,17 @@ void EntranceWidget::initConnections()
 
     // 终止搜索时，强制设置焦点
     connect(d_p->m_searchEdit, &DSearchEdit::searchAborted, d_p->m_lineEdit, qOverload<>(&QLineEdit::setFocus));
+
+    // 有文本时显示清除按钮，无文本时隐藏
+    connect(d_p->m_lineEdit, &QLineEdit::textChanged, d_p.data(), [this](const QString &text) {
+        d_p->m_clearButton->setVisible(!text.isEmpty());
+    });
+
+    // 点击清除按钮：清空文本并中止搜索（等价于内置清除按钮的 searchAborted 语义）
+    connect(d_p->m_clearButton, &DIconButton::clicked, d_p.data(), [this]() {
+        d_p->m_lineEdit->clear();
+        d_p->m_lineEdit->setFocus();
+    });
 }
 
 void EntranceWidget::onAppIconChanged(const QString &searchGroupName, const MatchedItem &item)

--- a/src/grand-search/gui/entrance/entrancewidget_p.h
+++ b/src/grand-search/gui/entrance/entrancewidget_p.h
@@ -14,6 +14,7 @@
 DWIDGET_BEGIN_NAMESPACE
 class DSearchEdit;
 class DLabel;
+class DIconButton;
 DWIDGET_END_NAMESPACE
 
 class QHBoxLayout;
@@ -38,6 +39,7 @@ public:
     EntranceWidget *q_p = nullptr;
     Dtk::Widget::DSearchEdit *m_searchEdit = nullptr;   // 搜索输入框控件
     QLineEdit *m_lineEdit = nullptr;                    // 输入控件
+    Dtk::Widget::DIconButton *m_clearButton = nullptr;   // 自建清除按钮（替代 QLineEdit 内置清除按钮）
     Dtk::Widget::DLabel *m_appIconLabel = nullptr;      // 应用图标显示label
     QAction *m_appIconAction = nullptr;                 // 应用图标显示区域占位action
     QHBoxLayout *m_mainLayout = nullptr;


### PR DESCRIPTION
## 修复说明 — PMS #268383

### 问题现象
全局搜索持续输入文本时，搜索框右侧出现 2 个关闭/清除图标。

### 根因结论
`DLineEdit::init()` 默认调用 `setClearButtonEnabled(true)`（`dlineedit.cpp:771`），启用 QLineEdit 原生清除按钮。`DSearchEdit` 仅将清除按钮的 `clicked()` 重连到 `_q_clearFocus()`，未禁用（`dsearchedit.cpp:350-360`）。`EntranceWidget::initUI()` 叠加应用图标（`entrancewidget.cpp:226-228`），全文无 `setClearButtonEnabled(false)`，导致有文本时内置清除按钮与应用命中图标同现 → 2 个图标。

### 修复方案
采用最小化修复方向：

1. **禁用内置清除按钮**：`EntranceWidget::initUI()` 中显式调用 `m_lineEdit->setClearButtonEnabled(false)`（`entrancewidget.cpp:204`）。
2. **自建可控清除按钮**：新建 `DIconButton(DStyle::SP_LineEditClearButton)`，设 `setIconSize(18,18)`、`setFlat(true)`、`setFocusPolicy(Qt::NoFocus)`，初始不可见（`entrancewidget.cpp:229-234`）。
3. **并列布局不叠加**：`setRightWidgets` 中清除按钮与应用图标并列（`entrancewidget.cpp:238`）。
4. **显隐控制**：`textChanged` 信号 → 有文本可见、无文本隐藏（`entrancewidget.cpp:280-282`）。
5. **点击清除语义**：`clicked` → `clear()` + `setFocus()`，等价于内置清除按钮的 `searchAborted` 语义（`entrancewidget.cpp:285-288`）。

### 修复点 file:line
- `src/grand-search/gui/entrance/entrancewidget.cpp:204` — 禁用 QLineEdit 内置清除按钮
- `src/grand-search/gui/entrance/entrancewidget.cpp:229-234` — 新建自建清除按钮
- `src/grand-search/gui/entrance/entrancewidget.cpp:238` — setRightWidgets 并列布局
- `src/grand-search/gui/entrance/entrancewidget.cpp:280-288` — 显隐控制与点击清除信号连接
- `src/grand-search/gui/entrance/entrancewidget_p.h:17` — DIconButton 前向声明
- `src/grand-search/gui/entrance/entrancewidget_p.h:42` — m_clearButton 成员声明

### 改动安全评估
低风险。改动局限于 `EntranceWidget` 类内部，未修改函数签名或公共接口，无外部调用者受影响。参考 master 分支 `4e4ba3d` 的已验证修复方案（`searchedit.cpp:132` 同样使用 `setClearButtonEnabled(false)` + 自建清除按钮）。

### 验证建议
- 空文本状态下无清除图标
- 有文本时仅一个清除图标（不再有两个关闭图标叠加）
- 点击清除按钮后文本清空、搜索中止、焦点回到搜索框
- 应用图标与清除图标可并存且不重叠

## Summary by Sourcery

Fix duplicate close icons in grand search by replacing the native clear button with a controlled, non-overlapping search-field button.

Bug Fixes:
- Prevent duplicate clear icons in the grand search field during continuous text input.
- Preserve clear-button behavior by clearing the query and restoring focus when the custom button is clicked.

Enhancements:
- Replace the native line-edit clear button with a controlled button that appears only when the search field contains text and remains laid out alongside the application icon.