### PR TITLE
feat: add search loading spinner indicator

### DIFF
--- a/src/grand-search/business/query/querycontroller.cpp
+++ b/src/grand-search/business/query/querycontroller.cpp
@@ -82,6 +82,7 @@ void QueryControllerPrivate::performSearch()
         m_keepAliveTimer->start();
     } else {
         qCWarning(logGrandSearch) << "Search failed to start - Mission:" << m_missionId;
+        emit q_p->searchFailed();
     }
 }
 

--- a/src/grand-search/business/query/querycontroller.h
+++ b/src/grand-search/business/query/querycontroller.h
@@ -32,6 +32,9 @@ signals:
     // 搜索文本改变后，发起新的搜索前，发出该任务ID改变信号
     void missionChanged(const QString &missionId, const QString &missionContent);
 
+    // 后端启动搜索失败时发出，通知界面停止加载状态
+    void searchFailed();
+
 private:
     QScopedPointer<QueryControllerPrivate> d_p;
 };

--- a/src/grand-search/gui/entrance/entrancewidget.cpp
+++ b/src/grand-search/gui/entrance/entrancewidget.cpp
@@ -40,6 +40,12 @@ void EntranceWidget::showLabelAppIcon(bool visible)
     d_p->m_searchEdit->setAppIconVisible(visible);
 }
 
+void EntranceWidget::setSearching(bool searching)
+{
+    Q_ASSERT(d_p->m_searchEdit);
+    d_p->m_searchEdit->setSearching(searching);
+}
+
 bool EntranceWidget::event(QEvent *event)
 {
     if (event->type() == QEvent::FocusIn) {

--- a/src/grand-search/gui/entrance/entrancewidget.h
+++ b/src/grand-search/gui/entrance/entrancewidget.h
@@ -32,6 +32,7 @@ private:
 
 public slots:
     void onAppIconChanged(const QString &searchGroupName, const MatchedItem &item);
+    void setSearching(bool searching);
 
 signals:
     void searchTextChanged(const QString &txt);

--- a/src/grand-search/gui/entrance/searchedit.cpp
+++ b/src/grand-search/gui/entrance/searchedit.cpp
@@ -11,10 +11,12 @@
 #include <DIconTheme>
 #include <DFontSizeManager>
 #include <DGuiApplicationHelper>
+#include <DSpinner>
 
 #include <QLineEdit>
 #include <QHBoxLayout>
 #include <QAction>
+#include <QWidgetAction>
 #include <QTimer>
 #include <QMenu>
 #include <QGuiApplication>
@@ -29,6 +31,7 @@ using namespace GrandSearch;
 static constexpr int DelayResponseTime = 50;
 static constexpr int AppIconSize = 32;
 static constexpr int SearchIconSize = 20;
+static constexpr int SearchIndicatorWidth = 40;
 
 SearchEditPrivate::SearchEditPrivate(SearchEdit *qq)
     : q(qq)
@@ -111,6 +114,26 @@ void SearchEditPrivate::init()
     m_lineEdit->addAction(m_searchAction, QLineEdit::LeadingPosition);
     m_searchAction->setVisible(false);
 
+    // 左侧搜索中 spinner action（搜索进行时显示，与搜索图标二选一）
+    m_spinner = new DSpinner;
+    m_spinner->setAttribute(Qt::WA_TransparentForMouseEvents);
+    m_spinner->setFocusPolicy(Qt::NoFocus);
+    m_spinner->setFixedSize(QSize(SearchIconSize, SearchIconSize));
+
+    // 固定宽度的容器，保证 spinner 与搜索图标占位一致，避免文字跳动
+    m_spinnerContainer = new QWidget;
+    QHBoxLayout *spinnerLayout = new QHBoxLayout(m_spinnerContainer);
+    spinnerLayout->setContentsMargins(0, 0, 0, 0);
+    spinnerLayout->setSpacing(0);
+    spinnerLayout->addWidget(m_spinner, 0, Qt::AlignCenter);
+    m_spinnerContainer->setFixedWidth(SearchIndicatorWidth);
+
+    m_spinnerAction = new QWidgetAction(q);
+    m_spinnerAction->setObjectName("_d_search_spinnerAction");
+    m_spinnerAction->setDefaultWidget(m_spinnerContainer);
+    m_lineEdit->addAction(m_spinnerAction, QLineEdit::LeadingPosition);
+    m_spinnerAction->setVisible(false);
+
     // 应用图标（右侧）
     m_appIconLabel = new DIconButton(q);
     m_appIconLabel->setIconSize({ AppIconSize, AppIconSize });
@@ -149,7 +172,7 @@ void SearchEditPrivate::init()
         if (list.at(i)->defaultAction() == m_searchAction) {
             QToolButton *searchBtn = list.at(i);
             searchBtn->setIconSize({ 16, 16 });
-            searchBtn->setFixedWidth(40);
+            searchBtn->setFixedWidth(SearchIndicatorWidth);
             break;
         }
     }
@@ -174,15 +197,35 @@ void SearchEditPrivate::init()
 
 void SearchEditPrivate::toEditMode(bool focus)
 {
-    if (focus || m_lineEdit->hasFocus() || !m_lineEdit->text().isEmpty()) {
-        m_searchAction->setVisible(true);
-        m_iconWidget->setVisible(false);
-        m_lineEdit->setPlaceholderText(m_placeholderText);
-    } else {
-        m_searchAction->setVisible(false);
-        m_iconWidget->setVisible(true);
-        m_lineEdit->setPlaceholderText(QString());
-    }
+    const bool inEditMode = focus || m_lineEdit->hasFocus() || !m_lineEdit->text().isEmpty();
+
+    // 编辑态显示左侧图标（搜索图标或 spinner），非编辑态显示居中占位
+    m_iconWidget->setVisible(!inEditMode);
+    m_lineEdit->setPlaceholderText(inEditMode ? m_placeholderText : QString());
+    updateSearchIndicator(inEditMode);
+}
+
+void SearchEditPrivate::updateSearchIndicator(bool inEditMode)
+{
+    const bool showSpinner = inEditMode && m_searching;
+
+    m_searchAction->setVisible(inEditMode && !m_searching);
+    m_spinnerAction->setVisible(showSpinner);
+    // spinner 是容器子控件，隐藏容器即可一并隐藏，避免残留占位
+    m_spinnerContainer->setVisible(showSpinner);
+
+    if (showSpinner)
+        m_spinner->start();
+    else
+        m_spinner->stop();
+}
+
+void SearchEditPrivate::setSearching(bool searching)
+{
+    if (m_searching == searching)
+        return;
+    m_searching = searching;
+    toEditMode(false);
 }
 
 void SearchEditPrivate::showContextMenu(const QPoint &pos)
@@ -330,6 +373,11 @@ void SearchEdit::clearEdit()
 void SearchEdit::setFocus()
 {
     d->m_lineEdit->setFocus();
+}
+
+void SearchEdit::setSearching(bool searching)
+{
+    d->setSearching(searching);
 }
 
 bool SearchEdit::eventFilter(QObject *watched, QEvent *event)

--- a/src/grand-search/gui/entrance/searchedit.h
+++ b/src/grand-search/gui/entrance/searchedit.h
@@ -46,6 +46,8 @@ public:
 
     void setFocus();
 
+    void setSearching(bool searching);
+
 signals:
     void debouncedTextChanged(const QString &text);
 

--- a/src/grand-search/gui/entrance/searchedit_p.h
+++ b/src/grand-search/gui/entrance/searchedit_p.h
@@ -8,11 +8,13 @@
 #include "searchedit.h"
 
 #include <DIconButton>
+#include <DSpinner>
 
 #include <QLabel>
 #include <QHBoxLayout>
 #include <QTimer>
 #include <QAction>
+#include <QWidgetAction>
 
 namespace GrandSearch {
 
@@ -22,9 +24,11 @@ class SearchEditPrivate
 
     void init();
     void toEditMode(bool focus);
+    void updateSearchIndicator(bool inEditMode);
     void showContextMenu(const QPoint &pos);
     void delayTextChanged();
     void notifyTextChanged();
+    void setSearching(bool searching);
 
     SearchEdit *q = nullptr;
 
@@ -36,10 +40,15 @@ class SearchEditPrivate
     QAction *m_searchAction = nullptr;
     QAction *m_clearAction = nullptr;
     QAction *m_appIconAction = nullptr;
+    QWidgetAction *m_spinnerAction = nullptr;
+    DTK_WIDGET_NAMESPACE::DSpinner *m_spinner = nullptr;
+    QWidget *m_spinnerContainer = nullptr;
 
     QHBoxLayout *m_lineEditLayout = nullptr;
 
     QTimer *m_delayTimer = nullptr;
+
+    bool m_searching = false;
 
     QString m_placeHolder;
     QString m_placeholderText;

--- a/src/grand-search/gui/mainwindow.cpp
+++ b/src/grand-search/gui/mainwindow.cpp
@@ -83,9 +83,20 @@ void MainWindow::connectToController()
     connect(d_p->m_queryController, &QueryController::missionChanged, d_p->m_matchController, &MatchController::onMissionChanged);
     connect(d_p->m_queryController, &QueryController::missionChanged, this, &MainWindow::onMissionChanged);
 
+    // 搜索状态驱动入口输入框的加载动画：非空任务开始，空任务/结束/失败则停止
+    connect(d_p->m_queryController, &QueryController::missionChanged, d_p->m_entranceWidget, [this](const QString &missionId, const QString &) {
+        d_p->m_entranceWidget->setSearching(!missionId.isEmpty());
+    });
+
     // 匹配结果解析显示
     connect(d_p->m_matchController, &MatchController::matchedResult, d_p->m_exhibitionWidget, &ExhibitionWidget::appendMatchedData);
     connect(d_p->m_matchController, &MatchController::searchCompleted, d_p->m_exhibitionWidget, &ExhibitionWidget::onSearchCompleted);
+    connect(d_p->m_matchController, &MatchController::searchCompleted, d_p->m_entranceWidget, [this]() {
+        d_p->m_entranceWidget->setSearching(false);
+    });
+    connect(d_p->m_queryController, &QueryController::searchFailed, d_p->m_entranceWidget, [this]() {
+        d_p->m_entranceWidget->setSearching(false);
+    });
 
     qCInfo(logGrandSearch) << "Controller connections established";
 }


### PR DESCRIPTION
1. Add a DSpinner loading indicator to the left side of the search input
box
2. Show the spinner while a search is in progress and hide it when
search completes or fails
3. Introduce a new `searchFailed` signal in QueryController to stop the
loading state when backend search fails to start
4. Refactor SearchEdit mode switching logic to properly toggle between
search icon and spinner
5. Connect missionChanged and searchCompleted signals in MainWindow to
drive the loading state

Log: Added a loading spinner to the search box during search, and fixed
the issue where the loading state could remain stuck when search fails
to start

Influence:
1. Verify the spinner appears when a search starts (non-empty mission)
2. Verify the spinner disappears after search completes
3. Verify the spinner stops and hides when backend search fails to start
4. Test toggling between edit mode and non-edit mode to ensure the
spinner and search icon switch correctly
5. Test clearing the search text to confirm the spinner is removed
6. Verify no layout shift or text jump occurs when the spinner replaces
the search icon

feat: 添加搜索加载动画指示器

1. 在搜索输入框左侧添加 DSpinner 加载指示器
2. 搜索进行时显示加载动画，搜索完成或失败时隐藏
3. 在 QueryController 中新增 searchFailed 信号，用于后端启动搜索失败时停
止加载状态
4. 重构 SearchEdit 的模式切换逻辑，使搜索图标和加载动画能够正确切换
5. 在 MainWindow 中连接 missionChanged 和 searchCompleted 信号以驱动加载
状态

Log: 搜索框新增搜索中加载动画，并修复搜索启动失败时加载状态可能卡住的
问题

Influence:
1. 验证搜索开始时（非空任务）加载动画是否显示
2. 验证搜索完成后加载动画是否消失
3. 验证后端启动搜索失败时加载动画是否停止并隐藏
4. 测试编辑模式和非编辑模式切换，确保加载动画和搜索图标切换正确
5. 测试清空搜索文本，确认加载动画被移除
6. 验证加载动画替换搜索图标时是否出现布局跳动或文字位置偏移

## Summary by Sourcery

Add search progress feedback to the search input and ensure its loading state is cleared when searches complete or fail.

New Features:
- Add a loading spinner to the search input while searches are in progress.

Bug Fixes:
- Stop the search loading state when backend search startup fails.

Enhancements:
- Coordinate search state across query, matching, and entrance components while preserving the search input layout when switching between the icon and spinner.