### PR TITLE
feat: improve search settings menu label

### DIFF
--- a/src/grand-search-shell-plugin/package/searchitem.qml
+++ b/src/grand-search-shell-plugin/package/searchitem.qml
@@ -41,7 +41,7 @@ AppletItem {
         sourceComponent: LP.Menu {
             id: platformMenu
             LP.MenuItem {
-                text: qsTr("SearchConfig")
+                text: qsTr("Search settings")
                 onTriggered: {
                     Applet.toggleGrandSearchConfig()
                 }

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem.ts
@@ -10,7 +10,7 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
+        <source>Search settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_ar.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_ar.ts
@@ -10,7 +10,7 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
+        <source>Search settings</source>
         <translation>إعدادات البحث</translation>
     </message>
 </context>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_az.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_az.ts
@@ -10,8 +10,8 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
-        <translation>Axtarış konfiqurasiyası</translation>
+        <source>Search settings</source>
+        <translation>Axtarış ayarları</translation>
     </message>
 </context>
 </TS>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_bo.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_bo.ts
@@ -10,8 +10,8 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
-        <translation>འཚོལ་བཤེར་སྒྲིག་བཀོད།</translation>
+        <source>Search settings</source>
+        <translation>བཤེར་འཚོལ་སྒྲིག་འགོད།</translation>
     </message>
 </context>
 </TS>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_ca.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_ca.ts
@@ -10,8 +10,8 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
-        <translation>Cerca de configuració</translation>
+        <source>Search settings</source>
+        <translation>Paràmetres de la cerca</translation>
     </message>
 </context>
 </TS>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_de.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_de.ts
@@ -10,8 +10,8 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
-        <translation>Such-Einstellungen</translation>
+        <source>Search settings</source>
+        <translation>Sucheinstellungen</translation>
     </message>
 </context>
 </TS>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_de_DE.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_de_DE.ts
@@ -10,8 +10,8 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
-        <translation>Such-Einstellungen</translation>
+        <source>Search settings</source>
+        <translation>Sucheinstellungen</translation>
     </message>
 </context>
 </TS>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_es.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_es.ts
@@ -10,8 +10,8 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
-        <translation>Configuración de Búsqueda</translation>
+        <source>Search settings</source>
+        <translation>Ajustes de búsqueda</translation>
     </message>
 </context>
 </TS>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_fi.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_fi.ts
@@ -10,8 +10,8 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
-        <translation>Hakuasetukset</translation>
+        <source>Search settings</source>
+        <translation>Haun asetukset</translation>
     </message>
 </context>
 </TS>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_fr.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_fr.ts
@@ -10,8 +10,8 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
-        <translation>Configuration de la recherche</translation>
+        <source>Search settings</source>
+        <translation>Paramètres de recherche</translation>
     </message>
 </context>
 </TS>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_hu.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_hu.ts
@@ -10,7 +10,7 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
+        <source>Search settings</source>
         <translation>Keresési beállítások</translation>
     </message>
 </context>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_it.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_it.ts
@@ -10,8 +10,8 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
-        <translation>Configurazione della ricerca</translation>
+        <source>Search settings</source>
+        <translation>Cerca impostazioni</translation>
     </message>
 </context>
 </TS>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_ja.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_ja.ts
@@ -10,7 +10,7 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
+        <source>Search settings</source>
         <translation>検索設定</translation>
     </message>
 </context>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_ko.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_ko.ts
@@ -10,7 +10,7 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
+        <source>Search settings</source>
         <translation>검색 설정</translation>
     </message>
 </context>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_lo.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_lo.ts
@@ -10,7 +10,7 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
+        <source>Search settings</source>
         <translation>ການຕັ້ງຄ່າການຄົ້ນຫາ</translation>
     </message>
 </context>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_nb_NO.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_nb_NO.ts
@@ -10,8 +10,8 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
-        <translation>Søkeinnstillinger</translation>
+        <source>Search settings</source>
+        <translation>Søkstillinger</translation>
     </message>
 </context>
 </TS>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_nl.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_nl.ts
@@ -10,7 +10,7 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
+        <source>Search settings</source>
         <translation>Zoekinstellingen</translation>
     </message>
 </context>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_pl.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_pl.ts
@@ -10,7 +10,7 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
+        <source>Search settings</source>
         <translation>Ustawienia wyszukiwania</translation>
     </message>
 </context>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_pt_BR.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_pt_BR.ts
@@ -10,8 +10,8 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
-        <translation>Configurações de pesquisa</translation>
+        <source>Search settings</source>
+        <translation>Configurações de Busca</translation>
     </message>
 </context>
 </TS>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_ru.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_ru.ts
@@ -10,7 +10,7 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
+        <source>Search settings</source>
         <translation>Настройки поиска</translation>
     </message>
 </context>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_sq.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_sq.ts
@@ -10,8 +10,8 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
-        <translation>Konfigurimi i kërkimit</translation>
+        <source>Search settings</source>
+        <translation>Rregullime kërkimi</translation>
     </message>
 </context>
 </TS>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_uk.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_uk.ts
@@ -10,8 +10,8 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
-        <translation>Налаштування пошуку</translation>
+        <source>Search settings</source>
+        <translation>Параметри пошуку</translation>
     </message>
 </context>
 </TS>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_zh_CN.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_zh_CN.ts
@@ -10,8 +10,8 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
-        <translation>搜索配置</translation>
+        <source>Search settings</source>
+        <translation>搜索设置</translation>
     </message>
 </context>
 </TS>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_zh_HK.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_zh_HK.ts
@@ -10,8 +10,8 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
-        <translation>搜尋配置</translation>
+        <source>Search settings</source>
+        <translation>搜索設置</translation>
     </message>
 </context>
 </TS>

--- a/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_zh_TW.ts
+++ b/src/grand-search-shell-plugin/translations/org.deepin.ds.dock.searchitem_zh_TW.ts
@@ -10,8 +10,8 @@
     </message>
     <message>
         <location filename="../package/searchitem.qml" line="44"/>
-        <source>SearchConfig</source>
-        <translation>搜尋配置</translation>
+        <source>Search settings</source>
+        <translation>搜尋設定</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
1. Replace the search menu item text from "SearchConfig" to "Search
settings"
2. Update all translation files to match the new source string
3. Fix inconsistencies in translations across multiple languages
4. Provide a more user-friendly and understandable label for the search
configuration action

Log: Updated search settings menu label in the dock plugin

Influence:
1. Right-click the search icon in the dock and verify the menu item
displays "Search settings" (or the localized equivalent)
2. Switch the system language to various locales and verify the
translated menu text is correct
3. Click the menu item and confirm the search configuration window still
opens as expected
4. Check that no other UI elements reference the old "SearchConfig"
string

feat: 优化搜索设置菜单文案

1. 将搜索菜单项文本从"SearchConfig"改为"Search settings"
2. 更新所有翻译文件以匹配新的源字符串
3. 修正多语言翻译中的不一致之处
4. 为用户提供更友好、更易理解的搜索配置操作标签

Log: 更新了dock插件中的搜索设置菜单标签

Influence:
1. 右键点击dock中的搜索图标，验证菜单项显示为"Search settings"（或对应本
地化文本）
2. 切换系统语言为不同区域，验证菜单文本翻译是否正确
3. 点击菜单项，确认搜索配置窗口仍能正常打开
4. 检查是否还有其他UI元素引用了旧的"SearchConfig"字符串

BUG: https://pms.uniontech.com/bug-view-367063.html

## Summary by Sourcery

Improve the dock search menu label and its localized translations while preserving access to search settings.

Bug Fixes:
- Replace the dock search menu label with clearer, more user-friendly wording.

Enhancements:
- Align the search menu translation source string and correct localized wording across supported languages.